### PR TITLE
ci: add ASan/TSan/UBSan sanitizer builds for safety baseline

### DIFF
--- a/.github/workflows/ci_build_sanitizers.yml
+++ b/.github/workflows/ci_build_sanitizers.yml
@@ -67,8 +67,8 @@ jobs:
           cmake -Bbuild \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/deps \
-            -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" \
-            -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" \
+            -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -Wno-maybe-uninitialized" \
+            -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -Wno-maybe-uninitialized" \
             -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined" \
             -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address,undefined" \
             -DBUILD_TESTING=ON \

--- a/.github/workflows/ci_build_sanitizers.yml
+++ b/.github/workflows/ci_build_sanitizers.yml
@@ -1,0 +1,120 @@
+# Sanitizer builds to detect memory errors, data races, and undefined behavior.
+# Tests use continue-on-error: true until all safety issues are fixed.
+
+name: Sanitizer Build & Test
+
+on:
+  pull_request:
+    paths:
+      - 'goldenmaster/**'
+      - 'templates/**'
+      - '.github/workflows/ci_build_sanitizers.yml'
+    branches: [main]
+
+jobs:
+  asan_ubsan:
+    name: "ASan + UBSan (Ubuntu GCC)"
+    runs-on: ubuntu-latest
+    env:
+      CTEST_OUTPUT_ON_FAILURE: 1
+      ASAN_OPTIONS: halt_on_error=0:print_stacktrace=1
+      UBSAN_OPTIONS: halt_on_error=0:print_stacktrace=1
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install dependencies
+        run: sudo apt-get install -y cmake libpoco-dev nlohmann-json3-dev libeigen3-dev
+      - name: Install paho.mqtt.c
+        run: |
+          git clone --branch v1.3.13 --depth 1 https://github.com/eclipse/paho.mqtt.c.git
+          cd paho.mqtt.c
+          cmake -Bbuild -H. -DPAHO_BUILD_SHARED=OFF -DPAHO_BUILD_STATIC=ON -DPAHO_WITH_SSL=ON -DBUILD_TESTING=OFF
+          sudo cmake --build build/ --target install
+      - name: Install catch2
+        run: |
+          git clone --branch v2.13.8 --depth 1 https://github.com/catchorg/Catch2.git
+          cd Catch2
+          cmake -Bbuild -H. -DBUILD_TESTING=OFF
+          sudo cmake --build build/ --target install
+      - name: Start Mosquitto
+        uses: namoshek/mosquitto-github-action@v1
+        with:
+          version: '1.6'
+          ports: '1883:1883'
+          container-name: 'mqtt'
+      - name: Start NATS Server
+        uses: onichandame/nats-action@master
+        with:
+          port: "4222"
+      - name: Configure with ASan + UBSan
+        working-directory: goldenmaster
+        run: |
+          cmake -Bbuild \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -g" \
+            -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -g" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined" \
+            -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address,undefined" \
+            -DBUILD_TESTING=ON \
+            -DTEST_FETCH_DEPS=ON
+      - name: Build
+        working-directory: goldenmaster
+        run: cmake --build build/ --parallel $(nproc)
+      - name: Test
+        working-directory: goldenmaster
+        run: ctest --test-dir build/ --output-on-failure --timeout 300
+        continue-on-error: true
+
+  tsan:
+    name: "TSan (Ubuntu GCC)"
+    runs-on: ubuntu-latest
+    env:
+      CTEST_OUTPUT_ON_FAILURE: 1
+      TSAN_OPTIONS: halt_on_error=0:second_deadlock_stack=1
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install dependencies
+        run: sudo apt-get install -y cmake libpoco-dev nlohmann-json3-dev libeigen3-dev
+      - name: Install paho.mqtt.c
+        run: |
+          git clone --branch v1.3.13 --depth 1 https://github.com/eclipse/paho.mqtt.c.git
+          cd paho.mqtt.c
+          cmake -Bbuild -H. -DPAHO_BUILD_SHARED=OFF -DPAHO_BUILD_STATIC=ON -DPAHO_WITH_SSL=ON -DBUILD_TESTING=OFF
+          sudo cmake --build build/ --target install
+      - name: Install catch2
+        run: |
+          git clone --branch v2.13.8 --depth 1 https://github.com/catchorg/Catch2.git
+          cd Catch2
+          cmake -Bbuild -H. -DBUILD_TESTING=OFF
+          sudo cmake --build build/ --target install
+      - name: Start Mosquitto
+        uses: namoshek/mosquitto-github-action@v1
+        with:
+          version: '1.6'
+          ports: '1883:1883'
+          container-name: 'mqtt'
+      - name: Start NATS Server
+        uses: onichandame/nats-action@master
+        with:
+          port: "4222"
+      - name: Configure with TSan
+        working-directory: goldenmaster
+        run: |
+          cmake -Bbuild \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_CXX_FLAGS="-fsanitize=thread -fno-omit-frame-pointer -g" \
+            -DCMAKE_C_FLAGS="-fsanitize=thread -fno-omit-frame-pointer -g" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=thread" \
+            -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=thread" \
+            -DBUILD_TESTING=ON \
+            -DTEST_FETCH_DEPS=ON
+      - name: Build
+        working-directory: goldenmaster
+        run: cmake --build build/ --parallel $(nproc)
+      - name: Test
+        working-directory: goldenmaster
+        run: ctest --test-dir build/ --output-on-failure --timeout 300
+        continue-on-error: true

--- a/.github/workflows/ci_build_sanitizers.yml
+++ b/.github/workflows/ci_build_sanitizers.yml
@@ -65,10 +65,10 @@ jobs:
         working-directory: goldenmaster
         run: |
           cmake -Bbuild \
-            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/deps \
-            -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -g" \
-            -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -g" \
+            -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" \
+            -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" \
             -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined" \
             -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address,undefined" \
             -DBUILD_TESTING=ON \
@@ -133,10 +133,10 @@ jobs:
         working-directory: goldenmaster
         run: |
           cmake -Bbuild \
-            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/deps \
-            -DCMAKE_CXX_FLAGS="-fsanitize=thread -fno-omit-frame-pointer -g" \
-            -DCMAKE_C_FLAGS="-fsanitize=thread -fno-omit-frame-pointer -g" \
+            -DCMAKE_CXX_FLAGS="-fsanitize=thread -fno-omit-frame-pointer" \
+            -DCMAKE_C_FLAGS="-fsanitize=thread -fno-omit-frame-pointer" \
             -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=thread" \
             -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=thread" \
             -DBUILD_TESTING=ON \

--- a/.github/workflows/ci_build_sanitizers.yml
+++ b/.github/workflows/ci_build_sanitizers.yml
@@ -37,6 +37,20 @@ jobs:
           cd Catch2
           cmake -Bbuild -H. -DBUILD_TESTING=OFF
           sudo cmake --build build/ --target install
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          cache: "pip"
+          cache-dependency-path: ".github/workflows/conan-requirements.txt"
+      - name: Install Conan
+        run: pip3 install -r .github/workflows/conan-requirements.txt
+      - name: Create default profile
+        run: conan profile detect
+      - name: Install nats using conan
+        run: |
+          mkdir -p deps
+          cd deps && conan install --requires=cnats/3.9.1@ --build missing -o nats/*:shared=False -o nats/*:fPIC=True -o nats/*:with_tls=False -o nats/*:with_sodium=False -o nats/*:enable_streaming=False --generator CMakeDeps --generator VirtualBuildEnv
       - name: Start Mosquitto
         uses: namoshek/mosquitto-github-action@v1
         with:
@@ -52,6 +66,7 @@ jobs:
         run: |
           cmake -Bbuild \
             -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/deps \
             -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -g" \
             -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -g" \
             -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined" \
@@ -90,6 +105,20 @@ jobs:
           cd Catch2
           cmake -Bbuild -H. -DBUILD_TESTING=OFF
           sudo cmake --build build/ --target install
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          cache: "pip"
+          cache-dependency-path: ".github/workflows/conan-requirements.txt"
+      - name: Install Conan
+        run: pip3 install -r .github/workflows/conan-requirements.txt
+      - name: Create default profile
+        run: conan profile detect
+      - name: Install nats using conan
+        run: |
+          mkdir -p deps
+          cd deps && conan install --requires=cnats/3.9.1@ --build missing -o nats/*:shared=False -o nats/*:fPIC=True -o nats/*:with_tls=False -o nats/*:with_sodium=False -o nats/*:enable_streaming=False --generator CMakeDeps --generator VirtualBuildEnv
       - name: Start Mosquitto
         uses: namoshek/mosquitto-github-action@v1
         with:
@@ -105,6 +134,7 @@ jobs:
         run: |
           cmake -Bbuild \
             -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/deps \
             -DCMAKE_CXX_FLAGS="-fsanitize=thread -fno-omit-frame-pointer -g" \
             -DCMAKE_C_FLAGS="-fsanitize=thread -fno-omit-frame-pointer -g" \
             -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=thread" \

--- a/.github/workflows/ci_build_sanitizers.yml
+++ b/.github/workflows/ci_build_sanitizers.yml
@@ -65,7 +65,7 @@ jobs:
         working-directory: goldenmaster
         run: |
           cmake -Bbuild \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/deps \
             -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" \
             -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer" \
@@ -133,7 +133,7 @@ jobs:
         working-directory: goldenmaster
         run: |
           cmake -Bbuild \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/deps \
             -DCMAKE_CXX_FLAGS="-fsanitize=thread -fno-omit-frame-pointer" \
             -DCMAKE_C_FLAGS="-fsanitize=thread -fno-omit-frame-pointer" \


### PR DESCRIPTION
## 📑 Description
Add ci_build_sanitizers.yml with two jobs:
- ASan + UBSan (Ubuntu GCC) for memory errors and undefined behavior
- TSan (Ubuntu GCC) for data races

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->