### PR TITLE
fix(core): use cppTestValue for struct-array element in test helper

### DIFF
--- a/.github/workflows/ci_build_features.yml
+++ b/.github/workflows/ci_build_features.yml
@@ -76,11 +76,7 @@ jobs:
         run: bin/apigear g x -f "${{ matrix.config.features }}" -t . -o test -i apigear/test-apis/testbed.simple.module.yaml,apigear/test-apis/testbed.struct.module.yaml
       - name: Start Mosquitto
         if: ${{ matrix.config.short == 'mqtt'}}
-        uses: namoshek/mosquitto-github-action@v1
-        with:
-          version: '1.6'
-          ports: '1883:1883'
-          container-name: 'mqtt'
+        run: sudo apt-get install -y mosquitto && sudo systemctl start mosquitto
       - name: Create Nats Server for ubuntu (only for nats)
         if: ${{ matrix.config.short == 'nats'}}
         uses: onichandame/nats-action@master
@@ -156,11 +152,7 @@ jobs:
         run: bin/apigear g x -f "${{ matrix.config.features }}" -t . -o test -i apigear/test-apis/testbed.simple.module.yaml,apigear/test-apis/testbed.struct.module.yaml
       - name: Start Mosquitto
         if: ${{ matrix.config.short == 'mqtt'}}
-        uses: namoshek/mosquitto-github-action@v1
-        with:
-          version: '1.6'
-          ports: '1883:1883'
-          container-name: 'mqtt'
+        run: sudo apt-get install -y mosquitto && sudo systemctl start mosquitto
       - name: Create Nats Server for ubuntu (only for nats)
         if: ${{ matrix.config.short == 'nats'}}
         uses: onichandame/nats-action@master
@@ -225,11 +217,7 @@ jobs:
         run: bin/apigear g x -f "${{ matrix.config.features }}" -t . -o test -i apigear/test-apis/testbed.simple.module.yaml
       - name: Start Mosquitto
         if: ${{ matrix.config.short == 'mqtt'}}
-        uses: namoshek/mosquitto-github-action@v1
-        with:
-          version: '1.6'
-          ports: '1883:1883'
-          container-name: 'mqtt'
+        run: sudo apt-get install -y mosquitto && sudo systemctl start mosquitto
       - name: Create Nats Server for ubuntu (only for nats)
         if: ${{ matrix.config.short == 'nats'}}
         uses: onichandame/nats-action@master

--- a/.github/workflows/ci_build_sanitizers.yml
+++ b/.github/workflows/ci_build_sanitizers.yml
@@ -52,11 +52,7 @@ jobs:
           mkdir -p deps
           cd deps && conan install --requires=cnats/3.9.1@ --build missing -o nats/*:shared=False -o nats/*:fPIC=True -o nats/*:with_tls=False -o nats/*:with_sodium=False -o nats/*:enable_streaming=False --generator CMakeDeps --generator VirtualBuildEnv
       - name: Start Mosquitto
-        uses: namoshek/mosquitto-github-action@v1
-        with:
-          version: '1.6'
-          ports: '1883:1883'
-          container-name: 'mqtt'
+        run: sudo apt-get install -y mosquitto && sudo systemctl start mosquitto
       - name: Start NATS Server
         uses: onichandame/nats-action@master
         with:
@@ -120,11 +116,7 @@ jobs:
           mkdir -p deps
           cd deps && conan install --requires=cnats/3.9.1@ --build missing -o nats/*:shared=False -o nats/*:fPIC=True -o nats/*:with_tls=False -o nats/*:with_sodium=False -o nats/*:enable_streaming=False --generator CMakeDeps --generator VirtualBuildEnv
       - name: Start Mosquitto
-        uses: namoshek/mosquitto-github-action@v1
-        with:
-          version: '1.6'
-          ports: '1883:1883'
-          container-name: 'mqtt'
+        run: sudo apt-get install -y mosquitto && sudo systemctl start mosquitto
       - name: Start NATS Server
         uses: onichandame/nats-action@master
         with:

--- a/.github/workflows/ci_build_test.yml
+++ b/.github/workflows/ci_build_test.yml
@@ -58,11 +58,7 @@ jobs:
       - run: cmake --version
       - name: Start Mosquitto
         if: ${{ matrix.config.os == 'ubuntu-latest'}}
-        uses: namoshek/mosquitto-github-action@v1
-        with:
-          version: '1.6'
-          ports: '1883:1883'
-          container-name: 'mqtt'
+        run: sudo apt-get install -y mosquitto && sudo systemctl start mosquitto
       - name: Create Nats Server for ubuntu (only ubuntu runs tests)
         if: ${{ matrix.config.os == 'ubuntu-latest'}}
         uses: onichandame/nats-action@master
@@ -167,11 +163,7 @@ jobs:
         run: git clone --branch v2.13.8 --depth 1 https://github.com/catchorg/Catch2.git && cd Catch2 && cmake -Bbuild -H. -DBUILD_TESTING=OFF && sudo cmake --build build/ --target install
       - name: Start Mosquitto
         if: ${{ matrix.config.os == 'ubuntu-latest'}}
-        uses: namoshek/mosquitto-github-action@v1
-        with:
-          version: '1.6'
-          ports: '1883:1883'
-          container-name: 'mqtt'
+        run: sudo apt-get install -y mosquitto && sudo systemctl start mosquitto
       - name: Create Nats Server for ubuntu (only ubuntu runs tests)
         if: ${{ matrix.config.os == 'ubuntu-latest'}}
         uses: onichandame/nats-action@master

--- a/apigear/goldenmaster.solution.yaml
+++ b/apigear/goldenmaster.solution.yaml
@@ -15,6 +15,7 @@ targets:
       - test-apis/custom_types.module.yaml
       - test-apis/extern_types.module.yaml
       - test-apis/counter.module.yaml
+      - test-apis/testbed.structarray.module.yaml
     output: ../test
     template: ..
     force: true

--- a/goldenmaster/CMakeLists.txt
+++ b/goldenmaster/CMakeLists.txt
@@ -208,6 +208,17 @@ if(NOT counter_FOUND)
   )
   FetchContent_MakeAvailable(counter)
 endif()
+find_package(tb_struct_array QUIET)
+if(NOT tb_struct_array_FOUND)
+  # pull tb_struct_array as dependency
+  message(STATUS "tb_struct_array NOT FOUND, building from source folder")
+  include(FetchContent)
+  FetchContent_Declare(tb_struct_array
+    SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/modules/tb_struct_array"
+    OVERRIDE_FIND_PACKAGE
+  )
+  FetchContent_MakeAvailable(tb_struct_array)
+endif()
 add_subdirectory(examples/app)
 add_subdirectory(examples/appthreadsafe)
 add_subdirectory(examples/olinkserver)

--- a/goldenmaster/examples/app/CMakeLists.txt
+++ b/goldenmaster/examples/app/CMakeLists.txt
@@ -31,6 +31,7 @@ find_package(tb_names REQUIRED COMPONENTS tb_names-core tb_names-implementation 
 find_package(custom_types REQUIRED COMPONENTS custom_types-core)
 find_package(extern_types REQUIRED COMPONENTS extern_types-core)
 find_package(counter REQUIRED COMPONENTS counter-core counter-implementation counter-monitor)
+find_package(tb_struct_array REQUIRED COMPONENTS tb_struct_array-core tb_struct_array-implementation tb_struct_array-monitor)
 find_package(apigear REQUIRED COMPONENTS poco-tracer)
 target_link_libraries(app
     apigear::poco-tracer
@@ -60,6 +61,9 @@ target_link_libraries(app
     counter::counter-core
     counter::counter-implementation
     counter::counter-monitor
+    tb_struct_array::tb_struct_array-core
+    tb_struct_array::tb_struct_array-implementation
+    tb_struct_array::tb_struct_array-monitor
 )
 
 install(TARGETS app

--- a/goldenmaster/examples/app/conanfile.txt
+++ b/goldenmaster/examples/app/conanfile.txt
@@ -9,6 +9,7 @@ tb_names/1.0.0
 custom_types/1.0.0
 extern_types/1.0.0
 counter/1.0.0
+tb_struct_array/1.0.0
 apigear/3.7.0
 
 [generators]

--- a/goldenmaster/examples/app/main.cpp
+++ b/goldenmaster/examples/app/main.cpp
@@ -43,10 +43,14 @@
 #include "testbed1/generated/monitor/structinterface.tracedecorator.h"
 #include "testbed1/implementation/structarrayinterface.h"
 #include "testbed1/generated/monitor/structarrayinterface.tracedecorator.h"
+#include "testbed1/implementation/structarray2interface.h"
+#include "testbed1/generated/monitor/structarray2interface.tracedecorator.h"
 #include "tb_names/implementation/names.h"
 #include "tb_names/generated/monitor/names.tracedecorator.h"
 #include "counter/implementation/counter.h"
 #include "counter/generated/monitor/counter.tracedecorator.h"
+#include "tb_struct_array/implementation/structarrayfieldinterface.h"
+#include "tb_struct_array/generated/monitor/structarrayfieldinterface.tracedecorator.h"
 #include "apigear/tracer/tracer.h"
 
 using namespace Test;
@@ -98,10 +102,14 @@ int main(){
     std::unique_ptr<Testbed1::IStructInterface> testTestbed1StructInterfaceTraceDecorator = Testbed1::StructInterfaceTraceDecorator::connect(*testTestbed1StructInterface, tracer);
     std::unique_ptr<Testbed1::IStructArrayInterface> testTestbed1StructArrayInterface = std::make_unique<Testbed1::StructArrayInterface>();
     std::unique_ptr<Testbed1::IStructArrayInterface> testTestbed1StructArrayInterfaceTraceDecorator = Testbed1::StructArrayInterfaceTraceDecorator::connect(*testTestbed1StructArrayInterface, tracer);
+    std::unique_ptr<Testbed1::IStructArray2Interface> testTestbed1StructArray2Interface = std::make_unique<Testbed1::StructArray2Interface>();
+    std::unique_ptr<Testbed1::IStructArray2Interface> testTestbed1StructArray2InterfaceTraceDecorator = Testbed1::StructArray2InterfaceTraceDecorator::connect(*testTestbed1StructArray2Interface, tracer);
     std::unique_ptr<TbNames::INamEs> testTbNamesNamEs = std::make_unique<TbNames::NamEs>();
     std::unique_ptr<TbNames::INamEs> testTbNamesNamEsTraceDecorator = TbNames::NamEsTraceDecorator::connect(*testTbNamesNamEs, tracer);
     std::unique_ptr<Counter::ICounter> testCounterCounter = std::make_unique<Counter::Counter>();
     std::unique_ptr<Counter::ICounter> testCounterCounterTraceDecorator = Counter::CounterTraceDecorator::connect(*testCounterCounter, tracer);
+    std::unique_ptr<TbStructArray::IStructArrayFieldInterface> testTbStructArrayStructArrayFieldInterface = std::make_unique<TbStructArray::StructArrayFieldInterface>();
+    std::unique_ptr<TbStructArray::IStructArrayFieldInterface> testTbStructArrayStructArrayFieldInterfaceTraceDecorator = TbStructArray::StructArrayFieldInterfaceTraceDecorator::connect(*testTbStructArrayStructArrayFieldInterface, tracer);
 
     return 0;
 }

--- a/goldenmaster/examples/appthreadsafe/CMakeLists.txt
+++ b/goldenmaster/examples/appthreadsafe/CMakeLists.txt
@@ -31,6 +31,7 @@ find_package(tb_names REQUIRED COMPONENTS tb_names-core tb_names-implementation)
 find_package(custom_types REQUIRED COMPONENTS custom_types-core)
 find_package(extern_types REQUIRED COMPONENTS extern_types-core)
 find_package(counter REQUIRED COMPONENTS counter-core counter-implementation)
+find_package(tb_struct_array REQUIRED COMPONENTS tb_struct_array-core tb_struct_array-implementation)
 target_link_libraries(appthreadsafe
     testbed2::testbed2-core
     testbed2::testbed2-implementation
@@ -48,6 +49,8 @@ target_link_libraries(appthreadsafe
     tb_names::tb_names-implementation
     counter::counter-core
     counter::counter-implementation
+    tb_struct_array::tb_struct_array-core
+    tb_struct_array::tb_struct_array-implementation
 )
 
 install(TARGETS appthreadsafe

--- a/goldenmaster/examples/appthreadsafe/conanfile.txt
+++ b/goldenmaster/examples/appthreadsafe/conanfile.txt
@@ -9,6 +9,7 @@ tb_names/1.0.0
 custom_types/1.0.0
 extern_types/1.0.0
 counter/1.0.0
+tb_struct_array/1.0.0
 
 [generators]
 CMakeDeps

--- a/goldenmaster/examples/appthreadsafe/main.cpp
+++ b/goldenmaster/examples/appthreadsafe/main.cpp
@@ -43,10 +43,14 @@
 #include "testbed1/generated/core/structinterface.threadsafedecorator.h"
 #include "testbed1/implementation/structarrayinterface.h"
 #include "testbed1/generated/core/structarrayinterface.threadsafedecorator.h"
+#include "testbed1/implementation/structarray2interface.h"
+#include "testbed1/generated/core/structarray2interface.threadsafedecorator.h"
 #include "tb_names/implementation/names.h"
 #include "tb_names/generated/core/names.threadsafedecorator.h"
 #include "counter/implementation/counter.h"
 #include "counter/generated/core/counter.threadsafedecorator.h"
+#include "tb_struct_array/implementation/structarrayfieldinterface.h"
+#include "tb_struct_array/generated/core/structarrayfieldinterface.threadsafedecorator.h"
 
 void testTestbed2ManyParamInterface()
 {
@@ -408,6 +412,33 @@ void testTestbed1StructArrayInterface()
     auto l_propString = std::list<StructString>();
     l_propString = testStructArrayInterface->getPropString();
     testStructArrayInterface->setPropString(l_propString);
+    auto l_propEnum = std::list<Enum0Enum>();
+    l_propEnum = testStructArrayInterface->getPropEnum();
+    testStructArrayInterface->setPropEnum(l_propEnum);
+}
+
+void testTestbed1StructArray2Interface()
+{
+    using namespace Test::Testbed1;
+
+    std::unique_ptr<IStructArray2Interface> testStructArray2Interface = std::make_unique<StructArray2InterfaceThreadSafeDecorator>(std::make_shared<StructArray2Interface>());
+
+    // Thread safe access
+    auto l_propBool = StructBoolWithArray();
+    l_propBool = testStructArray2Interface->getPropBool();
+    testStructArray2Interface->setPropBool(l_propBool);
+    auto l_propInt = StructIntWithArray();
+    l_propInt = testStructArray2Interface->getPropInt();
+    testStructArray2Interface->setPropInt(l_propInt);
+    auto l_propFloat = StructFloatWithArray();
+    l_propFloat = testStructArray2Interface->getPropFloat();
+    testStructArray2Interface->setPropFloat(l_propFloat);
+    auto l_propString = StructStringWithArray();
+    l_propString = testStructArray2Interface->getPropString();
+    testStructArray2Interface->setPropString(l_propString);
+    auto l_propEnum = StructEnumWithArray();
+    l_propEnum = testStructArray2Interface->getPropEnum();
+    testStructArray2Interface->setPropEnum(l_propEnum);
 }
 
 void testTbNamesNamEs()
@@ -452,6 +483,27 @@ void testCounterCounter()
     testCounter->setExternVectorArray(l_externVectorArray);
 }
 
+void testTbStructArrayStructArrayFieldInterface()
+{
+    using namespace Test::TbStructArray;
+
+    std::unique_ptr<IStructArrayFieldInterface> testStructArrayFieldInterface = std::make_unique<StructArrayFieldInterfaceThreadSafeDecorator>(std::make_shared<StructArrayFieldInterface>());
+
+    // Thread safe access
+    auto l_propStructArray = StructWithArrayOfStructs();
+    l_propStructArray = testStructArrayFieldInterface->getPropStructArray();
+    testStructArrayFieldInterface->setPropStructArray(l_propStructArray);
+    auto l_propEnumArray = StructWithArrayOfEnums();
+    l_propEnumArray = testStructArrayFieldInterface->getPropEnumArray();
+    testStructArrayFieldInterface->setPropEnumArray(l_propEnumArray);
+    auto l_propIntArray = StructWithArrayOfInts();
+    l_propIntArray = testStructArrayFieldInterface->getPropIntArray();
+    testStructArrayFieldInterface->setPropIntArray(l_propIntArray);
+    auto l_propMixed = MixedStruct();
+    l_propMixed = testStructArrayFieldInterface->getPropMixed();
+    testStructArrayFieldInterface->setPropMixed(l_propMixed);
+}
+
 
 int main(){
     testTestbed2ManyParamInterface();
@@ -476,8 +528,10 @@ int main(){
     testTbSimpleEmptyInterface();
     testTestbed1StructInterface();
     testTestbed1StructArrayInterface();
+    testTestbed1StructArray2Interface();
     testTbNamesNamEs();
     testCounterCounter();
+    testTbStructArrayStructArrayFieldInterface();
 
     return 0;
 }

--- a/goldenmaster/examples/mqttclient/CMakeLists.txt
+++ b/goldenmaster/examples/mqttclient/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(tb_names REQUIRED COMPONENTS tb_names-core tb_names-mqtt)
 find_package(custom_types REQUIRED COMPONENTS custom_types-core)
 find_package(extern_types REQUIRED COMPONENTS extern_types-core)
 find_package(counter REQUIRED COMPONENTS counter-core counter-mqtt)
+find_package(tb_struct_array REQUIRED COMPONENTS tb_struct_array-core tb_struct_array-mqtt)
 target_link_libraries(MQTTClient
     apigear::utilities
     testbed2::testbed2-core
@@ -43,6 +44,8 @@ target_link_libraries(MQTTClient
     tb_names::tb_names-mqtt
     counter::counter-core
     counter::counter-mqtt
+    tb_struct_array::tb_struct_array-core
+    tb_struct_array::tb_struct_array-mqtt
 )
 
 # we assume that the examples are built together with the libraries and thus ignore this warning

--- a/goldenmaster/examples/mqttclient/conanfile.txt
+++ b/goldenmaster/examples/mqttclient/conanfile.txt
@@ -9,6 +9,7 @@ tb_names/1.0.0
 custom_types/1.0.0
 extern_types/1.0.0
 counter/1.0.0
+tb_struct_array/1.0.0
 apigear/3.7.0
 
 [generators]

--- a/goldenmaster/examples/mqttclient/main.cpp
+++ b/goldenmaster/examples/mqttclient/main.cpp
@@ -21,8 +21,10 @@
 #include "tb_simple/generated/mqtt/emptyinterfaceclient.h"
 #include "testbed1/generated/mqtt/structinterfaceclient.h"
 #include "testbed1/generated/mqtt/structarrayinterfaceclient.h"
+#include "testbed1/generated/mqtt/structarray2interfaceclient.h"
 #include "tb_names/generated/mqtt/namesclient.h"
 #include "counter/generated/mqtt/counterclient.h"
+#include "tb_struct_array/generated/mqtt/structarrayfieldinterfaceclient.h"
 #include "apigear/mqtt/mqttclient.h"
 #include "apigear/utilities/logger.h"
 #include <iostream>
@@ -89,8 +91,10 @@ int main(){
     std::unique_ptr<TbSimple::IEmptyInterface> testTbSimpleEmptyInterface = std::make_unique<TbSimple::MQTT::EmptyInterfaceClient>(mqttclient);
     std::unique_ptr<Testbed1::IStructInterface> testTestbed1StructInterface = std::make_unique<Testbed1::MQTT::StructInterfaceClient>(mqttclient);
     std::unique_ptr<Testbed1::IStructArrayInterface> testTestbed1StructArrayInterface = std::make_unique<Testbed1::MQTT::StructArrayInterfaceClient>(mqttclient);
+    std::unique_ptr<Testbed1::IStructArray2Interface> testTestbed1StructArray2Interface = std::make_unique<Testbed1::MQTT::StructArray2InterfaceClient>(mqttclient);
     std::unique_ptr<TbNames::INamEs> testTbNamesNamEs = std::make_unique<TbNames::MQTT::Nam_EsClient>(mqttclient);
     std::unique_ptr<Counter::ICounter> testCounterCounter = std::make_unique<Counter::MQTT::CounterClient>(mqttclient);
+    std::unique_ptr<TbStructArray::IStructArrayFieldInterface> testTbStructArrayStructArrayFieldInterface = std::make_unique<TbStructArray::MQTT::StructArrayFieldInterfaceClient>(mqttclient);
 
     // start mqtt connection
     mqttclient->connectToHost("");

--- a/goldenmaster/examples/mqttserver/CMakeLists.txt
+++ b/goldenmaster/examples/mqttserver/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(tb_names REQUIRED COMPONENTS tb_names-core tb_names-implementation 
 find_package(custom_types REQUIRED COMPONENTS custom_types-core)
 find_package(extern_types REQUIRED COMPONENTS extern_types-core)
 find_package(counter REQUIRED COMPONENTS counter-core counter-implementation counter-mqtt)
+find_package(tb_struct_array REQUIRED COMPONENTS tb_struct_array-core tb_struct_array-implementation tb_struct_array-mqtt)
 target_link_libraries(MQTTServer
     apigear::utilities
     testbed2::testbed2-core
@@ -53,6 +54,9 @@ target_link_libraries(MQTTServer
     counter::counter-core
     counter::counter-implementation
     counter::counter-mqtt
+    tb_struct_array::tb_struct_array-core
+    tb_struct_array::tb_struct_array-implementation
+    tb_struct_array::tb_struct_array-mqtt
 )
 
 # we assume that the examples are built together with the libraries and thus ignore this warning

--- a/goldenmaster/examples/mqttserver/conanfile.txt
+++ b/goldenmaster/examples/mqttserver/conanfile.txt
@@ -9,6 +9,7 @@ tb_names/1.0.0
 custom_types/1.0.0
 extern_types/1.0.0
 counter/1.0.0
+tb_struct_array/1.0.0
 apigear/3.7.0
 
 [generators]

--- a/goldenmaster/examples/mqttserver/main.cpp
+++ b/goldenmaster/examples/mqttserver/main.cpp
@@ -43,10 +43,14 @@
 #include "testbed1/generated/mqtt/structinterfaceservice.h"
 #include "testbed1/implementation/structarrayinterface.h"
 #include "testbed1/generated/mqtt/structarrayinterfaceservice.h"
+#include "testbed1/implementation/structarray2interface.h"
+#include "testbed1/generated/mqtt/structarray2interfaceservice.h"
 #include "tb_names/implementation/names.h"
 #include "tb_names/generated/mqtt/namesservice.h"
 #include "counter/implementation/counter.h"
 #include "counter/generated/mqtt/counterservice.h"
+#include "tb_struct_array/implementation/structarrayfieldinterface.h"
+#include "tb_struct_array/generated/mqtt/structarrayfieldinterfaceservice.h"
 #include "apigear/mqtt/mqttservice.h"
 #include "apigear/utilities/logger.h"
 #include <iostream>
@@ -137,10 +141,14 @@ int main(){
     Testbed1::MQTT::StructInterfaceService testTestbed1StructInterfaceService(testTestbed1StructInterface, mqttservice);
     std::shared_ptr<Testbed1::IStructArrayInterface> testTestbed1StructArrayInterface = std::make_shared<Testbed1::StructArrayInterface>();
     Testbed1::MQTT::StructArrayInterfaceService testTestbed1StructArrayInterfaceService(testTestbed1StructArrayInterface, mqttservice);
+    std::shared_ptr<Testbed1::IStructArray2Interface> testTestbed1StructArray2Interface = std::make_shared<Testbed1::StructArray2Interface>();
+    Testbed1::MQTT::StructArray2InterfaceService testTestbed1StructArray2InterfaceService(testTestbed1StructArray2Interface, mqttservice);
     std::shared_ptr<TbNames::INamEs> testTbNamesNamEs = std::make_shared<TbNames::NamEs>();
     TbNames::MQTT::Nam_EsService testTbNamesNamEsService(testTbNamesNamEs, mqttservice);
     std::shared_ptr<Counter::ICounter> testCounterCounter = std::make_shared<Counter::Counter>();
     Counter::MQTT::CounterService testCounterCounterService(testCounterCounter, mqttservice);
+    std::shared_ptr<TbStructArray::IStructArrayFieldInterface> testTbStructArrayStructArrayFieldInterface = std::make_shared<TbStructArray::StructArrayFieldInterface>();
+    TbStructArray::MQTT::StructArrayFieldInterfaceService testTbStructArrayStructArrayFieldInterfaceService(testTbStructArrayStructArrayFieldInterface, mqttservice);
 
     // start mqtt connection
     mqttservice->connectToHost("");

--- a/goldenmaster/examples/natsclient/CMakeLists.txt
+++ b/goldenmaster/examples/natsclient/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(tb_names REQUIRED COMPONENTS tb_names-core tb_names-nats)
 find_package(custom_types REQUIRED COMPONENTS custom_types-core)
 find_package(extern_types REQUIRED COMPONENTS extern_types-core)
 find_package(counter REQUIRED COMPONENTS counter-core counter-nats)
+find_package(tb_struct_array REQUIRED COMPONENTS tb_struct_array-core tb_struct_array-nats)
 find_package(apigear REQUIRED COMPONENTS nats)
 target_link_libraries(NatsClient
     apigear::utilities
@@ -45,6 +46,8 @@ target_link_libraries(NatsClient
     tb_names::tb_names-nats
     counter::counter-core
     counter::counter-nats
+    tb_struct_array::tb_struct_array-core
+    tb_struct_array::tb_struct_array-nats
 )
 
 # we assume that the examples are built together with the libraries and thus ignore this warning

--- a/goldenmaster/examples/natsclient/conanfile.txt
+++ b/goldenmaster/examples/natsclient/conanfile.txt
@@ -9,6 +9,7 @@ tb_names/1.0.0
 custom_types/1.0.0
 extern_types/1.0.0
 counter/1.0.0
+tb_struct_array/1.0.0
 apigear/3.7.0
 
 [generators]

--- a/goldenmaster/examples/natsclient/main.cpp
+++ b/goldenmaster/examples/natsclient/main.cpp
@@ -21,8 +21,10 @@
 #include "tb_simple/generated/nats/emptyinterfaceclient.h"
 #include "testbed1/generated/nats/structinterfaceclient.h"
 #include "testbed1/generated/nats/structarrayinterfaceclient.h"
+#include "testbed1/generated/nats/structarray2interfaceclient.h"
 #include "tb_names/generated/nats/namesclient.h"
 #include "counter/generated/nats/counterclient.h"
+#include "tb_struct_array/generated/nats/structarrayfieldinterfaceclient.h"
 #include "apigear/utilities/logger.h"
 #include <iostream>
 #include "apigear/nats/natsclient.h"
@@ -73,8 +75,10 @@ int main(){
     auto testTbSimpleEmptyInterface = TbSimple::Nats::EmptyInterfaceClient::create(client);
     auto testTestbed1StructInterface = Testbed1::Nats::StructInterfaceClient::create(client);
     auto testTestbed1StructArrayInterface = Testbed1::Nats::StructArrayInterfaceClient::create(client);
+    auto testTestbed1StructArray2Interface = Testbed1::Nats::StructArray2InterfaceClient::create(client);
     auto testTbNamesNamEs = TbNames::Nats::Nam_EsClient::create(client);
     auto testCounterCounter = Counter::Nats::CounterClient::create(client);
+    auto testTbStructArrayStructArrayFieldInterface = TbStructArray::Nats::StructArrayFieldInterfaceClient::create(client);
 
    
     

--- a/goldenmaster/examples/natsserver/CMakeLists.txt
+++ b/goldenmaster/examples/natsserver/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(tb_names REQUIRED COMPONENTS tb_names-core tb_names-implementation 
 find_package(custom_types REQUIRED COMPONENTS custom_types-core)
 find_package(extern_types REQUIRED COMPONENTS extern_types-core)
 find_package(counter REQUIRED COMPONENTS counter-core counter-implementation counter-nats)
+find_package(tb_struct_array REQUIRED COMPONENTS tb_struct_array-core tb_struct_array-implementation tb_struct_array-nats)
 target_link_libraries(NatsServer
     apigear::utilities
     apigear::nats
@@ -54,6 +55,9 @@ target_link_libraries(NatsServer
     counter::counter-core
     counter::counter-implementation
     counter::counter-nats
+    tb_struct_array::tb_struct_array-core
+    tb_struct_array::tb_struct_array-implementation
+    tb_struct_array::tb_struct_array-nats
 )
 
 # we assume that the examples are built together with the libraries and thus ignore this warning

--- a/goldenmaster/examples/natsserver/conanfile.txt
+++ b/goldenmaster/examples/natsserver/conanfile.txt
@@ -9,6 +9,7 @@ tb_names/1.0.0
 custom_types/1.0.0
 extern_types/1.0.0
 counter/1.0.0
+tb_struct_array/1.0.0
 apigear/3.7.0
 
 [generators]

--- a/goldenmaster/examples/natsserver/main.cpp
+++ b/goldenmaster/examples/natsserver/main.cpp
@@ -43,10 +43,14 @@
 #include "testbed1/generated/nats/structinterfaceservice.h"
 #include "testbed1/implementation/structarrayinterface.h"
 #include "testbed1/generated/nats/structarrayinterfaceservice.h"
+#include "testbed1/implementation/structarray2interface.h"
+#include "testbed1/generated/nats/structarray2interfaceservice.h"
 #include "tb_names/implementation/names.h"
 #include "tb_names/generated/nats/namesservice.h"
 #include "counter/implementation/counter.h"
 #include "counter/generated/nats/counterservice.h"
+#include "tb_struct_array/implementation/structarrayfieldinterface.h"
+#include "tb_struct_array/generated/nats/structarrayfieldinterfaceservice.h"
 #include "apigear/nats/natsservice.h"
 #include "apigear/utilities/logger.h"
 #include <iostream>
@@ -121,10 +125,14 @@ int main(){
     auto testTestbed1StructInterfaceService = Testbed1::Nats::StructInterfaceService::create(testTestbed1StructInterface, service);
     std::shared_ptr<Testbed1::IStructArrayInterface> testTestbed1StructArrayInterface = std::make_shared<Testbed1::StructArrayInterface>();
     auto testTestbed1StructArrayInterfaceService = Testbed1::Nats::StructArrayInterfaceService::create(testTestbed1StructArrayInterface, service);
+    std::shared_ptr<Testbed1::IStructArray2Interface> testTestbed1StructArray2Interface = std::make_shared<Testbed1::StructArray2Interface>();
+    auto testTestbed1StructArray2InterfaceService = Testbed1::Nats::StructArray2InterfaceService::create(testTestbed1StructArray2Interface, service);
     std::shared_ptr<TbNames::INamEs> testTbNamesNamEs = std::make_shared<TbNames::NamEs>();
     auto testTbNamesNamEsService = TbNames::Nats::Nam_EsService::create(testTbNamesNamEs, service);
     std::shared_ptr<Counter::ICounter> testCounterCounter = std::make_shared<Counter::Counter>();
     auto testCounterCounterService = Counter::Nats::CounterService::create(testCounterCounter, service);
+    std::shared_ptr<TbStructArray::IStructArrayFieldInterface> testTbStructArrayStructArrayFieldInterface = std::make_shared<TbStructArray::StructArrayFieldInterface>();
+    auto testTbStructArrayStructArrayFieldInterfaceService = TbStructArray::Nats::StructArrayFieldInterfaceService::create(testTbStructArrayStructArrayFieldInterface, service);
 
     service->connect("nats://localhost:4222");
 

--- a/goldenmaster/examples/olinkclient/CMakeLists.txt
+++ b/goldenmaster/examples/olinkclient/CMakeLists.txt
@@ -34,6 +34,7 @@ find_package(tb_names REQUIRED COMPONENTS tb_names-core tb_names-implementation 
 find_package(custom_types REQUIRED COMPONENTS custom_types-core)
 find_package(extern_types REQUIRED COMPONENTS extern_types-core)
 find_package(counter REQUIRED COMPONENTS counter-core counter-implementation counter-monitor counter-olink)
+find_package(tb_struct_array REQUIRED COMPONENTS tb_struct_array-core tb_struct_array-implementation tb_struct_array-monitor tb_struct_array-olink)
 target_link_libraries(OLinkClient
     apigear::poco-tracer
     testbed2::testbed2-core
@@ -68,6 +69,10 @@ target_link_libraries(OLinkClient
     counter::counter-implementation
     counter::counter-monitor
     counter::counter-olink
+    tb_struct_array::tb_struct_array-core
+    tb_struct_array::tb_struct_array-implementation
+    tb_struct_array::tb_struct_array-monitor
+    tb_struct_array::tb_struct_array-olink
 )
 
 install(TARGETS OLinkClient

--- a/goldenmaster/examples/olinkclient/conanfile.txt
+++ b/goldenmaster/examples/olinkclient/conanfile.txt
@@ -9,6 +9,7 @@ tb_names/1.0.0
 custom_types/1.0.0
 extern_types/1.0.0
 counter/1.0.0
+tb_struct_array/1.0.0
 apigear/3.7.0
 
 [generators]

--- a/goldenmaster/examples/olinkclient/main.cpp
+++ b/goldenmaster/examples/olinkclient/main.cpp
@@ -43,10 +43,14 @@
 #include "testbed1/generated/monitor/structinterface.tracedecorator.h"
 #include "testbed1/generated/olink/structarrayinterfaceclient.h"
 #include "testbed1/generated/monitor/structarrayinterface.tracedecorator.h"
+#include "testbed1/generated/olink/structarray2interfaceclient.h"
+#include "testbed1/generated/monitor/structarray2interface.tracedecorator.h"
 #include "tb_names/generated/olink/namesclient.h"
 #include "tb_names/generated/monitor/names.tracedecorator.h"
 #include "counter/generated/olink/counterclient.h"
 #include "counter/generated/monitor/counter.tracedecorator.h"
+#include "tb_struct_array/generated/olink/structarrayfieldinterfaceclient.h"
+#include "tb_struct_array/generated/monitor/structarrayfieldinterface.tracedecorator.h"
 
 #include "apigear/olink/olinkconnection.h"
 #include "apigear/tracer/tracer.h"
@@ -156,12 +160,18 @@ int main(){
     auto testbed1StructArrayInterface = std::make_shared<Testbed1::olink::StructArrayInterfaceClient>();
     clientNetworkEndpoint.connectAndLinkObject(testbed1StructArrayInterface);
     std::unique_ptr<Testbed1::IStructArrayInterface> testbed1StructArrayInterfaceTraced = Testbed1::StructArrayInterfaceTraceDecorator::connect(*testbed1StructArrayInterface, tracer);
+    auto testbed1StructArray2Interface = std::make_shared<Testbed1::olink::StructArray2InterfaceClient>();
+    clientNetworkEndpoint.connectAndLinkObject(testbed1StructArray2Interface);
+    std::unique_ptr<Testbed1::IStructArray2Interface> testbed1StructArray2InterfaceTraced = Testbed1::StructArray2InterfaceTraceDecorator::connect(*testbed1StructArray2Interface, tracer);
     auto tbNamesNamEs = std::make_shared<TbNames::olink::Nam_EsClient>();
     clientNetworkEndpoint.connectAndLinkObject(tbNamesNamEs);
     std::unique_ptr<TbNames::INamEs> tbNamesNamEsTraced = TbNames::NamEsTraceDecorator::connect(*tbNamesNamEs, tracer);
     auto counterCounter = std::make_shared<Counter::olink::CounterClient>();
     clientNetworkEndpoint.connectAndLinkObject(counterCounter);
     std::unique_ptr<Counter::ICounter> counterCounterTraced = Counter::CounterTraceDecorator::connect(*counterCounter, tracer);
+    auto tbStructArrayStructArrayFieldInterface = std::make_shared<TbStructArray::olink::StructArrayFieldInterfaceClient>();
+    clientNetworkEndpoint.connectAndLinkObject(tbStructArrayStructArrayFieldInterface);
+    std::unique_ptr<TbStructArray::IStructArrayFieldInterface> tbStructArrayStructArrayFieldInterfaceTraced = TbStructArray::StructArrayFieldInterfaceTraceDecorator::connect(*tbStructArrayStructArrayFieldInterface, tracer);
     
     clientNetworkEndpoint.connectToHost(Poco::URI("ws://localhost:8000"));
 
@@ -198,8 +208,10 @@ int main(){
     clientNetworkEndpoint.disconnectAndUnlink(tbSimpleEmptyInterface->olinkObjectName());
     clientNetworkEndpoint.disconnectAndUnlink(testbed1StructInterface->olinkObjectName());
     clientNetworkEndpoint.disconnectAndUnlink(testbed1StructArrayInterface->olinkObjectName());
+    clientNetworkEndpoint.disconnectAndUnlink(testbed1StructArray2Interface->olinkObjectName());
     clientNetworkEndpoint.disconnectAndUnlink(tbNamesNamEs->olinkObjectName());
     clientNetworkEndpoint.disconnectAndUnlink(counterCounter->olinkObjectName());
+    clientNetworkEndpoint.disconnectAndUnlink(tbStructArrayStructArrayFieldInterface->olinkObjectName());
 
     return 0;
 }

--- a/goldenmaster/examples/olinkserver/CMakeLists.txt
+++ b/goldenmaster/examples/olinkserver/CMakeLists.txt
@@ -34,6 +34,7 @@ find_package(tb_names REQUIRED COMPONENTS tb_names-core tb_names-implementation 
 find_package(custom_types REQUIRED COMPONENTS custom_types-core)
 find_package(extern_types REQUIRED COMPONENTS extern_types-core)
 find_package(counter REQUIRED COMPONENTS counter-core counter-implementation counter-olink)
+find_package(tb_struct_array REQUIRED COMPONENTS tb_struct_array-core tb_struct_array-implementation tb_struct_array-olink)
 target_link_libraries(OLinkServer
     testbed2::testbed2-core
     testbed2::testbed2-implementation
@@ -61,6 +62,9 @@ target_link_libraries(OLinkServer
     counter::counter-core
     counter::counter-implementation
     counter::counter-olink
+    tb_struct_array::tb_struct_array-core
+    tb_struct_array::tb_struct_array-implementation
+    tb_struct_array::tb_struct_array-olink
 )
 
 install(TARGETS OLinkServer

--- a/goldenmaster/examples/olinkserver/conanfile.txt
+++ b/goldenmaster/examples/olinkserver/conanfile.txt
@@ -9,6 +9,7 @@ tb_names/1.0.0
 custom_types/1.0.0
 extern_types/1.0.0
 counter/1.0.0
+tb_struct_array/1.0.0
 apigear/3.7.0
 
 [generators]

--- a/goldenmaster/examples/olinkserver/main.cpp
+++ b/goldenmaster/examples/olinkserver/main.cpp
@@ -65,12 +65,18 @@
 #include "testbed1/implementation/structarrayinterface.h"
 #include "testbed1/generated/olink/structarrayinterfaceservice.h"
 #include "testbed1/generated/core/structarrayinterface.threadsafedecorator.h"
+#include "testbed1/implementation/structarray2interface.h"
+#include "testbed1/generated/olink/structarray2interfaceservice.h"
+#include "testbed1/generated/core/structarray2interface.threadsafedecorator.h"
 #include "tb_names/implementation/names.h"
 #include "tb_names/generated/olink/namesservice.h"
 #include "tb_names/generated/core/names.threadsafedecorator.h"
 #include "counter/implementation/counter.h"
 #include "counter/generated/olink/counterservice.h"
 #include "counter/generated/core/counter.threadsafedecorator.h"
+#include "tb_struct_array/implementation/structarrayfieldinterface.h"
+#include "tb_struct_array/generated/olink/structarrayfieldinterfaceservice.h"
+#include "tb_struct_array/generated/core/structarrayfieldinterface.threadsafedecorator.h"
 
 #include "apigear/olink/olinklogadapter.h"
 #include "olink/remoteregistry.h"
@@ -201,6 +207,10 @@ int main(){
     auto testbed1StructArrayInterfaceThreadSafe = std::make_shared<Testbed1::StructArrayInterfaceThreadSafeDecorator>(testbed1StructArrayInterface);
     auto testbed1OlinkStructArrayInterfaceService = std::make_shared<Testbed1::olink::StructArrayInterfaceService>(testbed1StructArrayInterfaceThreadSafe, registry);
     registry.addSource(testbed1OlinkStructArrayInterfaceService);
+    auto testbed1StructArray2Interface = std::make_shared<Testbed1::StructArray2Interface>();
+    auto testbed1StructArray2InterfaceThreadSafe = std::make_shared<Testbed1::StructArray2InterfaceThreadSafeDecorator>(testbed1StructArray2Interface);
+    auto testbed1OlinkStructArray2InterfaceService = std::make_shared<Testbed1::olink::StructArray2InterfaceService>(testbed1StructArray2InterfaceThreadSafe, registry);
+    registry.addSource(testbed1OlinkStructArray2InterfaceService);
     auto tbNamesNamEs = std::make_shared<TbNames::NamEs>();
     auto tbNamesNamEsThreadSafe = std::make_shared<TbNames::NamEsThreadSafeDecorator>(tbNamesNamEs);
     auto tbNamesOlinkNamEsService = std::make_shared<TbNames::olink::Nam_EsService>(tbNamesNamEsThreadSafe, registry);
@@ -209,6 +219,10 @@ int main(){
     auto counterCounterThreadSafe = std::make_shared<Counter::CounterThreadSafeDecorator>(counterCounter);
     auto counterOlinkCounterService = std::make_shared<Counter::olink::CounterService>(counterCounterThreadSafe, registry);
     registry.addSource(counterOlinkCounterService);
+    auto tbStructArrayStructArrayFieldInterface = std::make_shared<TbStructArray::StructArrayFieldInterface>();
+    auto tbStructArrayStructArrayFieldInterfaceThreadSafe = std::make_shared<TbStructArray::StructArrayFieldInterfaceThreadSafeDecorator>(tbStructArrayStructArrayFieldInterface);
+    auto tbStructArrayOlinkStructArrayFieldInterfaceService = std::make_shared<TbStructArray::olink::StructArrayFieldInterfaceService>(tbStructArrayStructArrayFieldInterfaceThreadSafe, registry);
+    registry.addSource(tbStructArrayOlinkStructArrayFieldInterfaceService);
 
     // Start your server after all the services are added.
     // This ensures that any new client that connects, will find the source it needs.
@@ -247,8 +261,10 @@ int main(){
     registry.removeSource(tbSimpleOlinkEmptyInterfaceService->olinkObjectName());
     registry.removeSource(testbed1OlinkStructInterfaceService->olinkObjectName());
     registry.removeSource(testbed1OlinkStructArrayInterfaceService->olinkObjectName());
+    registry.removeSource(testbed1OlinkStructArray2InterfaceService->olinkObjectName());
     registry.removeSource(tbNamesOlinkNamEsService->olinkObjectName());
     registry.removeSource(counterOlinkCounterService->olinkObjectName());
+    registry.removeSource(tbStructArrayOlinkStructArrayFieldInterfaceService->olinkObjectName());
     
     return 0;
 }

--- a/goldenmaster/modules/tb_simple/generated/api/simpleinterface.api.h
+++ b/goldenmaster/modules/tb_simple/generated/api/simpleinterface.api.h
@@ -36,6 +36,14 @@ public:
     virtual std::future<void> funcNoReturnValueAsync(bool paramBool, std::function<void(void)> callback = nullptr) = 0;
 
 
+    virtual bool funcNoParams() = 0;
+    /**
+    * Asynchronous version of funcNoParams()
+    * @return Promise of type bool which is set once the function has completed
+    */
+    virtual std::future<bool> funcNoParamsAsync( std::function<void(bool)> callback = nullptr) = 0;
+
+
     virtual bool funcBool(bool paramBool) = 0;
     /**
     * Asynchronous version of funcBool(bool paramBool)

--- a/goldenmaster/modules/tb_simple/generated/core/simpleinterface.threadsafedecorator.cpp
+++ b/goldenmaster/modules/tb_simple/generated/core/simpleinterface.threadsafedecorator.cpp
@@ -16,6 +16,15 @@ std::future<void> SimpleInterfaceThreadSafeDecorator::funcNoReturnValueAsync(boo
 {
     return m_impl->funcNoReturnValueAsync(paramBool, callback);
 }
+bool SimpleInterfaceThreadSafeDecorator::funcNoParams()
+{
+    return m_impl->funcNoParams();
+}
+
+std::future<bool> SimpleInterfaceThreadSafeDecorator::funcNoParamsAsync( std::function<void(bool)> callback)
+{
+    return m_impl->funcNoParamsAsync( callback);
+}
 bool SimpleInterfaceThreadSafeDecorator::funcBool(bool paramBool)
 {
     return m_impl->funcBool(paramBool);

--- a/goldenmaster/modules/tb_simple/generated/core/simpleinterface.threadsafedecorator.h
+++ b/goldenmaster/modules/tb_simple/generated/core/simpleinterface.threadsafedecorator.h
@@ -68,6 +68,17 @@ public:
     * Forwards call to SimpleInterface implementation.
     * @warning This forward call is not made thread safe by this class.
     */
+    bool funcNoParams() override;
+    /** 
+    * Forwards call to SimpleInterface implementation.
+    * @warning This forward call is not made thread safe by this class.
+    */
+    std::future<bool> funcNoParamsAsync( std::function<void(bool)> callback = nullptr) override;
+
+    /** 
+    * Forwards call to SimpleInterface implementation.
+    * @warning This forward call is not made thread safe by this class.
+    */
     bool funcBool(bool paramBool) override;
     /** 
     * Forwards call to SimpleInterface implementation.

--- a/goldenmaster/modules/tb_simple/generated/monitor/simpleinterface.tracedecorator.cpp
+++ b/goldenmaster/modules/tb_simple/generated/monitor/simpleinterface.tracedecorator.cpp
@@ -29,6 +29,16 @@ std::future<void> SimpleInterfaceTraceDecorator::funcNoReturnValueAsync(bool par
     m_tracer->trace_funcNoReturnValue(paramBool);
     return m_impl.funcNoReturnValueAsync(paramBool, callback);
 }
+bool SimpleInterfaceTraceDecorator::funcNoParams()
+{
+    m_tracer->trace_funcNoParams();
+    return m_impl.funcNoParams();
+}
+std::future<bool> SimpleInterfaceTraceDecorator::funcNoParamsAsync( std::function<void(bool)> callback)
+{
+    m_tracer->trace_funcNoParams();
+    return m_impl.funcNoParamsAsync( callback);
+}
 bool SimpleInterfaceTraceDecorator::funcBool(bool paramBool)
 {
     m_tracer->trace_funcBool(paramBool);

--- a/goldenmaster/modules/tb_simple/generated/monitor/simpleinterface.tracedecorator.h
+++ b/goldenmaster/modules/tb_simple/generated/monitor/simpleinterface.tracedecorator.h
@@ -39,6 +39,11 @@ public:
     /** Traces funcNoReturnValue and forwards call to SimpleInterface implementation. */
     std::future<void> funcNoReturnValueAsync(bool paramBool, std::function<void(void)> callback = nullptr) override;
     
+    /** Traces funcNoParams and forwards call to SimpleInterface implementation. */
+    bool funcNoParams() override;
+    /** Traces funcNoParams and forwards call to SimpleInterface implementation. */
+    std::future<bool> funcNoParamsAsync( std::function<void(bool)> callback = nullptr) override;
+    
     /** Traces funcBool and forwards call to SimpleInterface implementation. */
     bool funcBool(bool paramBool) override;
     /** Traces funcBool and forwards call to SimpleInterface implementation. */

--- a/goldenmaster/modules/tb_simple/generated/monitor/simpleinterface.tracer.cpp
+++ b/goldenmaster/modules/tb_simple/generated/monitor/simpleinterface.tracer.cpp
@@ -30,6 +30,12 @@ void SimpleInterfaceTracer::trace_funcNoReturnValue(bool paramBool)
     m_tracer.call("tb.simple.SimpleInterface#funcNoReturnValue", fields_);
 }
 
+void SimpleInterfaceTracer::trace_funcNoParams()
+{
+    nlohmann::json fields_;
+    m_tracer.call("tb.simple.SimpleInterface#funcNoParams", fields_);
+}
+
 void SimpleInterfaceTracer::trace_funcBool(bool paramBool)
 {
     nlohmann::json fields_;

--- a/goldenmaster/modules/tb_simple/generated/monitor/simpleinterface.tracer.h
+++ b/goldenmaster/modules/tb_simple/generated/monitor/simpleinterface.tracer.h
@@ -32,6 +32,11 @@ public:
   */
   void trace_funcNoReturnValue(bool paramBool);
   /**
+  * Prepares information about the funcNoParams call in a nlohmann::json format and puts to a tracer.
+  * @param The SimpleInterface object to trace.
+  */
+  void trace_funcNoParams();
+  /**
   * Prepares information about the funcBool call in a nlohmann::json format and puts to a tracer.
   * @param The SimpleInterface object to trace.
   */

--- a/goldenmaster/modules/tb_simple/generated/mqtt/simpleinterfaceclient.cpp
+++ b/goldenmaster/modules/tb_simple/generated/mqtt/simpleinterfaceclient.cpp
@@ -46,6 +46,7 @@ std::map<std::string, ApiGear::MQTT::CallbackFunction> SimpleInterfaceClient::cr
         { std::string("tb.simple/SimpleInterface/sig/sigFloat64"), [this](const std::string& args, const std::string&, const std::string&){ this->onSigFloat64(args); } },
         { std::string("tb.simple/SimpleInterface/sig/sigString"), [this](const std::string& args, const std::string&, const std::string&){ this->onSigString(args); } },
         { std::string("tb.simple/SimpleInterface/rpc/funcNoReturnValue/"+clientId+"/result"), [this](const std::string& args, const std::string&, const std::string& correlationData){ this->onInvokeReply(args, correlationData); } },
+        { std::string("tb.simple/SimpleInterface/rpc/funcNoParams/"+clientId+"/result"), [this](const std::string& args, const std::string&, const std::string& correlationData){ this->onInvokeReply(args, correlationData); } },
         { std::string("tb.simple/SimpleInterface/rpc/funcBool/"+clientId+"/result"), [this](const std::string& args, const std::string&, const std::string& correlationData){ this->onInvokeReply(args, correlationData); } },
         { std::string("tb.simple/SimpleInterface/rpc/funcInt/"+clientId+"/result"), [this](const std::string& args, const std::string&, const std::string& correlationData){ this->onInvokeReply(args, correlationData); } },
         { std::string("tb.simple/SimpleInterface/rpc/funcInt32/"+clientId+"/result"), [this](const std::string& args, const std::string&, const std::string& correlationData){ this->onInvokeReply(args, correlationData); } },
@@ -318,6 +319,40 @@ std::future<void> SimpleInterfaceClient::funcNoReturnValueAsync(bool paramBool, 
             {
                 callback();
             }
+            return resultPromise.get_future().get();
+        }
+    );
+}
+
+bool SimpleInterfaceClient::funcNoParams()
+{
+    if(m_client == nullptr) {
+        return false;
+    }
+    bool value(funcNoParamsAsync().get());
+    return value;
+}
+
+std::future<bool> SimpleInterfaceClient::funcNoParamsAsync( std::function<void(bool)> callback)
+{
+    if(m_client == nullptr) {
+        throw std::runtime_error("Client is not initialized");
+    }
+    return std::async(std::launch::async, [this, callback]()
+        {
+            std::promise<bool> resultPromise;
+            static const auto topic = std::string("tb.simple/SimpleInterface/rpc/funcNoParams");
+            static const auto responseTopic = std::string(topic + "/" + m_client->getClientId() + "/result");
+            ApiGear::MQTT::InvokeReplyFunc responseHandler = [&resultPromise, callback](ApiGear::MQTT::InvokeReplyArg arg) {
+                const bool& value = arg.value.get<bool>();
+                resultPromise.set_value(value);
+                if (callback)
+                {
+                    callback(value);
+                }
+            };
+            auto responseId = registerResponseHandler(responseHandler);
+            m_client->invokeRemote(topic, responseTopic, nlohmann::json::array({}).dump(), responseId);
             return resultPromise.get_future().get();
         }
     );

--- a/goldenmaster/modules/tb_simple/generated/mqtt/simpleinterfaceclient.h
+++ b/goldenmaster/modules/tb_simple/generated/mqtt/simpleinterfaceclient.h
@@ -46,6 +46,8 @@ public:
     void setPropString(const std::string& propString) override;
     void funcNoReturnValue(bool paramBool) override;
     std::future<void> funcNoReturnValueAsync(bool paramBool, std::function<void(void)> callback = nullptr) override;
+    bool funcNoParams() override;
+    std::future<bool> funcNoParamsAsync( std::function<void(bool)> callback = nullptr) override;
     bool funcBool(bool paramBool) override;
     std::future<bool> funcBoolAsync(bool paramBool, std::function<void(bool)> callback = nullptr) override;
     int funcInt(int paramInt) override;

--- a/goldenmaster/modules/tb_simple/generated/mqtt/simpleinterfaceservice.cpp
+++ b/goldenmaster/modules/tb_simple/generated/mqtt/simpleinterfaceservice.cpp
@@ -34,6 +34,7 @@ std::map<std::string, ApiGear::MQTT::CallbackFunction> SimpleInterfaceService::c
         {std::string("tb.simple/SimpleInterface/set/propFloat64"), [this](const std::string& args, const std::string&, const std::string&){ this->onSetPropFloat64(args); } },
         {std::string("tb.simple/SimpleInterface/set/propString"), [this](const std::string& args, const std::string&, const std::string&){ this->onSetPropString(args); } },
         {std::string("tb.simple/SimpleInterface/rpc/funcNoReturnValue"), [this](const std::string& args, const std::string& responseTopic, const std::string& correlationData) { this->onInvokeFuncNoReturnValue(args, responseTopic, correlationData); } },
+        {std::string("tb.simple/SimpleInterface/rpc/funcNoParams"), [this](const std::string& args, const std::string& responseTopic, const std::string& correlationData) { this->onInvokeFuncNoParams(args, responseTopic, correlationData); } },
         {std::string("tb.simple/SimpleInterface/rpc/funcBool"), [this](const std::string& args, const std::string& responseTopic, const std::string& correlationData) { this->onInvokeFuncBool(args, responseTopic, correlationData); } },
         {std::string("tb.simple/SimpleInterface/rpc/funcInt"), [this](const std::string& args, const std::string& responseTopic, const std::string& correlationData) { this->onInvokeFuncInt(args, responseTopic, correlationData); } },
         {std::string("tb.simple/SimpleInterface/rpc/funcInt32"), [this](const std::string& args, const std::string& responseTopic, const std::string& correlationData) { this->onInvokeFuncInt32(args, responseTopic, correlationData); } },
@@ -156,6 +157,12 @@ void SimpleInterfaceService::onInvokeFuncNoReturnValue(const std::string& args, 
     (void) correlationData;
     const bool& paramBool = json_args.at(0).get<bool>();
     m_impl->funcNoReturnValue(paramBool);
+}
+void SimpleInterfaceService::onInvokeFuncNoParams(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    auto result = m_impl->funcNoParams();
+    m_service->notifyInvokeResponse(responseTopic, nlohmann::json(result).dump(), correlationData);
 }
 void SimpleInterfaceService::onInvokeFuncBool(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const
 {

--- a/goldenmaster/modules/tb_simple/generated/mqtt/simpleinterfaceservice.h
+++ b/goldenmaster/modules/tb_simple/generated/mqtt/simpleinterfaceservice.h
@@ -31,6 +31,7 @@ private:
 
     void onConnectionStatusChanged(bool connectionStatus);
     void onInvokeFuncNoReturnValue(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const;
+    void onInvokeFuncNoParams(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const;
     void onInvokeFuncBool(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const;
     void onInvokeFuncInt(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const;
     void onInvokeFuncInt32(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const;

--- a/goldenmaster/modules/tb_simple/generated/mqtt/tests/test_simpleinterface.cpp
+++ b/goldenmaster/modules/tb_simple/generated/mqtt/tests/test_simpleinterface.cpp
@@ -354,6 +354,35 @@ TEST_CASE("mqtt  tb.simple SimpleInterface tests")
     {
         auto resultFuture = clientSimpleInterface->funcNoReturnValueAsync(false,[](){/* you can add a callback, but it will be called right after sending the request. It does not wait for the actual function on server side to be finished. */ });
     }
+    SECTION("Test method funcNoParams")
+    {
+        [[maybe_unused]] auto result =  clientSimpleInterface->funcNoParams();
+        // CHECK EFFECTS OF YOUR METHOD AFER FUTURE IS DONE
+    }
+    SECTION("Test method funcNoParams async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSimpleInterface->funcNoParamsAsync();
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == false); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    SECTION("Test method funcNoParams async with callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSimpleInterface->funcNoParamsAsync([&finished, &m_wait](bool value){ (void) value; finished = true; m_wait.notify_all(); /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ });
+
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == false); 
+    }
     SECTION("Test method funcBool")
     {
         [[maybe_unused]] auto result =  clientSimpleInterface->funcBool(false);

--- a/goldenmaster/modules/tb_simple/generated/nats/simpleinterfaceclient.cpp
+++ b/goldenmaster/modules/tb_simple/generated/nats/simpleinterfaceclient.cpp
@@ -425,6 +425,50 @@ std::future<void> SimpleInterfaceClient::funcNoReturnValueAsync(bool paramBool, 
     });
 }
 
+bool SimpleInterfaceClient::funcNoParams()
+{
+    if(m_client == nullptr) {
+        return false;
+    }
+    bool value(funcNoParamsAsync().get());
+    return value;
+}
+
+std::future<bool> SimpleInterfaceClient::funcNoParamsAsync( std::function<void(bool)> user_callback)
+{
+    if(m_client == nullptr) {
+        throw std::runtime_error("Client is not initialized");
+    }
+    static const auto topic = std::string("tb.simple.SimpleInterface.rpc.funcNoParams");
+
+    return std::async(std::launch::async, [this, user_callback]()
+    {
+        std::promise<bool> resultPromise;
+        auto callback = [&resultPromise, user_callback](const auto& result)
+        {
+            if (result.empty())
+            {
+                resultPromise.set_value(false);
+                if (user_callback)
+                {
+                    user_callback(false);
+                }
+                return;
+            }
+            nlohmann::json field = nlohmann::json::parse(result);
+            const bool value = field.get<bool>();
+            resultPromise.set_value(value);
+            if (user_callback)
+            {
+                user_callback(value);
+            }
+        };
+
+        m_client->request(topic,  nlohmann::json::array({}).dump(), callback);
+        return resultPromise.get_future().get();
+    });
+}
+
 bool SimpleInterfaceClient::funcBool(bool paramBool)
 {
     if(m_client == nullptr) {

--- a/goldenmaster/modules/tb_simple/generated/nats/simpleinterfaceclient.h
+++ b/goldenmaster/modules/tb_simple/generated/nats/simpleinterfaceclient.h
@@ -50,6 +50,8 @@ public:
     void setPropString(const std::string& propString) override;
     void funcNoReturnValue(bool paramBool) override;
     std::future<void> funcNoReturnValueAsync(bool paramBool, std::function<void(void)> callback = nullptr) override;
+    bool funcNoParams() override;
+    std::future<bool> funcNoParamsAsync( std::function<void(bool)> callback = nullptr) override;
     bool funcBool(bool paramBool) override;
     std::future<bool> funcBoolAsync(bool paramBool, std::function<void(bool)> callback = nullptr) override;
     int funcInt(int paramInt) override;

--- a/goldenmaster/modules/tb_simple/generated/nats/simpleinterfaceservice.cpp
+++ b/goldenmaster/modules/tb_simple/generated/nats/simpleinterfaceservice.cpp
@@ -7,7 +7,7 @@ using namespace Test::TbSimple;
 using namespace Test::TbSimple::Nats;
 
 namespace{
-const uint32_t  expectedMethodSubscriptions = 9;
+const uint32_t  expectedMethodSubscriptions = 10;
 const uint32_t  expectedPropertiesSubscriptions = 8;
 const uint32_t  initRespSubscription = 1;
 constexpr uint32_t expectedSubscriptionsCount = initRespSubscription + expectedMethodSubscriptions + expectedPropertiesSubscriptions;
@@ -70,6 +70,7 @@ void SimpleInterfaceService::onConnected()
     subscribeTopic("tb.simple.SimpleInterface.set.propFloat64", [this](const auto& value){ onSetPropFloat64(value); });
     subscribeTopic("tb.simple.SimpleInterface.set.propString", [this](const auto& value){ onSetPropString(value); });
     subscribeRequest("tb.simple.SimpleInterface.rpc.funcNoReturnValue", [this](const auto& args){  return onInvokeFuncNoReturnValue(args); });
+    subscribeRequest("tb.simple.SimpleInterface.rpc.funcNoParams", [this](const auto& args){  return onInvokeFuncNoParams(args); });
     subscribeRequest("tb.simple.SimpleInterface.rpc.funcBool", [this](const auto& args){  return onInvokeFuncBool(args); });
     subscribeRequest("tb.simple.SimpleInterface.rpc.funcInt", [this](const auto& args){  return onInvokeFuncInt(args); });
     subscribeRequest("tb.simple.SimpleInterface.rpc.funcInt32", [this](const auto& args){  return onInvokeFuncInt32(args); });
@@ -298,6 +299,12 @@ std::string SimpleInterfaceService::onInvokeFuncNoReturnValue(const std::string&
     const bool& paramBool = json_args.at(0).get<bool>();
     m_impl->funcNoReturnValue(paramBool);
     return "0";
+}
+std::string SimpleInterfaceService::onInvokeFuncNoParams(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    auto result = m_impl->funcNoParams();
+    return nlohmann::json(result).dump();
 }
 std::string SimpleInterfaceService::onInvokeFuncBool(const std::string& args) const
 {

--- a/goldenmaster/modules/tb_simple/generated/nats/simpleinterfaceservice.h
+++ b/goldenmaster/modules/tb_simple/generated/nats/simpleinterfaceservice.h
@@ -67,6 +67,7 @@ private:
     /// @param fields contains the param of the type std::string
     void onSetPropString(const std::string& args) const;
     std::string onInvokeFuncNoReturnValue(const std::string& args) const;
+    std::string onInvokeFuncNoParams(const std::string& args) const;
     std::string onInvokeFuncBool(const std::string& args) const;
     std::string onInvokeFuncInt(const std::string& args) const;
     std::string onInvokeFuncInt32(const std::string& args) const;

--- a/goldenmaster/modules/tb_simple/generated/nats/tests/test_simpleinterface.cpp
+++ b/goldenmaster/modules/tb_simple/generated/nats/tests/test_simpleinterface.cpp
@@ -344,6 +344,40 @@ TEST_CASE("Nats  tb.simple SimpleInterface tests")
 
         resultFuture.wait();
     }
+    SECTION("Test method funcNoParams")
+    {
+        [[maybe_unused]] auto result = clientSimpleInterface->funcNoParams();
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcNoParams async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSimpleInterface->funcNoParamsAsync();
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == false); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcNoParams async with callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSimpleInterface->funcNoParamsAsync(
+            [&finished, &m_wait](bool value)
+            {
+                REQUIRE(value == false);
+                finished = true;
+                m_wait.notify_all();
+                /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */
+            });
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+
+        resultFuture.wait();
+    }
     SECTION("Test method funcBool")
     {
         [[maybe_unused]] auto result = clientSimpleInterface->funcBool(false);

--- a/goldenmaster/modules/tb_simple/generated/olink/simpleinterfaceclient.cpp
+++ b/goldenmaster/modules/tb_simple/generated/olink/simpleinterfaceclient.cpp
@@ -334,6 +334,31 @@ std::future<void> SimpleInterfaceClient::funcNoReturnValueAsync(bool paramBool, 
     return resultPromise->get_future();
 }
 
+bool SimpleInterfaceClient::funcNoParams()
+{
+    return funcNoParamsAsync().get();
+}
+
+std::future<bool> SimpleInterfaceClient::funcNoParamsAsync( std::function<void(bool)> callback)
+{
+    if(!m_node) {
+        AG_LOG_WARNING("Attempt to invoke method but" + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return std::future<bool>{};
+    }
+    std::shared_ptr<std::promise<bool>> resultPromise = std::make_shared<std::promise<bool>>();
+    static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcNoParams");
+    m_node->invokeRemote(operationId,
+        nlohmann::json::array({}), [resultPromise, callback](ApiGear::ObjectLink::InvokeReplyArg arg) {
+            const bool& value = arg.value.get<bool>();
+            resultPromise->set_value(value);
+            if (callback)
+            {
+                callback(value);
+            }
+        });
+    return resultPromise->get_future();
+}
+
 bool SimpleInterfaceClient::funcBool(bool paramBool)
 {
     return funcBoolAsync(paramBool).get();

--- a/goldenmaster/modules/tb_simple/generated/olink/simpleinterfaceclient.h
+++ b/goldenmaster/modules/tb_simple/generated/olink/simpleinterfaceclient.h
@@ -136,6 +136,15 @@ public:
     */
     std::future<void> funcNoReturnValueAsync(bool paramBool, std::function<void(void)> callback = nullptr) override;
     /**
+    * Remote call of ISimpleInterface::funcNoParams on the SimpleInterface service.
+    * Uses funcNoParamsAsync
+    */
+    bool funcNoParams() override;
+    /**
+    * Remote call of ISimpleInterface::funcNoParams on the SimpleInterface service.
+    */
+    std::future<bool> funcNoParamsAsync( std::function<void(bool)> callback = nullptr) override;
+    /**
     * Remote call of ISimpleInterface::funcBool on the SimpleInterface service.
     * Uses funcBoolAsync
     */

--- a/goldenmaster/modules/tb_simple/generated/olink/simpleinterfaceservice.cpp
+++ b/goldenmaster/modules/tb_simple/generated/olink/simpleinterfaceservice.cpp
@@ -45,6 +45,10 @@ nlohmann::json SimpleInterfaceService::olinkInvoke(const std::string& methodId, 
         m_SimpleInterface->funcNoReturnValue(paramBool);
         return nlohmann::json{};
     }
+    if(memberMethod == "funcNoParams") {
+        bool result = m_SimpleInterface->funcNoParams();
+        return result;
+    }
     if(memberMethod == "funcBool") {
         const bool& paramBool = fcnArgs.at(0);
         bool result = m_SimpleInterface->funcBool(paramBool);

--- a/goldenmaster/modules/tb_simple/generated/olink/tests/test_simpleinterface.cpp
+++ b/goldenmaster/modules/tb_simple/generated/olink/tests/test_simpleinterface.cpp
@@ -344,6 +344,36 @@ TEST_CASE("olink  tb.simple SimpleInterface tests")
         resultFuture.wait();
         
     }
+    SECTION("Test method funcNoParams")
+    {
+        [[maybe_unused]] auto result = clientSimpleInterface->funcNoParams();
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcNoParams async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSimpleInterface->funcNoParamsAsync();
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == false); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    SECTION("Test method funcNoParams async with a callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientSimpleInterface->funcNoParamsAsync([&finished, &m_wait](bool value){ (void) value;finished = true; m_wait.notify_all(); /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ });
+         
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == false); 
+        
+    }
     SECTION("Test method funcBool")
     {
         [[maybe_unused]] auto result = clientSimpleInterface->funcBool(false);

--- a/goldenmaster/modules/tb_simple/implementation/simpleinterface.cpp
+++ b/goldenmaster/modules/tb_simple/implementation/simpleinterface.cpp
@@ -140,6 +140,24 @@ std::future<void> SimpleInterface::funcNoReturnValueAsync(bool paramBool, std::f
     );
 }
 
+bool SimpleInterface::funcNoParams()
+{
+    // do business logic here
+    return false;
+}
+
+std::future<bool> SimpleInterface::funcNoParamsAsync( std::function<void(bool)> callback)
+{
+    return std::async(std::launch::async, [this, callback]()
+        {auto result = funcNoParams();
+            if (callback)
+            {
+                callback(result);
+            }return result;
+        }
+    );
+}
+
 bool SimpleInterface::funcBool(bool paramBool)
 {
     (void) paramBool; // suppress the 'Unreferenced Formal Parameter' warning.

--- a/goldenmaster/modules/tb_simple/implementation/simpleinterface.h
+++ b/goldenmaster/modules/tb_simple/implementation/simpleinterface.h
@@ -44,6 +44,9 @@ public:
     void funcNoReturnValue(bool paramBool) override;
     std::future<void> funcNoReturnValueAsync(bool paramBool, std::function<void(void)> callback = nullptr) override;
         
+    bool funcNoParams() override;
+    std::future<bool> funcNoParamsAsync( std::function<void(bool)> callback = nullptr) override;
+        
     bool funcBool(bool paramBool) override;
     std::future<bool> funcBoolAsync(bool paramBool, std::function<void(bool)> callback = nullptr) override;
         

--- a/goldenmaster/modules/tb_simple/implementation/simpleinterface.test.cpp
+++ b/goldenmaster/modules/tb_simple/implementation/simpleinterface.test.cpp
@@ -24,6 +24,23 @@ TEST_CASE("Testing SimpleInterface", "[SimpleInterface]"){
         auto future = testSimpleInterface->funcNoReturnValueAsync(false,[]( ){ /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ }
             );
     }
+    SECTION("Test operation funcNoParams") {
+        // Do implement test here
+        testSimpleInterface->funcNoParams();
+    }
+
+    SECTION("Test operation async funcNoParams") {
+        // Do implement test here
+
+        auto future = testSimpleInterface->funcNoParamsAsync();
+    }
+
+    SECTION("Test operation async funcNoParams with a callback") {
+        // Do implement test here
+
+        auto future = testSimpleInterface->funcNoParamsAsync([](bool value){ (void)value; /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ }
+            );
+    }
     SECTION("Test operation funcBool") {
         // Do implement test here
         testSimpleInterface->funcBool(false);

--- a/goldenmaster/modules/tb_struct_array/CMakeLists.txt
+++ b/goldenmaster/modules/tb_struct_array/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.24)
+project(tb_struct_array)
+
+# needed to access CMAKE_INSTALL_LIBDIR
+include(GNUInstallDirs)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_BINARY_DIR})
+set(InstallDir ${CMAKE_INSTALL_LIBDIR}/cmake/tb_struct_array)
+
+# enable testing
+if(BUILD_TESTING)
+include(CTest)
+enable_testing()
+endif(BUILD_TESTING)
+
+# define variable for library include paths
+get_filename_component(MODULES_DIR "${CMAKE_CURRENT_SOURCE_DIR}/.." ABSOLUTE)
+
+add_subdirectory(generated/api)
+add_subdirectory(generated/core)
+add_subdirectory(implementation)
+add_subdirectory(generated/monitor)
+add_subdirectory(generated/olink)
+add_subdirectory(generated/mqtt)
+add_subdirectory(generated/nats)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(Tb_struct_arrayConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/tb_struct_arrayConfig.cmake
+  INSTALL_DESTINATION ${InstallDir})
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/tb_struct_arrayConfigVersion.cmake
+  VERSION 1.0.0
+  COMPATIBILITY SameMinorVersion )
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/tb_struct_arrayConfig.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/tb_struct_arrayConfigVersion.cmake
+        DESTINATION ${InstallDir} )

--- a/goldenmaster/modules/tb_struct_array/Tb_struct_arrayConfig.cmake.in
+++ b/goldenmaster/modules/tb_struct_array/Tb_struct_arrayConfig.cmake.in
@@ -1,0 +1,30 @@
+set(TB_STRUCT_ARRAY_VERSION 1.0.0)
+@PACKAGE_INIT@
+
+# make sure we have all needed dependencies
+include(CMakeFindDependencyMacro)
+find_dependency(Threads REQUIRED)
+find_dependency(nlohmann_json REQUIRED)
+find_dependency(apigear COMPONENTS utilities REQUIRED)
+find_dependency(apigear COMPONENTS poco-tracer REQUIRED)
+find_dependency(apigear COMPONENTS poco-olink REQUIRED)
+find_dependency(apigear COMPONENTS paho-mqtt REQUIRED)
+find_dependency(apigear COMPONENTS nats REQUIRED)
+
+INCLUDE("${CMAKE_CURRENT_LIST_DIR}/Tb_struct_arrayApiTargets.cmake")
+INCLUDE("${CMAKE_CURRENT_LIST_DIR}/Tb_struct_arrayCoreTargets.cmake")
+INCLUDE("${CMAKE_CURRENT_LIST_DIR}/Tb_struct_arrayMonitorTargets.cmake")
+INCLUDE("${CMAKE_CURRENT_LIST_DIR}/Tb_struct_arrayOLinkTargets.cmake")
+INCLUDE("${CMAKE_CURRENT_LIST_DIR}/Tb_struct_arrayMqttTargets.cmake")
+INCLUDE("${CMAKE_CURRENT_LIST_DIR}/Tb_struct_arrayNatsTargets.cmake")
+INCLUDE("${CMAKE_CURRENT_LIST_DIR}/Tb_struct_arrayImplementationTargets.cmake")
+
+check_required_components(
+TbStructArray-api
+TbStructArray-core
+TbStructArray-monitor
+TbStructArray-olink
+TbStructArray-mqtt
+TbStructArray-nats
+TbStructArray-implementation
+)

--- a/goldenmaster/modules/tb_struct_array/conan/conanfile.py
+++ b/goldenmaster/modules/tb_struct_array/conan/conanfile.py
@@ -1,0 +1,116 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.build import check_max_cppstd, check_min_cppstd, cross_building
+from conan.tools.files import load, copy
+from conan.tools.build import can_run
+from pathlib import os
+
+class tb_struct_arrayConan(ConanFile):
+    name = "tb_struct_array"
+    version = "1.0.0"
+    package_type = "library"
+    license = "GPL v3"
+    author = "ApiGear UG"
+    #url = "<Package recipe repository url here, for issues about the package>"
+    settings = "os", "compiler", "build_type", "arch"
+    options = {
+        "build_testing": [True, False],
+        "shared": [True, False],
+        "fPIC": [True, False]
+    }
+    default_options = {
+        "build_testing": True,
+        "shared": True,
+        "fPIC": False,
+        "apigear/*:enable_monitor": True,
+        "apigear/*:enable_olink": True,
+        "apigear/*:enable_mqtt": True,
+        "apigear/*:enable_nats": True,
+    }
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            self.options.rm_safe("fPIC")
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
+
+    def requirements(self):
+        self.requires("nlohmann_json/3.11.3", transitive_headers=True)
+        
+        self.requires("apigear/3.7.0", transitive_headers=True)
+
+    def build_requirements(self):
+        self.test_requires("catch2/2.13.7")
+
+    def validate(self):
+        check_min_cppstd(self, "17")
+
+    def layout(self):
+        cmake_layout(self)
+        self.folders.root = ".."
+        self.folders.source = "tb_struct_array"
+
+    def export_sources(self):
+        # move one level up from the recipe folder
+        source_folder = os.path.join(self.recipe_folder, "..")
+        # wrap sources into modules name
+        dst_folder = os.path.join(self.export_sources_folder, "tb_struct_array")
+        copy(self, "*", source_folder, dst_folder)
+
+    def source(self):
+        cmake_file = load(self, "CMakeLists.txt")
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        if not cross_building(self):
+            tc.cache_variables['BUILD_TESTING'] = self.options.build_testing
+        tc.generate()
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def build(self):
+        cmake = CMake(self)
+
+        # workaround wrong layout setup if not using "conan create"
+        if self.folders.base_source.endswith("tb_struct_array"):
+            print("Building outside of the conan cache")
+            # we are building outside of the conan cache
+            cmake.configure(build_script_folder="..")
+        else:
+            cmake.configure()
+
+        cmake.build()
+
+        # we skip tests on windows since the conanrun env does not include locally built libraries
+        if can_run(self) and self.settings.os != "Windows":
+            cmake.test()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        # generates a Findtb_struct_array.cmake file in addition to the tb_struct_array-config.cmake
+        self.cpp_info.set_property("cmake_find_mode", "both")
+        self.cpp_info.components["tb_struct_array-api"].includedirs.append(os.path.join(self.package_folder, "include"))
+        self.cpp_info.components["tb_struct_array-api"].libs = ["tb_struct_array-api"]
+        self.cpp_info.components["tb_struct_array-core"].includedirs.append(os.path.join(self.package_folder, "include"))
+        self.cpp_info.components["tb_struct_array-core"].libs = ["tb_struct_array-core"]
+        self.cpp_info.components["tb_struct_array-core"].requires = ["apigear::utilities", "tb_struct_array-api", "nlohmann_json::nlohmann_json"]
+        self.cpp_info.components["tb_struct_array-implementation"].includedirs.append(os.path.join(self.package_folder, "include"))
+        self.cpp_info.components["tb_struct_array-implementation"].libs = ["tb_struct_array-implementation"]
+        self.cpp_info.components["tb_struct_array-implementation"].requires = ["apigear::utilities", "tb_struct_array-core", "nlohmann_json::nlohmann_json"]
+        self.cpp_info.components["tb_struct_array-monitor"].includedirs.append(os.path.join(self.package_folder, "include"))
+        self.cpp_info.components["tb_struct_array-monitor"].libs = ["tb_struct_array-monitor"]
+        self.cpp_info.components["tb_struct_array-monitor"].requires = ["tb_struct_array-core", "nlohmann_json::nlohmann_json", "apigear::poco-tracer"]
+        self.cpp_info.components["tb_struct_array-olink"].includedirs.append(os.path.join(self.package_folder, "include"))
+        self.cpp_info.components["tb_struct_array-olink"].libs = ["tb_struct_array-olink"]
+        self.cpp_info.components["tb_struct_array-olink"].requires = ["tb_struct_array-core", "nlohmann_json::nlohmann_json", "apigear::poco-olink"]
+        self.cpp_info.components["tb_struct_array-mqtt"].includedirs.append(os.path.join(self.package_folder, "include"))
+        self.cpp_info.components["tb_struct_array-mqtt"].libs = ["tb_struct_array-mqtt"]
+        self.cpp_info.components["tb_struct_array-mqtt"].requires = ["tb_struct_array-core", "nlohmann_json::nlohmann_json", "apigear::paho-mqtt"]
+        self.cpp_info.components["tb_struct_array-nats"].includedirs.append(os.path.join(self.package_folder, "include"))
+        self.cpp_info.components["tb_struct_array-nats"].libs = ["tb_struct_array-nats"]
+        self.cpp_info.components["tb_struct_array-nats"].requires = ["tb_struct_array-core", "nlohmann_json::nlohmann_json", "apigear::nats"]

--- a/goldenmaster/modules/tb_struct_array/conan/test_package/CMakeLists.txt
+++ b/goldenmaster/modules/tb_struct_array/conan/test_package/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.24)
+project(Testtb_struct_array)
+include(CTest)
+find_package(tb_struct_array CONFIG REQUIRED)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# add test for tb_struct_array
+set (SOURCES_TEST
+    main.cpp
+)
+add_executable(test_tb_struct_array
+    ${SOURCES_TEST}
+)
+target_link_libraries(test_tb_struct_array tb_struct_array::tb_struct_array-implementation)
+add_test(NAME test_tb_struct_array COMMAND $<TARGET_FILE:test_tb_struct_array>)
+# ensure maximum compiler support
+if(NOT MSVC)
+  target_compile_options(test_tb_struct_array PRIVATE -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wnon-virtual-dtor -Woverloaded-virtual -Wcast-align -Werror)
+else()
+  target_compile_options(test_tb_struct_array PRIVATE /W4 /WX /wd4251)
+endif()

--- a/goldenmaster/modules/tb_struct_array/conan/test_package/conanfile.py
+++ b/goldenmaster/modules/tb_struct_array/conan/test_package/conanfile.py
@@ -1,0 +1,28 @@
+import os
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
+
+
+class tb_struct_arrayTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        # Current dir is "test_package/build/<build_id>" and CMakeLists.txt is
+        # in "test_package"
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindirs[0], "test_tb_struct_array")
+            self.run(cmd, env="conanrun")

--- a/goldenmaster/modules/tb_struct_array/conan/test_package/main.cpp
+++ b/goldenmaster/modules/tb_struct_array/conan/test_package/main.cpp
@@ -1,0 +1,10 @@
+
+#include "tb_struct_array/implementation/structarrayfieldinterface.h"
+
+using namespace Test::TbStructArray;
+
+int main(){
+    std::unique_ptr<IStructArrayFieldInterface> testStructArrayFieldInterface = std::make_unique<StructArrayFieldInterface>();
+
+    return 0;
+}

--- a/goldenmaster/modules/tb_struct_array/generated/api/CMakeLists.txt
+++ b/goldenmaster/modules/tb_struct_array/generated/api/CMakeLists.txt
@@ -1,0 +1,36 @@
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set (SOURCES
+    datastructs.api.cpp
+)
+add_library(tb_struct_array-api SHARED ${SOURCES})
+add_library(tb_struct_array::tb_struct_array-api ALIAS tb_struct_array-api)
+target_include_directories(tb_struct_array-api
+    PUBLIC
+    $<BUILD_INTERFACE:${MODULES_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+# ensure maximum compiler support
+if(NOT MSVC)
+  target_compile_options(tb_struct_array-api PRIVATE -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wnon-virtual-dtor -Woverloaded-virtual -Wcast-align -Werror -fvisibility=hidden)
+else()
+  target_compile_options(tb_struct_array-api PRIVATE /W4 /WX /wd4251)
+endif()
+
+# install binary files
+install(TARGETS tb_struct_array-api
+        EXPORT Tb_struct_arrayApiTargets)
+# install includes
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} DESTINATION include/tb_struct_array/generated FILES_MATCHING PATTERN "*.h")
+
+export(EXPORT Tb_struct_arrayApiTargets
+  NAMESPACE tb_struct_array::
+)
+
+install(EXPORT Tb_struct_arrayApiTargets
+  FILE Tb_struct_arrayApiTargets.cmake
+  DESTINATION ${InstallDir}
+  NAMESPACE tb_struct_array::
+)

--- a/goldenmaster/modules/tb_struct_array/generated/api/common.h
+++ b/goldenmaster/modules/tb_struct_array/generated/api/common.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#if defined _WIN32 || defined __CYGWIN__
+#ifdef __GNUC__
+  #define TEST_TB_STRUCT_ARRAY_EXPORT __attribute__ ((dllexport))
+#else
+  #define TEST_TB_STRUCT_ARRAY_EXPORT __declspec(dllexport)
+#endif
+#else
+  #if __GNUC__ >= 4
+    #define TEST_TB_STRUCT_ARRAY_EXPORT __attribute__ ((visibility ("default")))
+  #else
+    #define TEST_TB_STRUCT_ARRAY_EXPORT
+  #endif
+#endif
+
+
+#ifndef THIRD_PARTY_INCLUDES_START
+  #if defined __clang__ || defined __GNUC__
+    #define THIRD_PARTY_INCLUDES_START \
+      _Pragma("GCC diagnostic push")                           /* Pushes the current diagnostic state onto a stack */ \
+      _Pragma("GCC diagnostic ignored \"-Wall\"")              /* Ignores warnings related to all enabled diagnostics */ \
+      _Pragma("GCC diagnostic ignored \"-Wextra\"")            /* Ignores extra warnings not covered by -Wall */ \
+      _Pragma("GCC diagnostic ignored \"-Wpedantic\"")         /* Ignores warnings that are pedantic and not required by the C++ standard */ \
+      _Pragma("GCC diagnostic ignored \"-Wconversion\"")       /* Ignores warnings related to implicit type conversions */ \
+      _Pragma("GCC diagnostic ignored \"-Wsign-conversion\"")  /* Ignores warnings related to sign conversions */ \
+      _Pragma("GCC diagnostic ignored \"-Wshadow\"")           /* Ignores warnings related to variable shadowing */ \
+      _Pragma("GCC diagnostic ignored \"-Wuninitialized\"")    /* Ignores warnings related to uninitialized variables */
+  #elif defined _MSC_VER
+    #define THIRD_PARTY_INCLUDES_START \
+      __pragma(warning(push, 0))           /* Pushes the current warning state onto a stack, set warning level to 0 */
+  #endif
+#endif
+
+#ifndef THIRD_PARTY_INCLUDES_END
+  #if defined __clang__ || defined __GNUC__
+    #define THIRD_PARTY_INCLUDES_END \
+      _Pragma("GCC diagnostic pop")  /* Pops the last diagnostic state from the stack */
+  #elif defined _MSC_VER
+    #define THIRD_PARTY_INCLUDES_END \
+      __pragma(warning(pop))  /* Pops the last warning state from the stack */
+  #endif
+#endif

--- a/goldenmaster/modules/tb_struct_array/generated/api/datastructs.api.cpp
+++ b/goldenmaster/modules/tb_struct_array/generated/api/datastructs.api.cpp
@@ -1,0 +1,144 @@
+#include "tb_struct_array/generated/api/datastructs.api.h"
+
+namespace Test {
+namespace TbStructArray {
+
+// ********************************************************************
+// Enumeration TestEnum
+// ********************************************************************
+TestEnumEnum toTestEnumEnum(std::uint8_t v, bool *ok)
+{
+    if (ok != nullptr) {
+        *ok = true;
+    }
+    switch (v) {
+        case 1: return TestEnumEnum::value1;
+        case 2: return TestEnumEnum::value2;
+        default:
+            if (ok != nullptr) {
+                *ok = false;
+            }
+            return TestEnumEnum::value1;
+    }
+}
+// ********************************************************************
+// Struct Point
+// ********************************************************************
+Point::Point() = default;
+Point::Point(float x, float y):
+    x(x),
+    y(y)
+{
+}
+
+bool operator==(const Point& lhs, const Point& rhs) noexcept
+{
+    return (
+        // consider using fuzzy compare, check library ApiGear::Utilities::fuzzyCompare
+        lhs.x == rhs.x &&
+        // consider using fuzzy compare, check library ApiGear::Utilities::fuzzyCompare
+        lhs.y == rhs.y
+
+    );
+}
+
+bool operator!=(const Point& lhs, const Point& rhs) noexcept
+{
+    return !(lhs == rhs);
+}
+// ********************************************************************
+// Struct StructWithArrayOfStructs
+// ********************************************************************
+StructWithArrayOfStructs::StructWithArrayOfStructs() = default;
+StructWithArrayOfStructs::StructWithArrayOfStructs(const std::list<Point>& points):
+    points(points)
+{
+}
+
+bool operator==(const StructWithArrayOfStructs& lhs, const StructWithArrayOfStructs& rhs) noexcept
+{
+    return (
+        lhs.points == rhs.points
+
+    );
+}
+
+bool operator!=(const StructWithArrayOfStructs& lhs, const StructWithArrayOfStructs& rhs) noexcept
+{
+    return !(lhs == rhs);
+}
+// ********************************************************************
+// Struct StructWithArrayOfEnums
+// ********************************************************************
+StructWithArrayOfEnums::StructWithArrayOfEnums() = default;
+StructWithArrayOfEnums::StructWithArrayOfEnums(const std::list<TestEnumEnum>& tags):
+    tags(tags)
+{
+}
+
+bool operator==(const StructWithArrayOfEnums& lhs, const StructWithArrayOfEnums& rhs) noexcept
+{
+    return (
+        lhs.tags == rhs.tags
+
+    );
+}
+
+bool operator!=(const StructWithArrayOfEnums& lhs, const StructWithArrayOfEnums& rhs) noexcept
+{
+    return !(lhs == rhs);
+}
+// ********************************************************************
+// Struct StructWithArrayOfInts
+// ********************************************************************
+StructWithArrayOfInts::StructWithArrayOfInts() = default;
+StructWithArrayOfInts::StructWithArrayOfInts(const std::list<int>& values):
+    values(values)
+{
+}
+
+bool operator==(const StructWithArrayOfInts& lhs, const StructWithArrayOfInts& rhs) noexcept
+{
+    return (
+        lhs.values == rhs.values
+
+    );
+}
+
+bool operator!=(const StructWithArrayOfInts& lhs, const StructWithArrayOfInts& rhs) noexcept
+{
+    return !(lhs == rhs);
+}
+// ********************************************************************
+// Struct MixedStruct
+// ********************************************************************
+MixedStruct::MixedStruct() = default;
+MixedStruct::MixedStruct(int id, const std::string& name, const Point& origin, const std::list<Point>& points, const std::list<TestEnumEnum>& flags, const std::list<int>& scores):
+    id(id),
+    name(name),
+    origin(origin),
+    points(points),
+    flags(flags),
+    scores(scores)
+{
+}
+
+bool operator==(const MixedStruct& lhs, const MixedStruct& rhs) noexcept
+{
+    return (
+        lhs.id == rhs.id &&
+        lhs.name == rhs.name &&
+        lhs.origin == rhs.origin &&
+        lhs.points == rhs.points &&
+        lhs.flags == rhs.flags &&
+        lhs.scores == rhs.scores
+
+    );
+}
+
+bool operator!=(const MixedStruct& lhs, const MixedStruct& rhs) noexcept
+{
+    return !(lhs == rhs);
+}
+} // namespace TbStructArray
+} // namespace Test

--- a/goldenmaster/modules/tb_struct_array/generated/api/datastructs.api.h
+++ b/goldenmaster/modules/tb_struct_array/generated/api/datastructs.api.h
@@ -1,0 +1,102 @@
+#pragma once
+
+#include <cinttypes>
+#include <string>
+#include <list>
+
+#include "tb_struct_array/generated/api/common.h"
+
+namespace Test {
+namespace TbStructArray {
+struct Point;
+struct StructWithArrayOfStructs;
+struct StructWithArrayOfEnums;
+struct StructWithArrayOfInts;
+struct MixedStruct;
+
+/**
+ * Enumeration TestEnum
+ */
+enum class TestEnumEnum {
+    value1 = 1,
+    value2 = 2
+};
+TEST_TB_STRUCT_ARRAY_EXPORT TestEnumEnum toTestEnumEnum(std::uint8_t v, bool *ok);
+
+/**
+ * Struct Point
+ */
+struct TEST_TB_STRUCT_ARRAY_EXPORT Point
+{
+    Point();
+    Point(float x, float y);
+
+    float x{};
+    float y{};
+
+};
+bool TEST_TB_STRUCT_ARRAY_EXPORT operator==(const Point &, const Point &) noexcept;
+bool TEST_TB_STRUCT_ARRAY_EXPORT operator!=(const Point &, const Point &) noexcept;
+
+/**
+ * Struct StructWithArrayOfStructs
+ */
+struct TEST_TB_STRUCT_ARRAY_EXPORT StructWithArrayOfStructs
+{
+    StructWithArrayOfStructs();
+    StructWithArrayOfStructs(const std::list<Point>& points);
+
+    std::list<Point> points{};
+
+};
+bool TEST_TB_STRUCT_ARRAY_EXPORT operator==(const StructWithArrayOfStructs &, const StructWithArrayOfStructs &) noexcept;
+bool TEST_TB_STRUCT_ARRAY_EXPORT operator!=(const StructWithArrayOfStructs &, const StructWithArrayOfStructs &) noexcept;
+
+/**
+ * Struct StructWithArrayOfEnums
+ */
+struct TEST_TB_STRUCT_ARRAY_EXPORT StructWithArrayOfEnums
+{
+    StructWithArrayOfEnums();
+    StructWithArrayOfEnums(const std::list<TestEnumEnum>& tags);
+
+    std::list<TestEnumEnum> tags{};
+
+};
+bool TEST_TB_STRUCT_ARRAY_EXPORT operator==(const StructWithArrayOfEnums &, const StructWithArrayOfEnums &) noexcept;
+bool TEST_TB_STRUCT_ARRAY_EXPORT operator!=(const StructWithArrayOfEnums &, const StructWithArrayOfEnums &) noexcept;
+
+/**
+ * Struct StructWithArrayOfInts
+ */
+struct TEST_TB_STRUCT_ARRAY_EXPORT StructWithArrayOfInts
+{
+    StructWithArrayOfInts();
+    StructWithArrayOfInts(const std::list<int>& values);
+
+    std::list<int> values{};
+
+};
+bool TEST_TB_STRUCT_ARRAY_EXPORT operator==(const StructWithArrayOfInts &, const StructWithArrayOfInts &) noexcept;
+bool TEST_TB_STRUCT_ARRAY_EXPORT operator!=(const StructWithArrayOfInts &, const StructWithArrayOfInts &) noexcept;
+
+/**
+ * Struct MixedStruct
+ */
+struct TEST_TB_STRUCT_ARRAY_EXPORT MixedStruct
+{
+    MixedStruct();
+    MixedStruct(int id, const std::string& name, const Point& origin, const std::list<Point>& points, const std::list<TestEnumEnum>& flags, const std::list<int>& scores);
+
+    int id{};
+    std::string name{};
+    Point origin{};
+    std::list<Point> points{};
+    std::list<TestEnumEnum> flags{};
+    std::list<int> scores{};
+
+};
+bool TEST_TB_STRUCT_ARRAY_EXPORT operator==(const MixedStruct &, const MixedStruct &) noexcept;
+bool TEST_TB_STRUCT_ARRAY_EXPORT operator!=(const MixedStruct &, const MixedStruct &) noexcept;
+} // namespace TbStructArray
+} // namespace Test

--- a/goldenmaster/modules/tb_struct_array/generated/api/structarrayfieldinterface.api.h
+++ b/goldenmaster/modules/tb_struct_array/generated/api/structarrayfieldinterface.api.h
@@ -1,0 +1,330 @@
+#pragma once
+
+#include <cstdint>
+#include <future>
+#include "tb_struct_array/generated/api/common.h"
+#include "tb_struct_array/generated/api/datastructs.api.h"
+
+namespace Test {
+namespace TbStructArray {
+
+class IStructArrayFieldInterfaceSubscriber;
+class IStructArrayFieldInterfacePublisher;
+
+/**
+*
+* IStructArrayFieldInterface provides an interface for
+ *  - methods defined for your StructArrayFieldInterface 
+ *  - property setters and getters for defined properties
+ * The IStructArrayFieldInterface also provides an interface to access a publisher IStructArrayFieldInterfacePublisher, a class used by IStructArrayFieldInterfaceSubscriber clients.
+ * The implementation should notify the publisher IStructArrayFieldInterfacePublisher about emitted signals or state changed. 
+ * The publisher responsibility is to keep its clients informed about requested changes.
+ * See also IStructArrayFieldInterfaceSubscriber, IStructArrayFieldInterfacePublisher
+ * and the example implementation StructArrayFieldInterface  or the
+ */
+class TEST_TB_STRUCT_ARRAY_EXPORT IStructArrayFieldInterface
+{
+public:
+    virtual ~IStructArrayFieldInterface() = default;
+
+
+    virtual MixedStruct funcMixed(const MixedStruct& paramMixed) = 0;
+    /**
+    * Asynchronous version of funcMixed(const MixedStruct& paramMixed)
+    * @return Promise of type MixedStruct which is set once the function has completed
+    */
+    virtual std::future<MixedStruct> funcMixedAsync(const MixedStruct& paramMixed, std::function<void(MixedStruct)> callback = nullptr) = 0;
+
+
+    virtual StructWithArrayOfStructs funcStructArray(const StructWithArrayOfStructs& paramPoints) = 0;
+    /**
+    * Asynchronous version of funcStructArray(const StructWithArrayOfStructs& paramPoints)
+    * @return Promise of type StructWithArrayOfStructs which is set once the function has completed
+    */
+    virtual std::future<StructWithArrayOfStructs> funcStructArrayAsync(const StructWithArrayOfStructs& paramPoints, std::function<void(StructWithArrayOfStructs)> callback = nullptr) = 0;
+
+    /**
+    * Sets the value of the propStructArray property.
+    */
+    virtual void setPropStructArray(const StructWithArrayOfStructs& propStructArray) = 0;
+    /**
+    * Gets the value of the propStructArray property.
+    */
+    virtual const StructWithArrayOfStructs& getPropStructArray() const = 0;
+
+    /**
+    * Sets the value of the propEnumArray property.
+    */
+    virtual void setPropEnumArray(const StructWithArrayOfEnums& propEnumArray) = 0;
+    /**
+    * Gets the value of the propEnumArray property.
+    */
+    virtual const StructWithArrayOfEnums& getPropEnumArray() const = 0;
+
+    /**
+    * Sets the value of the propIntArray property.
+    */
+    virtual void setPropIntArray(const StructWithArrayOfInts& propIntArray) = 0;
+    /**
+    * Gets the value of the propIntArray property.
+    */
+    virtual const StructWithArrayOfInts& getPropIntArray() const = 0;
+
+    /**
+    * Sets the value of the propMixed property.
+    */
+    virtual void setPropMixed(const MixedStruct& propMixed) = 0;
+    /**
+    * Gets the value of the propMixed property.
+    */
+    virtual const MixedStruct& getPropMixed() const = 0;
+
+    /**
+    * Access to a publisher, use it to subscribe for StructArrayFieldInterface changes and signal emission.
+    * This function name doesn't follow the convention, because it is added to user defined interface,
+    * to avoid potentially name clashes, it has the trailing underscore in the name.
+    * @return The publisher for StructArrayFieldInterface.
+    */
+    virtual IStructArrayFieldInterfacePublisher& _getPublisher() const = 0;
+};
+
+
+/**
+ * The IStructArrayFieldInterfaceSubscriber contains functions to allow informing about signals or property changes of the IStructArrayFieldInterface implementation.
+ * The implementation for IStructArrayFieldInterface should provide mechanism for subscription of the IStructArrayFieldInterfaceSubscriber clients.
+ * See IStructArrayFieldInterfacePublisher, which provides facilitation for this purpose.
+ * The implementation for IStructArrayFieldInterface should call the IStructArrayFieldInterfaceSubscriber interface functions on either signal emit or property change.
+ * You can use IStructArrayFieldInterfaceSubscriber class to implement clients of the IStructArrayFieldInterface or the network adapter - see Olink Server and Client example.
+ */
+class TEST_TB_STRUCT_ARRAY_EXPORT IStructArrayFieldInterfaceSubscriber
+{
+public:
+    virtual ~IStructArrayFieldInterfaceSubscriber() = default;
+    /**
+    * Called by the IStructArrayFieldInterfacePublisher when the StructArrayFieldInterface emits sigMixed, if subscribed for the sigMixed.
+    * @param paramMixed 
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual void onSigMixed(const MixedStruct& paramMixed) = 0;
+    /**
+    * Called by the IStructArrayFieldInterfacePublisher when the StructArrayFieldInterface emits sigStructArray, if subscribed for the sigStructArray.
+    * @param paramPoints 
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual void onSigStructArray(const StructWithArrayOfStructs& paramPoints) = 0;
+    /**
+    * Called by the IStructArrayFieldInterfacePublisher when propStructArray value has changed if subscribed for the propStructArray change.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual void onPropStructArrayChanged(const StructWithArrayOfStructs& propStructArray) = 0;
+    /**
+    * Called by the IStructArrayFieldInterfacePublisher when propEnumArray value has changed if subscribed for the propEnumArray change.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual void onPropEnumArrayChanged(const StructWithArrayOfEnums& propEnumArray) = 0;
+    /**
+    * Called by the IStructArrayFieldInterfacePublisher when propIntArray value has changed if subscribed for the propIntArray change.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual void onPropIntArrayChanged(const StructWithArrayOfInts& propIntArray) = 0;
+    /**
+    * Called by the IStructArrayFieldInterfacePublisher when propMixed value has changed if subscribed for the propMixed change.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual void onPropMixedChanged(const MixedStruct& propMixed) = 0;
+};
+
+/** Callback for changes of propStructArray */
+using StructArrayFieldInterfacePropStructArrayPropertyCb = std::function<void(const StructWithArrayOfStructs& propStructArray)>;
+/** Callback for changes of propEnumArray */
+using StructArrayFieldInterfacePropEnumArrayPropertyCb = std::function<void(const StructWithArrayOfEnums& propEnumArray)>;
+/** Callback for changes of propIntArray */
+using StructArrayFieldInterfacePropIntArrayPropertyCb = std::function<void(const StructWithArrayOfInts& propIntArray)>;
+/** Callback for changes of propMixed */
+using StructArrayFieldInterfacePropMixedPropertyCb = std::function<void(const MixedStruct& propMixed)>;
+/** Callback for sigMixed signal triggers */
+using StructArrayFieldInterfaceSigMixedSignalCb = std::function<void(const MixedStruct& paramMixed)> ;
+/** Callback for sigStructArray signal triggers */
+using StructArrayFieldInterfaceSigStructArraySignalCb = std::function<void(const StructWithArrayOfStructs& paramPoints)> ;
+
+
+/**
+ * The IStructArrayFieldInterfacePublisher provides an api for clients to subscribe to or unsubscribe from a signal emission 
+ * or a property change.
+ * Implement this interface to keep track of clients of your IStructArrayFieldInterface implementation.
+ * The publisher provides two independent methods of subscription
+ *  - subscribing with a IStructArrayFieldInterfaceSubscriber objects - for all of the changes
+ *  - subscribing any object for single type of change property or a signal
+ * The publish functions needs to be called by implementation of the IIStructArrayFieldInterface on each state changed or signal emitted
+ * to notify all the subscribers about this change.
+ */
+class TEST_TB_STRUCT_ARRAY_EXPORT IStructArrayFieldInterfacePublisher
+{
+public:
+    virtual ~IStructArrayFieldInterfacePublisher() = default;
+
+    /**
+    * Use this function to subscribe for any change of the StructArrayFieldInterface.
+    * Subscriber will be informed of any emitted signal and any property changes.
+    * This is parallel notification system to single subscription. If you will subscribe also for a single change
+    * your subscriber will be informed twice about that change, one for each subscription mechanism.
+    * @param IStructArrayFieldInterfaceSubscriber which is subscribed in this function to any change of the StructArrayFieldInterface.
+    */
+    virtual void subscribeToAllChanges(IStructArrayFieldInterfaceSubscriber& subscriber) = 0;
+    /**
+    * Use this function to remove subscription to all of the changes of the StructArrayFieldInterface.
+    * Not all subscriptions will be removed, the ones made separately for single signal or property change stay intact.
+    * Make sure to remove them.
+    * @param IStructArrayFieldInterfaceSubscriber which subscription for any change of the StructArrayFieldInterface is removed.
+    */
+    virtual void unsubscribeFromAllChanges(IStructArrayFieldInterfaceSubscriber& subscriber) = 0;
+
+    /**
+    * Use this function to subscribe for propStructArray value changes.
+    * If your subscriber uses subscription with IStructArrayFieldInterfaceSubscriber interface, you will get two notifications, one for each subscription mechanism.
+    * @param StructArrayFieldInterfacePropStructArrayPropertyCb callback that will be executed on each change of the property.
+    * Make sure to remove subscription before the callback becomes invalid.
+    * @return subscription token for the subscription removal.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual uint64_t subscribeToPropStructArrayChanged(StructArrayFieldInterfacePropStructArrayPropertyCb callback) = 0;
+    /**
+    * Use this function to unsubscribe from propStructArray property changes.
+    * If your subscriber uses subscription with IStructArrayFieldInterfaceSubscriber interface, you will be still informed about this change,
+    * as those are two independent subscription mechanisms.
+    * @param subscription token received on subscription.
+    */
+    virtual void unsubscribeFromPropStructArrayChanged(uint64_t handleId) = 0;
+
+    /**
+    * Use this function to subscribe for propEnumArray value changes.
+    * If your subscriber uses subscription with IStructArrayFieldInterfaceSubscriber interface, you will get two notifications, one for each subscription mechanism.
+    * @param StructArrayFieldInterfacePropEnumArrayPropertyCb callback that will be executed on each change of the property.
+    * Make sure to remove subscription before the callback becomes invalid.
+    * @return subscription token for the subscription removal.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual uint64_t subscribeToPropEnumArrayChanged(StructArrayFieldInterfacePropEnumArrayPropertyCb callback) = 0;
+    /**
+    * Use this function to unsubscribe from propEnumArray property changes.
+    * If your subscriber uses subscription with IStructArrayFieldInterfaceSubscriber interface, you will be still informed about this change,
+    * as those are two independent subscription mechanisms.
+    * @param subscription token received on subscription.
+    */
+    virtual void unsubscribeFromPropEnumArrayChanged(uint64_t handleId) = 0;
+
+    /**
+    * Use this function to subscribe for propIntArray value changes.
+    * If your subscriber uses subscription with IStructArrayFieldInterfaceSubscriber interface, you will get two notifications, one for each subscription mechanism.
+    * @param StructArrayFieldInterfacePropIntArrayPropertyCb callback that will be executed on each change of the property.
+    * Make sure to remove subscription before the callback becomes invalid.
+    * @return subscription token for the subscription removal.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual uint64_t subscribeToPropIntArrayChanged(StructArrayFieldInterfacePropIntArrayPropertyCb callback) = 0;
+    /**
+    * Use this function to unsubscribe from propIntArray property changes.
+    * If your subscriber uses subscription with IStructArrayFieldInterfaceSubscriber interface, you will be still informed about this change,
+    * as those are two independent subscription mechanisms.
+    * @param subscription token received on subscription.
+    */
+    virtual void unsubscribeFromPropIntArrayChanged(uint64_t handleId) = 0;
+
+    /**
+    * Use this function to subscribe for propMixed value changes.
+    * If your subscriber uses subscription with IStructArrayFieldInterfaceSubscriber interface, you will get two notifications, one for each subscription mechanism.
+    * @param StructArrayFieldInterfacePropMixedPropertyCb callback that will be executed on each change of the property.
+    * Make sure to remove subscription before the callback becomes invalid.
+    * @return subscription token for the subscription removal.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual uint64_t subscribeToPropMixedChanged(StructArrayFieldInterfacePropMixedPropertyCb callback) = 0;
+    /**
+    * Use this function to unsubscribe from propMixed property changes.
+    * If your subscriber uses subscription with IStructArrayFieldInterfaceSubscriber interface, you will be still informed about this change,
+    * as those are two independent subscription mechanisms.
+    * @param subscription token received on subscription.
+    */
+    virtual void unsubscribeFromPropMixedChanged(uint64_t handleId) = 0;
+
+    /**
+    * Use this function to subscribe for sigMixed signal changes.
+    * @param StructArrayFieldInterfaceSigMixedSignalCb callback that will be executed on each signal emission.
+    * Make sure to remove subscription before the callback becomes invalid.
+    * @return subscription token for the subscription removal.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual uint64_t subscribeToSigMixed(StructArrayFieldInterfaceSigMixedSignalCb callback) = 0;
+    /**
+    * Use this function to unsubscribe from sigMixed signal changes.
+    * @param subscription token received on subscription.
+    */
+    virtual void unsubscribeFromSigMixed(uint64_t handleId) = 0;
+
+    /**
+    * Use this function to subscribe for sigStructArray signal changes.
+    * @param StructArrayFieldInterfaceSigStructArraySignalCb callback that will be executed on each signal emission.
+    * Make sure to remove subscription before the callback becomes invalid.
+    * @return subscription token for the subscription removal.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual uint64_t subscribeToSigStructArray(StructArrayFieldInterfaceSigStructArraySignalCb callback) = 0;
+    /**
+    * Use this function to unsubscribe from sigStructArray signal changes.
+    * @param subscription token received on subscription.
+    */
+    virtual void unsubscribeFromSigStructArray(uint64_t handleId) = 0;
+
+    /**
+    * Publishes the property changed to all subscribed clients.
+    * Needs to be invoked by the StructArrayFieldInterface implementation when property propStructArray changes.
+    * @param The new value of propStructArray.
+    */
+    virtual void publishPropStructArrayChanged(const StructWithArrayOfStructs& propStructArray) const = 0;
+    /**
+    * Publishes the property changed to all subscribed clients.
+    * Needs to be invoked by the StructArrayFieldInterface implementation when property propEnumArray changes.
+    * @param The new value of propEnumArray.
+    */
+    virtual void publishPropEnumArrayChanged(const StructWithArrayOfEnums& propEnumArray) const = 0;
+    /**
+    * Publishes the property changed to all subscribed clients.
+    * Needs to be invoked by the StructArrayFieldInterface implementation when property propIntArray changes.
+    * @param The new value of propIntArray.
+    */
+    virtual void publishPropIntArrayChanged(const StructWithArrayOfInts& propIntArray) const = 0;
+    /**
+    * Publishes the property changed to all subscribed clients.
+    * Needs to be invoked by the StructArrayFieldInterface implementation when property propMixed changes.
+    * @param The new value of propMixed.
+    */
+    virtual void publishPropMixedChanged(const MixedStruct& propMixed) const = 0;
+    /**
+    * Publishes the emitted signal to all subscribed clients.
+    * Needs to be invoked by the StructArrayFieldInterface implementation when sigMixed is emitted.
+    * @param paramMixed 
+    */
+    virtual void publishSigMixed(const MixedStruct& paramMixed) const = 0;
+    /**
+    * Publishes the emitted signal to all subscribed clients.
+    * Needs to be invoked by the StructArrayFieldInterface implementation when sigStructArray is emitted.
+    * @param paramPoints 
+    */
+    virtual void publishSigStructArray(const StructWithArrayOfStructs& paramPoints) const = 0;
+};
+
+
+} // namespace TbStructArray
+} // namespace Test

--- a/goldenmaster/modules/tb_struct_array/generated/api/tb_struct_array.h
+++ b/goldenmaster/modules/tb_struct_array/generated/api/tb_struct_array.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#include "tb_struct_array/generated/api/datastructs.api.h"
+#include "tb_struct_array/generated/api/structarrayfieldinterface.api.h"

--- a/goldenmaster/modules/tb_struct_array/generated/core/CMakeLists.txt
+++ b/goldenmaster/modules/tb_struct_array/generated/core/CMakeLists.txt
@@ -1,0 +1,42 @@
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(nlohmann_json REQUIRED)
+find_package(apigear REQUIRED utilities)
+set (SOURCES_CORE_SUPPORT
+    tb_struct_array.json.adapter.cpp
+    test_struct_helper.cpp
+    structarrayfieldinterface.publisher.cpp
+    structarrayfieldinterface.threadsafedecorator.cpp
+)
+add_library(tb_struct_array-core SHARED ${SOURCES_CORE_SUPPORT})
+add_library(tb_struct_array::tb_struct_array-core ALIAS tb_struct_array-core)
+target_include_directories(tb_struct_array-core
+    PUBLIC
+    $<BUILD_INTERFACE:${MODULES_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(tb_struct_array-core PUBLIC apigear::utilities tb_struct_array::tb_struct_array-api nlohmann_json::nlohmann_json)
+# ensure maximum compiler support
+if(NOT MSVC)
+  target_compile_options(tb_struct_array-core PRIVATE -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wnon-virtual-dtor -Woverloaded-virtual -Wcast-align -Werror -fvisibility=hidden)
+else()
+  target_compile_options(tb_struct_array-core PRIVATE /W4 /WX /wd4251)
+endif()
+
+install(TARGETS tb_struct_array-core
+        EXPORT Tb_struct_arrayCoreTargets)
+# install includes
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} DESTINATION include/tb_struct_array/generated FILES_MATCHING PATTERN "*.h")
+
+export(EXPORT Tb_struct_arrayCoreTargets
+  NAMESPACE tb_struct_array::
+)
+
+install(EXPORT Tb_struct_arrayCoreTargets
+  FILE Tb_struct_arrayCoreTargets.cmake
+  DESTINATION ${InstallDir}
+  NAMESPACE tb_struct_array::
+)

--- a/goldenmaster/modules/tb_struct_array/generated/core/structarrayfieldinterface.data.h
+++ b/goldenmaster/modules/tb_struct_array/generated/core/structarrayfieldinterface.data.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "tb_struct_array/generated/api/tb_struct_array.h"
+
+
+namespace Test
+{
+namespace TbStructArray
+{
+
+/**
+* A helper structure for implementations of StructArrayFieldInterface. Stores all the properties.
+*/
+struct StructArrayFieldInterfaceData
+{
+    StructWithArrayOfStructs m_propStructArray {StructWithArrayOfStructs()};
+    StructWithArrayOfEnums m_propEnumArray {StructWithArrayOfEnums()};
+    StructWithArrayOfInts m_propIntArray {StructWithArrayOfInts()};
+    MixedStruct m_propMixed {MixedStruct()};
+};
+
+}
+}

--- a/goldenmaster/modules/tb_struct_array/generated/core/structarrayfieldinterface.publisher.cpp
+++ b/goldenmaster/modules/tb_struct_array/generated/core/structarrayfieldinterface.publisher.cpp
@@ -1,0 +1,162 @@
+
+
+#include "tb_struct_array/generated/core/structarrayfieldinterface.publisher.h"
+#include <algorithm>
+
+
+using namespace Test::TbStructArray;
+
+void StructArrayFieldInterfacePublisher::subscribeToAllChanges(IStructArrayFieldInterfaceSubscriber& subscriber)
+{
+    std::unique_lock<std::shared_timed_mutex> lock(m_allChangesSubscribersMutex);
+    auto found = std::find_if(m_allChangesSubscribers.begin(), m_allChangesSubscribers.end(),
+                        [&subscriber](const auto element){return &(element.get()) == &subscriber;});
+    if (found == m_allChangesSubscribers.end())
+    {
+        m_allChangesSubscribers.push_back(std::reference_wrapper<IStructArrayFieldInterfaceSubscriber>(subscriber));
+    }
+}
+
+void StructArrayFieldInterfacePublisher::unsubscribeFromAllChanges(IStructArrayFieldInterfaceSubscriber& subscriber)
+{
+    std::unique_lock<std::shared_timed_mutex> lock(m_allChangesSubscribersMutex);
+    auto found = std::find_if(m_allChangesSubscribers.begin(), m_allChangesSubscribers.end(),
+                        [&subscriber](const auto element){return &(element.get()) == &subscriber;});
+    if (found != m_allChangesSubscribers.end())
+    {
+        m_allChangesSubscribers.erase(found);
+    }
+}
+
+uint64_t StructArrayFieldInterfacePublisher::subscribeToPropStructArrayChanged(StructArrayFieldInterfacePropStructArrayPropertyCb callback)
+{
+    return PropStructArrayPublisher.subscribeForChange(callback);
+}
+
+void StructArrayFieldInterfacePublisher::unsubscribeFromPropStructArrayChanged(uint64_t handleId)
+{
+    PropStructArrayPublisher.unsubscribeFromChange(handleId);
+}
+
+void StructArrayFieldInterfacePublisher::publishPropStructArrayChanged(const StructWithArrayOfStructs& propStructArray) const
+{
+    std::shared_lock<std::shared_timed_mutex> allChangesSubscribersLock(m_allChangesSubscribersMutex);
+    const auto allChangesSubscribers = m_allChangesSubscribers;
+    allChangesSubscribersLock.unlock();
+    for(const auto& subscriber: allChangesSubscribers)
+    {
+        subscriber.get().onPropStructArrayChanged(propStructArray);
+    }
+    PropStructArrayPublisher.publishChange(propStructArray);
+}
+
+uint64_t StructArrayFieldInterfacePublisher::subscribeToPropEnumArrayChanged(StructArrayFieldInterfacePropEnumArrayPropertyCb callback)
+{
+    return PropEnumArrayPublisher.subscribeForChange(callback);
+}
+
+void StructArrayFieldInterfacePublisher::unsubscribeFromPropEnumArrayChanged(uint64_t handleId)
+{
+    PropEnumArrayPublisher.unsubscribeFromChange(handleId);
+}
+
+void StructArrayFieldInterfacePublisher::publishPropEnumArrayChanged(const StructWithArrayOfEnums& propEnumArray) const
+{
+    std::shared_lock<std::shared_timed_mutex> allChangesSubscribersLock(m_allChangesSubscribersMutex);
+    const auto allChangesSubscribers = m_allChangesSubscribers;
+    allChangesSubscribersLock.unlock();
+    for(const auto& subscriber: allChangesSubscribers)
+    {
+        subscriber.get().onPropEnumArrayChanged(propEnumArray);
+    }
+    PropEnumArrayPublisher.publishChange(propEnumArray);
+}
+
+uint64_t StructArrayFieldInterfacePublisher::subscribeToPropIntArrayChanged(StructArrayFieldInterfacePropIntArrayPropertyCb callback)
+{
+    return PropIntArrayPublisher.subscribeForChange(callback);
+}
+
+void StructArrayFieldInterfacePublisher::unsubscribeFromPropIntArrayChanged(uint64_t handleId)
+{
+    PropIntArrayPublisher.unsubscribeFromChange(handleId);
+}
+
+void StructArrayFieldInterfacePublisher::publishPropIntArrayChanged(const StructWithArrayOfInts& propIntArray) const
+{
+    std::shared_lock<std::shared_timed_mutex> allChangesSubscribersLock(m_allChangesSubscribersMutex);
+    const auto allChangesSubscribers = m_allChangesSubscribers;
+    allChangesSubscribersLock.unlock();
+    for(const auto& subscriber: allChangesSubscribers)
+    {
+        subscriber.get().onPropIntArrayChanged(propIntArray);
+    }
+    PropIntArrayPublisher.publishChange(propIntArray);
+}
+
+uint64_t StructArrayFieldInterfacePublisher::subscribeToPropMixedChanged(StructArrayFieldInterfacePropMixedPropertyCb callback)
+{
+    return PropMixedPublisher.subscribeForChange(callback);
+}
+
+void StructArrayFieldInterfacePublisher::unsubscribeFromPropMixedChanged(uint64_t handleId)
+{
+    PropMixedPublisher.unsubscribeFromChange(handleId);
+}
+
+void StructArrayFieldInterfacePublisher::publishPropMixedChanged(const MixedStruct& propMixed) const
+{
+    std::shared_lock<std::shared_timed_mutex> allChangesSubscribersLock(m_allChangesSubscribersMutex);
+    const auto allChangesSubscribers = m_allChangesSubscribers;
+    allChangesSubscribersLock.unlock();
+    for(const auto& subscriber: allChangesSubscribers)
+    {
+        subscriber.get().onPropMixedChanged(propMixed);
+    }
+    PropMixedPublisher.publishChange(propMixed);
+}
+
+uint64_t StructArrayFieldInterfacePublisher::subscribeToSigMixed(StructArrayFieldInterfaceSigMixedSignalCb callback)
+{
+    return SigMixedPublisher.subscribeForChange(callback);
+}
+
+void StructArrayFieldInterfacePublisher::unsubscribeFromSigMixed(uint64_t handleId)
+{
+    SigMixedPublisher.unsubscribeFromChange(handleId);
+}
+
+void StructArrayFieldInterfacePublisher::publishSigMixed(const MixedStruct& paramMixed) const
+{
+    std::shared_lock<std::shared_timed_mutex> allChangesSubscribersLock(m_allChangesSubscribersMutex);
+    const auto allChangesSubscribers = m_allChangesSubscribers;
+    allChangesSubscribersLock.unlock();
+    for(const auto& subscriber: allChangesSubscribers)
+    {
+        subscriber.get().onSigMixed(paramMixed);
+    }
+    SigMixedPublisher.publishChange(paramMixed);
+}
+
+uint64_t StructArrayFieldInterfacePublisher::subscribeToSigStructArray(StructArrayFieldInterfaceSigStructArraySignalCb callback)
+{
+    return SigStructArrayPublisher.subscribeForChange(callback);
+}
+
+void StructArrayFieldInterfacePublisher::unsubscribeFromSigStructArray(uint64_t handleId)
+{
+    SigStructArrayPublisher.unsubscribeFromChange(handleId);
+}
+
+void StructArrayFieldInterfacePublisher::publishSigStructArray(const StructWithArrayOfStructs& paramPoints) const
+{
+    std::shared_lock<std::shared_timed_mutex> allChangesSubscribersLock(m_allChangesSubscribersMutex);
+    const auto allChangesSubscribers = m_allChangesSubscribers;
+    allChangesSubscribersLock.unlock();
+    for(const auto& subscriber: allChangesSubscribers)
+    {
+        subscriber.get().onSigStructArray(paramPoints);
+    }
+    SigStructArrayPublisher.publishChange(paramPoints);
+}
+

--- a/goldenmaster/modules/tb_struct_array/generated/core/structarrayfieldinterface.publisher.h
+++ b/goldenmaster/modules/tb_struct_array/generated/core/structarrayfieldinterface.publisher.h
@@ -1,0 +1,130 @@
+#pragma once
+
+#include "tb_struct_array/generated/api/datastructs.api.h"
+#include "tb_struct_array/generated/api/structarrayfieldinterface.api.h"
+#include "tb_struct_array/generated/api/common.h"
+
+#include <atomic>
+#include <vector>
+#include <map>
+#include <functional>
+#include <shared_mutex>
+#include <apigear/utilities/single_pub.hpp>
+
+namespace Test {
+namespace TbStructArray {
+
+/**
+ * The implementation of a StructArrayFieldInterfacePublisher.
+ * Use this class to store clients of the StructArrayFieldInterface and inform them about the change
+ * on call of the appropriate publish function.
+ *
+ * @warning Subscription management (subscribe/unsubscribe) is thread safe. However, subscriber
+ * callbacks are invoked without holding any internal lock — the subscriber itself must be
+ * thread safe if it can be called from multiple threads.
+ */
+class TEST_TB_STRUCT_ARRAY_EXPORT StructArrayFieldInterfacePublisher : public IStructArrayFieldInterfacePublisher
+{
+public:
+    /**
+    * Implementation of IStructArrayFieldInterfacePublisher::subscribeToAllChanges
+    */
+    void subscribeToAllChanges(IStructArrayFieldInterfaceSubscriber& subscriber) override;
+    /**
+    * Implementation of IStructArrayFieldInterfacePublisher::unsubscribeFromAllChanges
+    */
+    void unsubscribeFromAllChanges(IStructArrayFieldInterfaceSubscriber& subscriber) override;
+
+    /**
+    * Implementation of IStructArrayFieldInterfacePublisher::subscribeToPropStructArrayChanged
+    */
+    uint64_t subscribeToPropStructArrayChanged(StructArrayFieldInterfacePropStructArrayPropertyCb callback) override;
+    /**
+    * Implementation of IStructArrayFieldInterfacePublisher::subscribeToPropStructArrayChanged
+    */
+    void unsubscribeFromPropStructArrayChanged(uint64_t handleId) override;
+
+    /**
+    * Implementation of IStructArrayFieldInterfacePublisher::subscribeToPropEnumArrayChanged
+    */
+    uint64_t subscribeToPropEnumArrayChanged(StructArrayFieldInterfacePropEnumArrayPropertyCb callback) override;
+    /**
+    * Implementation of IStructArrayFieldInterfacePublisher::subscribeToPropEnumArrayChanged
+    */
+    void unsubscribeFromPropEnumArrayChanged(uint64_t handleId) override;
+
+    /**
+    * Implementation of IStructArrayFieldInterfacePublisher::subscribeToPropIntArrayChanged
+    */
+    uint64_t subscribeToPropIntArrayChanged(StructArrayFieldInterfacePropIntArrayPropertyCb callback) override;
+    /**
+    * Implementation of IStructArrayFieldInterfacePublisher::subscribeToPropIntArrayChanged
+    */
+    void unsubscribeFromPropIntArrayChanged(uint64_t handleId) override;
+
+    /**
+    * Implementation of IStructArrayFieldInterfacePublisher::subscribeToPropMixedChanged
+    */
+    uint64_t subscribeToPropMixedChanged(StructArrayFieldInterfacePropMixedPropertyCb callback) override;
+    /**
+    * Implementation of IStructArrayFieldInterfacePublisher::subscribeToPropMixedChanged
+    */
+    void unsubscribeFromPropMixedChanged(uint64_t handleId) override;
+
+    /**
+    * Implementation of IStructArrayFieldInterfacePublisher::subscribeToSigMixed
+    */
+    uint64_t subscribeToSigMixed(StructArrayFieldInterfaceSigMixedSignalCb callback) override;
+    /**
+    * Implementation of IStructArrayFieldInterfacePublisher::unsubscribeFromSigMixed
+    */
+    void unsubscribeFromSigMixed(uint64_t handleId) override;
+
+    /**
+    * Implementation of IStructArrayFieldInterfacePublisher::subscribeToSigStructArray
+    */
+    uint64_t subscribeToSigStructArray(StructArrayFieldInterfaceSigStructArraySignalCb callback) override;
+    /**
+    * Implementation of IStructArrayFieldInterfacePublisher::unsubscribeFromSigStructArray
+    */
+    void unsubscribeFromSigStructArray(uint64_t handleId) override;
+
+    /**
+    * Implementation of IStructArrayFieldInterfacePublisher::publishPropStructArrayChanged
+    */
+    void publishPropStructArrayChanged(const StructWithArrayOfStructs& propStructArray) const override;
+    /**
+    * Implementation of IStructArrayFieldInterfacePublisher::publishPropEnumArrayChanged
+    */
+    void publishPropEnumArrayChanged(const StructWithArrayOfEnums& propEnumArray) const override;
+    /**
+    * Implementation of IStructArrayFieldInterfacePublisher::publishPropIntArrayChanged
+    */
+    void publishPropIntArrayChanged(const StructWithArrayOfInts& propIntArray) const override;
+    /**
+    * Implementation of IStructArrayFieldInterfacePublisher::publishPropMixedChanged
+    */
+    void publishPropMixedChanged(const MixedStruct& propMixed) const override;
+    /**
+    * Implementation of IStructArrayFieldInterfacePublisher::publishSigMixed
+    */
+    void publishSigMixed(const MixedStruct& paramMixed) const override;
+    /**
+    * Implementation of IStructArrayFieldInterfacePublisher::publishSigStructArray
+    */
+    void publishSigStructArray(const StructWithArrayOfStructs& paramPoints) const override;
+private:
+    // Subscribers informed about any property change or signal emitted in StructArrayFieldInterface
+    std::vector<std::reference_wrapper<IStructArrayFieldInterfaceSubscriber>> m_allChangesSubscribers;
+    // Mutex for m_allChangesSubscribers
+    mutable std::shared_timed_mutex m_allChangesSubscribersMutex;
+    ApiGear::Utilities::SinglePub<StructWithArrayOfStructs> PropStructArrayPublisher;
+    ApiGear::Utilities::SinglePub<StructWithArrayOfEnums> PropEnumArrayPublisher;
+    ApiGear::Utilities::SinglePub<StructWithArrayOfInts> PropIntArrayPublisher;
+    ApiGear::Utilities::SinglePub<MixedStruct> PropMixedPublisher;
+    ApiGear::Utilities::SinglePub<MixedStruct> SigMixedPublisher;
+    ApiGear::Utilities::SinglePub<StructWithArrayOfStructs> SigStructArrayPublisher;
+};
+
+} // namespace TbStructArray
+} // namespace Test

--- a/goldenmaster/modules/tb_struct_array/generated/core/structarrayfieldinterface.threadsafedecorator.cpp
+++ b/goldenmaster/modules/tb_struct_array/generated/core/structarrayfieldinterface.threadsafedecorator.cpp
@@ -1,0 +1,76 @@
+
+
+#include "tb_struct_array/generated/core/structarrayfieldinterface.threadsafedecorator.h"
+
+using namespace Test::TbStructArray;
+StructArrayFieldInterfaceThreadSafeDecorator::StructArrayFieldInterfaceThreadSafeDecorator(std::shared_ptr<IStructArrayFieldInterface> impl)
+    : m_impl(impl)
+{
+}
+MixedStruct StructArrayFieldInterfaceThreadSafeDecorator::funcMixed(const MixedStruct& paramMixed)
+{
+    return m_impl->funcMixed(paramMixed);
+}
+
+std::future<MixedStruct> StructArrayFieldInterfaceThreadSafeDecorator::funcMixedAsync(const MixedStruct& paramMixed, std::function<void(MixedStruct)> callback)
+{
+    return m_impl->funcMixedAsync(paramMixed, callback);
+}
+StructWithArrayOfStructs StructArrayFieldInterfaceThreadSafeDecorator::funcStructArray(const StructWithArrayOfStructs& paramPoints)
+{
+    return m_impl->funcStructArray(paramPoints);
+}
+
+std::future<StructWithArrayOfStructs> StructArrayFieldInterfaceThreadSafeDecorator::funcStructArrayAsync(const StructWithArrayOfStructs& paramPoints, std::function<void(StructWithArrayOfStructs)> callback)
+{
+    return m_impl->funcStructArrayAsync(paramPoints, callback);
+}
+void StructArrayFieldInterfaceThreadSafeDecorator::setPropStructArray(const StructWithArrayOfStructs& propStructArray)
+{
+    std::unique_lock<std::shared_timed_mutex> lock(m_propStructArrayMutex);
+    m_impl->setPropStructArray(propStructArray);
+}
+
+const StructWithArrayOfStructs& StructArrayFieldInterfaceThreadSafeDecorator::getPropStructArray() const
+{
+    std::shared_lock<std::shared_timed_mutex> lock(m_propStructArrayMutex);
+    return m_impl->getPropStructArray();
+}
+void StructArrayFieldInterfaceThreadSafeDecorator::setPropEnumArray(const StructWithArrayOfEnums& propEnumArray)
+{
+    std::unique_lock<std::shared_timed_mutex> lock(m_propEnumArrayMutex);
+    m_impl->setPropEnumArray(propEnumArray);
+}
+
+const StructWithArrayOfEnums& StructArrayFieldInterfaceThreadSafeDecorator::getPropEnumArray() const
+{
+    std::shared_lock<std::shared_timed_mutex> lock(m_propEnumArrayMutex);
+    return m_impl->getPropEnumArray();
+}
+void StructArrayFieldInterfaceThreadSafeDecorator::setPropIntArray(const StructWithArrayOfInts& propIntArray)
+{
+    std::unique_lock<std::shared_timed_mutex> lock(m_propIntArrayMutex);
+    m_impl->setPropIntArray(propIntArray);
+}
+
+const StructWithArrayOfInts& StructArrayFieldInterfaceThreadSafeDecorator::getPropIntArray() const
+{
+    std::shared_lock<std::shared_timed_mutex> lock(m_propIntArrayMutex);
+    return m_impl->getPropIntArray();
+}
+void StructArrayFieldInterfaceThreadSafeDecorator::setPropMixed(const MixedStruct& propMixed)
+{
+    std::unique_lock<std::shared_timed_mutex> lock(m_propMixedMutex);
+    m_impl->setPropMixed(propMixed);
+}
+
+const MixedStruct& StructArrayFieldInterfaceThreadSafeDecorator::getPropMixed() const
+{
+    std::shared_lock<std::shared_timed_mutex> lock(m_propMixedMutex);
+    return m_impl->getPropMixed();
+}
+
+IStructArrayFieldInterfacePublisher& StructArrayFieldInterfaceThreadSafeDecorator::_getPublisher() const
+{
+    return m_impl->_getPublisher();
+}

--- a/goldenmaster/modules/tb_struct_array/generated/core/structarrayfieldinterface.threadsafedecorator.h
+++ b/goldenmaster/modules/tb_struct_array/generated/core/structarrayfieldinterface.threadsafedecorator.h
@@ -1,0 +1,109 @@
+
+#pragma once
+#include "tb_struct_array/generated/api/tb_struct_array.h"
+#include "tb_struct_array/generated/api/common.h"
+#include <memory>
+#include <shared_mutex>
+
+namespace Test {
+namespace TbStructArray {
+
+/**
+* @brief The StructArrayFieldInterfaceThreadSafeDecorator can be used to make property access thread safe.
+*
+* Each property is guarded with its own @c std::shared_timed_mutex — multiple concurrent
+* get calls are allowed, but a set call is exclusive.
+*
+* @note Operation (method) calls are NOT guarded by this decorator. If the underlying
+* implementation is not thread safe, callers must coordinate access to operations themselves.
+* Operations can be locked by adding the same mutex mechanism in the concrete
+* implementation of StructArrayFieldInterface.
+* @see StructArrayFieldInterface
+*
+\code{.cpp}
+using namespace Test::TbStructArray;
+
+std::unique_ptr<IStructArrayFieldInterface> testStructArrayFieldInterface = std::make_unique<StructArrayFieldInterfaceThreadSafeDecorator>(std::make_shared<StructArrayFieldInterface>());
+
+// Thread safe access
+auto propStructArray = testStructArrayFieldInterface->getPropStructArray();
+testStructArrayFieldInterface->setPropStructArray(StructWithArrayOfStructs());
+auto propEnumArray = testStructArrayFieldInterface->getPropEnumArray();
+testStructArrayFieldInterface->setPropEnumArray(StructWithArrayOfEnums());
+auto propIntArray = testStructArrayFieldInterface->getPropIntArray();
+testStructArrayFieldInterface->setPropIntArray(StructWithArrayOfInts());
+auto propMixed = testStructArrayFieldInterface->getPropMixed();
+testStructArrayFieldInterface->setPropMixed(MixedStruct());
+\endcode
+*/
+class TEST_TB_STRUCT_ARRAY_EXPORT StructArrayFieldInterfaceThreadSafeDecorator : public IStructArrayFieldInterface
+{
+public:
+    /** 
+    * ctor
+    * @param impl The StructArrayFieldInterface object to make thread safe.
+    */
+    explicit StructArrayFieldInterfaceThreadSafeDecorator(std::shared_ptr<IStructArrayFieldInterface> impl);
+
+    /** 
+    * Forwards call to StructArrayFieldInterface implementation.
+    * @warning This forward call is not made thread safe by this class.
+    */
+    MixedStruct funcMixed(const MixedStruct& paramMixed) override;
+    /** 
+    * Forwards call to StructArrayFieldInterface implementation.
+    * @warning This forward call is not made thread safe by this class.
+    */
+    std::future<MixedStruct> funcMixedAsync(const MixedStruct& paramMixed, std::function<void(MixedStruct)> callback = nullptr) override;
+
+    /** 
+    * Forwards call to StructArrayFieldInterface implementation.
+    * @warning This forward call is not made thread safe by this class.
+    */
+    StructWithArrayOfStructs funcStructArray(const StructWithArrayOfStructs& paramPoints) override;
+    /** 
+    * Forwards call to StructArrayFieldInterface implementation.
+    * @warning This forward call is not made thread safe by this class.
+    */
+    std::future<StructWithArrayOfStructs> funcStructArrayAsync(const StructWithArrayOfStructs& paramPoints, std::function<void(StructWithArrayOfStructs)> callback = nullptr) override;
+
+    /** Guards and forwards call to StructArrayFieldInterface implementation. */
+    void setPropStructArray(const StructWithArrayOfStructs& propStructArray) override;
+    /** Guards and forwards call to StructArrayFieldInterface implementation. */
+    const StructWithArrayOfStructs& getPropStructArray() const override;
+
+    /** Guards and forwards call to StructArrayFieldInterface implementation. */
+    void setPropEnumArray(const StructWithArrayOfEnums& propEnumArray) override;
+    /** Guards and forwards call to StructArrayFieldInterface implementation. */
+    const StructWithArrayOfEnums& getPropEnumArray() const override;
+
+    /** Guards and forwards call to StructArrayFieldInterface implementation. */
+    void setPropIntArray(const StructWithArrayOfInts& propIntArray) override;
+    /** Guards and forwards call to StructArrayFieldInterface implementation. */
+    const StructWithArrayOfInts& getPropIntArray() const override;
+
+    /** Guards and forwards call to StructArrayFieldInterface implementation. */
+    void setPropMixed(const MixedStruct& propMixed) override;
+    /** Guards and forwards call to StructArrayFieldInterface implementation. */
+    const MixedStruct& getPropMixed() const override;
+
+    /**
+    * Access to a publisher, use it to subscribe for StructArrayFieldInterface changes and signal emission.
+    * This call is thread safe.
+    * @return The publisher for StructArrayFieldInterface.
+    */
+    IStructArrayFieldInterfacePublisher& _getPublisher() const override;
+private:
+    /** The StructArrayFieldInterface object which is guarded */
+    std::shared_ptr<IStructArrayFieldInterface> m_impl;
+    // Mutex for propStructArray property
+    mutable std::shared_timed_mutex m_propStructArrayMutex;
+    // Mutex for propEnumArray property
+    mutable std::shared_timed_mutex m_propEnumArrayMutex;
+    // Mutex for propIntArray property
+    mutable std::shared_timed_mutex m_propIntArrayMutex;
+    // Mutex for propMixed property
+    mutable std::shared_timed_mutex m_propMixedMutex;
+};
+} // namespace TbStructArray
+} // namespace Test

--- a/goldenmaster/modules/tb_struct_array/generated/core/tb_struct_array.json.adapter.cpp
+++ b/goldenmaster/modules/tb_struct_array/generated/core/tb_struct_array.json.adapter.cpp
@@ -1,0 +1,103 @@
+#include "tb_struct_array/generated/core/tb_struct_array.json.adapter.h"
+
+namespace Test {
+namespace TbStructArray {
+void from_json(const nlohmann::json& j, Point& p) {
+    p = Point(
+        j.at("x").get<float>(),
+        j.at("y").get<float>()
+    );
+}
+void to_json(nlohmann::json& j, const Point& p) {
+    j = nlohmann::json{
+        {"x", p.x},
+        {"y", p.y}
+        };
+}
+
+std::ostream& operator<<(std::ostream& os, const Point& obj)
+{
+    nlohmann::json j = obj;
+    os << j.dump(4);
+    return os;
+}
+void from_json(const nlohmann::json& j, StructWithArrayOfStructs& p) {
+    p = StructWithArrayOfStructs(
+        j.at("points").get<std::list<Point>>()
+    );
+}
+void to_json(nlohmann::json& j, const StructWithArrayOfStructs& p) {
+    j = nlohmann::json{
+        {"points", p.points}
+        };
+}
+
+std::ostream& operator<<(std::ostream& os, const StructWithArrayOfStructs& obj)
+{
+    nlohmann::json j = obj;
+    os << j.dump(4);
+    return os;
+}
+void from_json(const nlohmann::json& j, StructWithArrayOfEnums& p) {
+    p = StructWithArrayOfEnums(
+        j.at("tags").get<std::list<TestEnumEnum>>()
+    );
+}
+void to_json(nlohmann::json& j, const StructWithArrayOfEnums& p) {
+    j = nlohmann::json{
+        {"tags", p.tags}
+        };
+}
+
+std::ostream& operator<<(std::ostream& os, const StructWithArrayOfEnums& obj)
+{
+    nlohmann::json j = obj;
+    os << j.dump(4);
+    return os;
+}
+void from_json(const nlohmann::json& j, StructWithArrayOfInts& p) {
+    p = StructWithArrayOfInts(
+        j.at("values").get<std::list<int>>()
+    );
+}
+void to_json(nlohmann::json& j, const StructWithArrayOfInts& p) {
+    j = nlohmann::json{
+        {"values", p.values}
+        };
+}
+
+std::ostream& operator<<(std::ostream& os, const StructWithArrayOfInts& obj)
+{
+    nlohmann::json j = obj;
+    os << j.dump(4);
+    return os;
+}
+void from_json(const nlohmann::json& j, MixedStruct& p) {
+    p = MixedStruct(
+        j.at("id").get<int>(),
+        j.at("name").get<std::string>(),
+        j.at("origin").get<Point>(),
+        j.at("points").get<std::list<Point>>(),
+        j.at("flags").get<std::list<TestEnumEnum>>(),
+        j.at("scores").get<std::list<int>>()
+    );
+}
+void to_json(nlohmann::json& j, const MixedStruct& p) {
+    j = nlohmann::json{
+        {"id", p.id},
+        {"name", p.name},
+        {"origin", p.origin},
+        {"points", p.points},
+        {"flags", p.flags},
+        {"scores", p.scores}
+        };
+}
+
+std::ostream& operator<<(std::ostream& os, const MixedStruct& obj)
+{
+    nlohmann::json j = obj;
+    os << j.dump(4);
+    return os;
+}
+} // namespace TbStructArray
+} // namespace Test

--- a/goldenmaster/modules/tb_struct_array/generated/core/tb_struct_array.json.adapter.h
+++ b/goldenmaster/modules/tb_struct_array/generated/core/tb_struct_array.json.adapter.h
@@ -1,0 +1,143 @@
+#pragma once
+
+#ifndef JSON_USE_IMPLICIT_CONVERSIONS
+#define JSON_USE_IMPLICIT_CONVERSIONS 0
+#endif
+#include <nlohmann/json.hpp>
+#include "tb_struct_array/generated/api/datastructs.api.h"
+#include "tb_struct_array/generated/api/common.h"
+
+namespace Test {
+namespace TbStructArray {
+/** Function that converts json formated data into Point.
+* The functions signature must follow the nlohmann from_jason function rules.
+* It is automatically called in usage j.get<class>();
+* @param j an input json formated data
+* @param p Point that will be filled with data from j.
+*  In case data is malformed or not convertable to Point the function will throw.
+*/
+void TEST_TB_STRUCT_ARRAY_EXPORT from_json(const nlohmann::json& j, Point& p);
+/** Function that converts json formated data into Point
+* The functions signature must follow the nlohmann to_jason function rules.
+* It is automatically called in usage j = p;
+* @param j a json formated data that will be filled with data from p
+* @param p an input Point/'}
+' from which json data will be filled
+*/
+void TEST_TB_STRUCT_ARRAY_EXPORT to_json(nlohmann::json& j, const Point& p);
+
+/**
+ * @brief Overloads the << operator to allow printing of Point objects to an output stream.
+ * 
+ * @param os The output stream to write to.
+ * @param obj The Point object to be printed.
+ * @return std::ostream& The modified output stream.
+ */
+TEST_TB_STRUCT_ARRAY_EXPORT std::ostream& operator<<(std::ostream& os, const Point& obj);
+
+/** Function that converts json formated data into StructWithArrayOfStructs.
+* The functions signature must follow the nlohmann from_jason function rules.
+* It is automatically called in usage j.get<class>();
+* @param j an input json formated data
+* @param p StructWithArrayOfStructs that will be filled with data from j.
+*  In case data is malformed or not convertable to StructWithArrayOfStructs the function will throw.
+*/
+void TEST_TB_STRUCT_ARRAY_EXPORT from_json(const nlohmann::json& j, StructWithArrayOfStructs& p);
+/** Function that converts json formated data into StructWithArrayOfStructs
+* The functions signature must follow the nlohmann to_jason function rules.
+* It is automatically called in usage j = p;
+* @param j a json formated data that will be filled with data from p
+* @param p an input StructWithArrayOfStructs/'}
+' from which json data will be filled
+*/
+void TEST_TB_STRUCT_ARRAY_EXPORT to_json(nlohmann::json& j, const StructWithArrayOfStructs& p);
+
+/**
+ * @brief Overloads the << operator to allow printing of StructWithArrayOfStructs objects to an output stream.
+ * 
+ * @param os The output stream to write to.
+ * @param obj The StructWithArrayOfStructs object to be printed.
+ * @return std::ostream& The modified output stream.
+ */
+TEST_TB_STRUCT_ARRAY_EXPORT std::ostream& operator<<(std::ostream& os, const StructWithArrayOfStructs& obj);
+
+/** Function that converts json formated data into StructWithArrayOfEnums.
+* The functions signature must follow the nlohmann from_jason function rules.
+* It is automatically called in usage j.get<class>();
+* @param j an input json formated data
+* @param p StructWithArrayOfEnums that will be filled with data from j.
+*  In case data is malformed or not convertable to StructWithArrayOfEnums the function will throw.
+*/
+void TEST_TB_STRUCT_ARRAY_EXPORT from_json(const nlohmann::json& j, StructWithArrayOfEnums& p);
+/** Function that converts json formated data into StructWithArrayOfEnums
+* The functions signature must follow the nlohmann to_jason function rules.
+* It is automatically called in usage j = p;
+* @param j a json formated data that will be filled with data from p
+* @param p an input StructWithArrayOfEnums/'}
+' from which json data will be filled
+*/
+void TEST_TB_STRUCT_ARRAY_EXPORT to_json(nlohmann::json& j, const StructWithArrayOfEnums& p);
+
+/**
+ * @brief Overloads the << operator to allow printing of StructWithArrayOfEnums objects to an output stream.
+ * 
+ * @param os The output stream to write to.
+ * @param obj The StructWithArrayOfEnums object to be printed.
+ * @return std::ostream& The modified output stream.
+ */
+TEST_TB_STRUCT_ARRAY_EXPORT std::ostream& operator<<(std::ostream& os, const StructWithArrayOfEnums& obj);
+
+/** Function that converts json formated data into StructWithArrayOfInts.
+* The functions signature must follow the nlohmann from_jason function rules.
+* It is automatically called in usage j.get<class>();
+* @param j an input json formated data
+* @param p StructWithArrayOfInts that will be filled with data from j.
+*  In case data is malformed or not convertable to StructWithArrayOfInts the function will throw.
+*/
+void TEST_TB_STRUCT_ARRAY_EXPORT from_json(const nlohmann::json& j, StructWithArrayOfInts& p);
+/** Function that converts json formated data into StructWithArrayOfInts
+* The functions signature must follow the nlohmann to_jason function rules.
+* It is automatically called in usage j = p;
+* @param j a json formated data that will be filled with data from p
+* @param p an input StructWithArrayOfInts/'}
+' from which json data will be filled
+*/
+void TEST_TB_STRUCT_ARRAY_EXPORT to_json(nlohmann::json& j, const StructWithArrayOfInts& p);
+
+/**
+ * @brief Overloads the << operator to allow printing of StructWithArrayOfInts objects to an output stream.
+ * 
+ * @param os The output stream to write to.
+ * @param obj The StructWithArrayOfInts object to be printed.
+ * @return std::ostream& The modified output stream.
+ */
+TEST_TB_STRUCT_ARRAY_EXPORT std::ostream& operator<<(std::ostream& os, const StructWithArrayOfInts& obj);
+
+/** Function that converts json formated data into MixedStruct.
+* The functions signature must follow the nlohmann from_jason function rules.
+* It is automatically called in usage j.get<class>();
+* @param j an input json formated data
+* @param p MixedStruct that will be filled with data from j.
+*  In case data is malformed or not convertable to MixedStruct the function will throw.
+*/
+void TEST_TB_STRUCT_ARRAY_EXPORT from_json(const nlohmann::json& j, MixedStruct& p);
+/** Function that converts json formated data into MixedStruct
+* The functions signature must follow the nlohmann to_jason function rules.
+* It is automatically called in usage j = p;
+* @param j a json formated data that will be filled with data from p
+* @param p an input MixedStruct/'}
+' from which json data will be filled
+*/
+void TEST_TB_STRUCT_ARRAY_EXPORT to_json(nlohmann::json& j, const MixedStruct& p);
+
+/**
+ * @brief Overloads the << operator to allow printing of MixedStruct objects to an output stream.
+ * 
+ * @param os The output stream to write to.
+ * @param obj The MixedStruct object to be printed.
+ * @return std::ostream& The modified output stream.
+ */
+TEST_TB_STRUCT_ARRAY_EXPORT std::ostream& operator<<(std::ostream& os, const MixedStruct& obj);
+
+} // namespace TbStructArray
+} // namespace Test

--- a/goldenmaster/modules/tb_struct_array/generated/core/tb_struct_array.test.cpp
+++ b/goldenmaster/modules/tb_struct_array/generated/core/tb_struct_array.test.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include "catch2/catch.hpp"

--- a/goldenmaster/modules/tb_struct_array/generated/core/test_struct_helper.cpp
+++ b/goldenmaster/modules/tb_struct_array/generated/core/test_struct_helper.cpp
@@ -1,0 +1,54 @@
+#include "test_struct_helper.h"
+
+using namespace Test;
+
+void TbStructArray::fillTestPoint(TbStructArray::Point& test_point)
+{
+	test_point.x = 1.1f;
+	test_point.y = 1.1f;
+}
+
+void TbStructArray::fillTestStructWithArrayOfStructs(TbStructArray::StructWithArrayOfStructs& test_struct_with_array_of_structs)
+{
+	auto local_points_array = std::list<TbStructArray::Point>();
+	auto elementpoints = TbStructArray::Point();
+	fillTestPoint(elementpoints);
+	local_points_array.push_back(elementpoints);
+	test_struct_with_array_of_structs.points = local_points_array;
+}
+
+void TbStructArray::fillTestStructWithArrayOfEnums(TbStructArray::StructWithArrayOfEnums& test_struct_with_array_of_enums)
+{
+	auto local_tags_array = std::list<TbStructArray::TestEnumEnum>();
+	auto elementtags = TbStructArray::TestEnumEnum::value2;
+	local_tags_array.push_back(elementtags);
+	test_struct_with_array_of_enums.tags = local_tags_array;
+}
+
+void TbStructArray::fillTestStructWithArrayOfInts(TbStructArray::StructWithArrayOfInts& test_struct_with_array_of_ints)
+{
+	auto local_values_array = std::list<int>();
+	auto elementvalues = 1;
+	local_values_array.push_back(elementvalues);
+	test_struct_with_array_of_ints.values = local_values_array;
+}
+
+void TbStructArray::fillTestMixedStruct(TbStructArray::MixedStruct& test_mixed_struct)
+{
+	test_mixed_struct.id = 1;
+	test_mixed_struct.name = std::string("xyz");
+	fillTestPoint(test_mixed_struct.origin);
+	auto local_points_array = std::list<TbStructArray::Point>();
+	auto elementpoints = TbStructArray::Point();
+	fillTestPoint(elementpoints);
+	local_points_array.push_back(elementpoints);
+	test_mixed_struct.points = local_points_array;
+	auto local_flags_array = std::list<TbStructArray::TestEnumEnum>();
+	auto elementflags = TbStructArray::TestEnumEnum::value2;
+	local_flags_array.push_back(elementflags);
+	test_mixed_struct.flags = local_flags_array;
+	auto local_scores_array = std::list<int>();
+	auto elementscores = 1;
+	local_scores_array.push_back(elementscores);
+	test_mixed_struct.scores = local_scores_array;
+}

--- a/goldenmaster/modules/tb_struct_array/generated/core/test_struct_helper.h
+++ b/goldenmaster/modules/tb_struct_array/generated/core/test_struct_helper.h
@@ -1,0 +1,21 @@
+
+#pragma once
+#include "tb_struct_array/generated/api/tb_struct_array.h"
+#include "tb_struct_array/generated/api/common.h"
+
+
+namespace Test {
+namespace TbStructArray {
+
+TEST_TB_STRUCT_ARRAY_EXPORT void fillTestPoint(Point& test_point);
+
+TEST_TB_STRUCT_ARRAY_EXPORT void fillTestStructWithArrayOfStructs(StructWithArrayOfStructs& test_struct_with_array_of_structs);
+
+TEST_TB_STRUCT_ARRAY_EXPORT void fillTestStructWithArrayOfEnums(StructWithArrayOfEnums& test_struct_with_array_of_enums);
+
+TEST_TB_STRUCT_ARRAY_EXPORT void fillTestStructWithArrayOfInts(StructWithArrayOfInts& test_struct_with_array_of_ints);
+
+TEST_TB_STRUCT_ARRAY_EXPORT void fillTestMixedStruct(MixedStruct& test_mixed_struct);
+
+}
+}

--- a/goldenmaster/modules/tb_struct_array/generated/monitor/CMakeLists.txt
+++ b/goldenmaster/modules/tb_struct_array/generated/monitor/CMakeLists.txt
@@ -1,0 +1,40 @@
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(apigear REQUIRED COMPONENTS poco-tracer)
+set (SOURCES_MONITOR
+    structarrayfieldinterface.tracedecorator.cpp
+    structarrayfieldinterface.tracer.cpp
+)
+add_library(tb_struct_array-monitor SHARED ${SOURCES_MONITOR})
+add_library(tb_struct_array::tb_struct_array-monitor ALIAS tb_struct_array-monitor)
+target_include_directories(tb_struct_array-monitor
+    INTERFACE
+    $<BUILD_INTERFACE:${MODULES_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(tb_struct_array-monitor PRIVATE
+    tb_struct_array::tb_struct_array-core
+    apigear::poco-tracer
+)
+# ensure maximum compiler support
+if(NOT MSVC)
+  target_compile_options(tb_struct_array-monitor PRIVATE -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wnon-virtual-dtor -Woverloaded-virtual -Wcast-align -Werror -fvisibility=hidden)
+else()
+  target_compile_options(tb_struct_array-monitor PRIVATE /W4 /WX /wd4251)
+endif()
+
+install(TARGETS tb_struct_array-monitor
+        EXPORT Tb_struct_arrayMonitorTargets)
+# install includes
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} DESTINATION include/tb_struct_array/generated FILES_MATCHING PATTERN "*.h")
+
+export(EXPORT Tb_struct_arrayMonitorTargets
+  NAMESPACE tb_struct_array::
+)
+
+install(EXPORT Tb_struct_arrayMonitorTargets
+  FILE Tb_struct_arrayMonitorTargets.cmake
+  DESTINATION ${InstallDir}
+  NAMESPACE tb_struct_array::
+)

--- a/goldenmaster/modules/tb_struct_array/generated/monitor/structarrayfieldinterface.tracedecorator.cpp
+++ b/goldenmaster/modules/tb_struct_array/generated/monitor/structarrayfieldinterface.tracedecorator.cpp
@@ -1,0 +1,117 @@
+
+
+#include "tb_struct_array/generated/monitor/structarrayfieldinterface.tracedecorator.h"
+#include "tb_struct_array/generated/monitor/structarrayfieldinterface.tracer.h"
+
+using namespace Test::TbStructArray;
+StructArrayFieldInterfaceTraceDecorator::StructArrayFieldInterfaceTraceDecorator(IStructArrayFieldInterface& impl, ApiGear::PocoImpl::Tracer& tracer)
+    : m_tracer(std::make_unique<StructArrayFieldInterfaceTracer>(tracer))
+    , m_impl(impl)
+{
+        m_impl._getPublisher().subscribeToAllChanges(*this);
+}
+StructArrayFieldInterfaceTraceDecorator::~StructArrayFieldInterfaceTraceDecorator()
+{
+    m_impl._getPublisher().unsubscribeFromAllChanges(*this);
+}
+
+std::unique_ptr<StructArrayFieldInterfaceTraceDecorator> StructArrayFieldInterfaceTraceDecorator::connect(IStructArrayFieldInterface& impl, ApiGear::PocoImpl::Tracer& tracer)
+{
+    return std::unique_ptr<StructArrayFieldInterfaceTraceDecorator>(new StructArrayFieldInterfaceTraceDecorator(impl, tracer));
+}
+MixedStruct StructArrayFieldInterfaceTraceDecorator::funcMixed(const MixedStruct& paramMixed)
+{
+    m_tracer->trace_funcMixed(paramMixed);
+    return m_impl.funcMixed(paramMixed);
+}
+std::future<MixedStruct> StructArrayFieldInterfaceTraceDecorator::funcMixedAsync(const MixedStruct& paramMixed, std::function<void(MixedStruct)> callback)
+{
+    m_tracer->trace_funcMixed(paramMixed);
+    return m_impl.funcMixedAsync(paramMixed, callback);
+}
+StructWithArrayOfStructs StructArrayFieldInterfaceTraceDecorator::funcStructArray(const StructWithArrayOfStructs& paramPoints)
+{
+    m_tracer->trace_funcStructArray(paramPoints);
+    return m_impl.funcStructArray(paramPoints);
+}
+std::future<StructWithArrayOfStructs> StructArrayFieldInterfaceTraceDecorator::funcStructArrayAsync(const StructWithArrayOfStructs& paramPoints, std::function<void(StructWithArrayOfStructs)> callback)
+{
+    m_tracer->trace_funcStructArray(paramPoints);
+    return m_impl.funcStructArrayAsync(paramPoints, callback);
+}
+void StructArrayFieldInterfaceTraceDecorator::setPropStructArray(const StructWithArrayOfStructs& propStructArray)
+{
+    m_impl.setPropStructArray(propStructArray);
+}
+
+const StructWithArrayOfStructs& StructArrayFieldInterfaceTraceDecorator::getPropStructArray() const
+{
+    return m_impl.getPropStructArray();
+}
+void StructArrayFieldInterfaceTraceDecorator::setPropEnumArray(const StructWithArrayOfEnums& propEnumArray)
+{
+    m_impl.setPropEnumArray(propEnumArray);
+}
+
+const StructWithArrayOfEnums& StructArrayFieldInterfaceTraceDecorator::getPropEnumArray() const
+{
+    return m_impl.getPropEnumArray();
+}
+void StructArrayFieldInterfaceTraceDecorator::setPropIntArray(const StructWithArrayOfInts& propIntArray)
+{
+    m_impl.setPropIntArray(propIntArray);
+}
+
+const StructWithArrayOfInts& StructArrayFieldInterfaceTraceDecorator::getPropIntArray() const
+{
+    return m_impl.getPropIntArray();
+}
+void StructArrayFieldInterfaceTraceDecorator::setPropMixed(const MixedStruct& propMixed)
+{
+    m_impl.setPropMixed(propMixed);
+}
+
+const MixedStruct& StructArrayFieldInterfaceTraceDecorator::getPropMixed() const
+{
+    return m_impl.getPropMixed();
+}
+void StructArrayFieldInterfaceTraceDecorator::onSigMixed(const MixedStruct& paramMixed)
+{
+    m_tracer->trace_sigMixed(paramMixed);
+}
+
+void StructArrayFieldInterfaceTraceDecorator::onSigStructArray(const StructWithArrayOfStructs& paramPoints)
+{
+    m_tracer->trace_sigStructArray(paramPoints);
+}
+
+void StructArrayFieldInterfaceTraceDecorator::onPropStructArrayChanged(const StructWithArrayOfStructs& propStructArray)
+{
+    (void) propStructArray; // suppress the 'Unreferenced Formal Parameter' warning.
+    m_tracer->capture_state(this);
+}
+
+void StructArrayFieldInterfaceTraceDecorator::onPropEnumArrayChanged(const StructWithArrayOfEnums& propEnumArray)
+{
+    (void) propEnumArray; // suppress the 'Unreferenced Formal Parameter' warning.
+    m_tracer->capture_state(this);
+}
+
+void StructArrayFieldInterfaceTraceDecorator::onPropIntArrayChanged(const StructWithArrayOfInts& propIntArray)
+{
+    (void) propIntArray; // suppress the 'Unreferenced Formal Parameter' warning.
+    m_tracer->capture_state(this);
+}
+
+void StructArrayFieldInterfaceTraceDecorator::onPropMixedChanged(const MixedStruct& propMixed)
+{
+    (void) propMixed; // suppress the 'Unreferenced Formal Parameter' warning.
+    m_tracer->capture_state(this);
+}
+
+
+
+IStructArrayFieldInterfacePublisher& StructArrayFieldInterfaceTraceDecorator::_getPublisher() const
+{
+    return m_impl._getPublisher();
+}

--- a/goldenmaster/modules/tb_struct_array/generated/monitor/structarrayfieldinterface.tracedecorator.h
+++ b/goldenmaster/modules/tb_struct_array/generated/monitor/structarrayfieldinterface.tracedecorator.h
@@ -1,0 +1,104 @@
+
+#pragma once
+#include "tb_struct_array/generated/api/tb_struct_array.h"
+#include "tb_struct_array/generated/api/common.h"
+#include <memory>
+
+namespace ApiGear { namespace PocoImpl { class Tracer; } }
+
+namespace Test {
+namespace TbStructArray {
+
+class StructArrayFieldInterfaceTracer;
+
+class TEST_TB_STRUCT_ARRAY_EXPORT StructArrayFieldInterfaceTraceDecorator : public IStructArrayFieldInterface, public IStructArrayFieldInterfaceSubscriber
+{
+protected:
+    /** 
+    * ctor
+    * Subscribes for signal emission.
+    * @param impl The StructArrayFieldInterface object to trace.
+    * @param tracer A Poco tracer to which traces are put, wrapped with relevant object info.
+    */
+    explicit StructArrayFieldInterfaceTraceDecorator(IStructArrayFieldInterface& impl, ApiGear::PocoImpl::Tracer& tracer);
+public:
+    /** 
+    * Use this function to get the StructArrayFieldInterfaceTraceDecorator object.
+    * @param impl The StructArrayFieldInterface object to trace.
+    * @param tracer A Poco tracer to which traces are put, wrapped with relevant object info.
+    */
+    static std::unique_ptr<StructArrayFieldInterfaceTraceDecorator> connect(IStructArrayFieldInterface& impl, ApiGear::PocoImpl::Tracer& tracer);
+    /**
+    * dtor
+    * Unsubscribes from signal emission.
+    */
+    virtual ~StructArrayFieldInterfaceTraceDecorator();
+
+    /** Traces funcMixed and forwards call to StructArrayFieldInterface implementation. */
+    MixedStruct funcMixed(const MixedStruct& paramMixed) override;
+    /** Traces funcMixed and forwards call to StructArrayFieldInterface implementation. */
+    std::future<MixedStruct> funcMixedAsync(const MixedStruct& paramMixed, std::function<void(MixedStruct)> callback = nullptr) override;
+    
+    /** Traces funcStructArray and forwards call to StructArrayFieldInterface implementation. */
+    StructWithArrayOfStructs funcStructArray(const StructWithArrayOfStructs& paramPoints) override;
+    /** Traces funcStructArray and forwards call to StructArrayFieldInterface implementation. */
+    std::future<StructWithArrayOfStructs> funcStructArrayAsync(const StructWithArrayOfStructs& paramPoints, std::function<void(StructWithArrayOfStructs)> callback = nullptr) override;
+    
+    /** Forwards call to StructArrayFieldInterface implementation. */
+    void setPropStructArray(const StructWithArrayOfStructs& propStructArray) override;
+    /** Forwards call to StructArrayFieldInterface implementation. */
+    const StructWithArrayOfStructs& getPropStructArray() const override;
+    
+    /** Forwards call to StructArrayFieldInterface implementation. */
+    void setPropEnumArray(const StructWithArrayOfEnums& propEnumArray) override;
+    /** Forwards call to StructArrayFieldInterface implementation. */
+    const StructWithArrayOfEnums& getPropEnumArray() const override;
+    
+    /** Forwards call to StructArrayFieldInterface implementation. */
+    void setPropIntArray(const StructWithArrayOfInts& propIntArray) override;
+    /** Forwards call to StructArrayFieldInterface implementation. */
+    const StructWithArrayOfInts& getPropIntArray() const override;
+    
+    /** Forwards call to StructArrayFieldInterface implementation. */
+    void setPropMixed(const MixedStruct& propMixed) override;
+    /** Forwards call to StructArrayFieldInterface implementation. */
+    const MixedStruct& getPropMixed() const override;
+    
+    /**
+    Traces sigMixed emission.
+    */
+    void onSigMixed(const MixedStruct& paramMixed) override;
+    /**
+    Traces sigStructArray emission.
+    */
+    void onSigStructArray(const StructWithArrayOfStructs& paramPoints) override;
+    /**
+    Traces propStructArray changed.
+    */
+    void onPropStructArrayChanged(const StructWithArrayOfStructs& propStructArray) override;
+    /**
+    Traces propEnumArray changed.
+    */
+    void onPropEnumArrayChanged(const StructWithArrayOfEnums& propEnumArray) override;
+    /**
+    Traces propIntArray changed.
+    */
+    void onPropIntArrayChanged(const StructWithArrayOfInts& propIntArray) override;
+    /**
+    Traces propMixed changed.
+    */
+    void onPropMixedChanged(const MixedStruct& propMixed) override;
+
+    /**
+    * Access to a publisher, use it to subscribe for StructArrayFieldInterface changes and signal emission.
+    * @return The publisher for StructArrayFieldInterface.
+    */
+    IStructArrayFieldInterfacePublisher& _getPublisher() const override;
+private:
+    /** A tracer that provides the traces for given StructArrayFieldInterface object. */
+    std::unique_ptr<StructArrayFieldInterfaceTracer> m_tracer;
+    /** The StructArrayFieldInterface object which is traced */
+    IStructArrayFieldInterface& m_impl;
+};
+} // namespace TbStructArray
+} // namespace Test

--- a/goldenmaster/modules/tb_struct_array/generated/monitor/structarrayfieldinterface.tracer.cpp
+++ b/goldenmaster/modules/tb_struct_array/generated/monitor/structarrayfieldinterface.tracer.cpp
@@ -1,0 +1,46 @@
+#include "apigear/tracer/tracer.h"
+#include "tb_struct_array/generated/core/tb_struct_array.json.adapter.h"
+#include "tb_struct_array/generated/monitor/structarrayfieldinterface.tracer.h"
+
+using namespace Test::TbStructArray;
+
+StructArrayFieldInterfaceTracer::StructArrayFieldInterfaceTracer(ApiGear::PocoImpl::Tracer& tracer)
+    : m_tracer(tracer)
+{
+}
+
+void StructArrayFieldInterfaceTracer::capture_state(IStructArrayFieldInterface* obj)
+{
+    nlohmann::json fields_;
+    fields_["propStructArray"] = obj->getPropStructArray();
+    fields_["propEnumArray"] = obj->getPropEnumArray();
+    fields_["propIntArray"] = obj->getPropIntArray();
+    fields_["propMixed"] = obj->getPropMixed();
+    m_tracer.state("tb.struct.array.StructArrayFieldInterface#_state", fields_);
+}
+
+void StructArrayFieldInterfaceTracer::trace_funcMixed(const MixedStruct& paramMixed)
+{
+    nlohmann::json fields_;
+    fields_["paramMixed"] = paramMixed;
+    m_tracer.call("tb.struct.array.StructArrayFieldInterface#funcMixed", fields_);
+}
+
+void StructArrayFieldInterfaceTracer::trace_funcStructArray(const StructWithArrayOfStructs& paramPoints)
+{
+    nlohmann::json fields_;
+    fields_["paramPoints"] = paramPoints;
+    m_tracer.call("tb.struct.array.StructArrayFieldInterface#funcStructArray", fields_);
+}
+void StructArrayFieldInterfaceTracer::trace_sigMixed(const MixedStruct& paramMixed)
+{
+    nlohmann::json fields_;
+    fields_["paramMixed"] = paramMixed;
+    m_tracer.signal("tb.struct.array.StructArrayFieldInterface#sigMixed", fields_);
+}
+void StructArrayFieldInterfaceTracer::trace_sigStructArray(const StructWithArrayOfStructs& paramPoints)
+{
+    nlohmann::json fields_;
+    fields_["paramPoints"] = paramPoints;
+    m_tracer.signal("tb.struct.array.StructArrayFieldInterface#sigStructArray", fields_);
+}

--- a/goldenmaster/modules/tb_struct_array/generated/monitor/structarrayfieldinterface.tracer.h
+++ b/goldenmaster/modules/tb_struct_array/generated/monitor/structarrayfieldinterface.tracer.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "tb_struct_array/generated/api/tb_struct_array.h"
+
+namespace ApiGear { namespace PocoImpl { class Tracer; } }
+
+namespace Test {
+namespace TbStructArray {
+
+/**
+* A helper class for tracing.
+* Builds the trace info with state and operations specific for StructArrayFieldInterface and pass to PocoImpl::Tracer.
+*/
+class StructArrayFieldInterfaceTracer
+{
+public:
+  /**
+  * ctor
+  * @param tracer A tracer object to which the information about the state and operations is put.
+  */
+  StructArrayFieldInterfaceTracer(ApiGear::PocoImpl::Tracer& tracer);
+  /** dtor */
+  virtual ~StructArrayFieldInterfaceTracer() = default;
+  /**
+  * Prepares the StructArrayFieldInterface object state in a nlohmann::json format and puts to a tracer.
+  * @param The StructArrayFieldInterface object to trace.
+  */
+  void capture_state(IStructArrayFieldInterface* obj);
+  /**
+  * Prepares information about the funcMixed call in a nlohmann::json format and puts to a tracer.
+  * @param The StructArrayFieldInterface object to trace.
+  */
+  void trace_funcMixed(const MixedStruct& paramMixed);
+  /**
+  * Prepares information about the funcStructArray call in a nlohmann::json format and puts to a tracer.
+  * @param The StructArrayFieldInterface object to trace.
+  */
+  void trace_funcStructArray(const StructWithArrayOfStructs& paramPoints);
+  /**
+  * Prepares information about the sigMixed call in a nlohmann::json format and puts to a tracer.
+  * @param The StructArrayFieldInterface object to trace.
+  */
+  void trace_sigMixed(const MixedStruct& paramMixed);
+  /**
+  * Prepares information about the sigStructArray call in a nlohmann::json format and puts to a tracer.
+  * @param The StructArrayFieldInterface object to trace.
+  */
+  void trace_sigStructArray(const StructWithArrayOfStructs& paramPoints);
+private:
+  /**
+  * A tracer object to which the information about the state and operations is put.
+  */
+  ApiGear::PocoImpl::Tracer& m_tracer;
+};
+
+} // namespace TbStructArray
+} // namespace Test

--- a/goldenmaster/modules/tb_struct_array/generated/mqtt/CMakeLists.txt
+++ b/goldenmaster/modules/tb_struct_array/generated/mqtt/CMakeLists.txt
@@ -1,0 +1,47 @@
+find_package(apigear OPTIONAL_COMPONENTS paho-mqtt)
+set (SOURCES_MQTT
+    structarrayfieldinterfaceservice.cpp
+    structarrayfieldinterfaceclient.cpp
+)
+add_library(tb_struct_array-mqtt SHARED ${SOURCES_MQTT})
+add_library(tb_struct_array::tb_struct_array-mqtt ALIAS tb_struct_array-mqtt)
+target_include_directories(tb_struct_array-mqtt
+    PUBLIC
+    $<BUILD_INTERFACE:${MODULES_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(tb_struct_array-mqtt
+    PRIVATE
+    tb_struct_array::tb_struct_array-core
+    PUBLIC
+    apigear::paho-mqtt
+    apigear::utilities
+)
+# ensure maximum compiler support
+if(NOT MSVC)
+  target_compile_options(tb_struct_array-mqtt PRIVATE -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wnon-virtual-dtor -Woverloaded-virtual -Wcast-align -Werror -fvisibility=hidden)
+else()
+  target_compile_options(tb_struct_array-mqtt PRIVATE /W4 /WX /wd4251)
+endif()
+
+install(TARGETS tb_struct_array-mqtt
+        EXPORT Tb_struct_arrayMqttTargets)
+# install includes
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} DESTINATION include/tb_struct_array/generated FILES_MATCHING PATTERN "*.h")
+
+export(EXPORT Tb_struct_arrayMqttTargets
+  NAMESPACE tb_struct_array::
+)
+
+install(EXPORT Tb_struct_arrayMqttTargets
+  FILE Tb_struct_arrayMqttTargets.cmake
+  DESTINATION ${InstallDir}
+  NAMESPACE tb_struct_array::
+)
+
+if(BUILD_TESTING)
+enable_testing()
+if (ENABLE_MQTT_TEST_FOR_NON_LINUX_OS OR ((NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin") AND (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")))
+add_subdirectory(tests)
+endif()
+endif()

--- a/goldenmaster/modules/tb_struct_array/generated/mqtt/structarrayfieldinterfaceclient.cpp
+++ b/goldenmaster/modules/tb_struct_array/generated/mqtt/structarrayfieldinterfaceclient.cpp
@@ -1,0 +1,278 @@
+#include "tb_struct_array/generated/mqtt/structarrayfieldinterfaceclient.h"
+#include "tb_struct_array/generated/core/structarrayfieldinterface.publisher.h"
+#include "tb_struct_array/generated/core/tb_struct_array.json.adapter.h"
+#include <random>
+
+using namespace Test::TbStructArray;
+using namespace Test::TbStructArray::MQTT;
+
+namespace {
+    std::mt19937 randomNumberGenerator (std::random_device{}());
+}
+
+StructArrayFieldInterfaceClient::StructArrayFieldInterfaceClient(std::shared_ptr<ApiGear::MQTT::Client> client)
+    : MqttBaseAdapter(client, createTopicMap(client->getClientId()))
+    , m_client(client)
+    , m_publisher(std::make_unique<StructArrayFieldInterfacePublisher>())
+{
+}
+
+std::shared_ptr<StructArrayFieldInterfaceClient> StructArrayFieldInterfaceClient::create(std::shared_ptr<ApiGear::MQTT::Client> client)
+{
+    return std::make_shared<StructArrayFieldInterfaceClient>(client);
+}
+
+StructArrayFieldInterfaceClient::~StructArrayFieldInterfaceClient()
+{
+}
+
+std::map<std::string, ApiGear::MQTT::CallbackFunction> StructArrayFieldInterfaceClient::createTopicMap(const std::string& clientId)
+{
+    return {
+        { std::string("tb.struct.array/StructArrayFieldInterface/prop/propStructArray"), [this](const std::string& args, const std::string&, const std::string&){ this->setPropStructArrayLocal(args); } },
+        { std::string("tb.struct.array/StructArrayFieldInterface/prop/propEnumArray"), [this](const std::string& args, const std::string&, const std::string&){ this->setPropEnumArrayLocal(args); } },
+        { std::string("tb.struct.array/StructArrayFieldInterface/prop/propIntArray"), [this](const std::string& args, const std::string&, const std::string&){ this->setPropIntArrayLocal(args); } },
+        { std::string("tb.struct.array/StructArrayFieldInterface/prop/propMixed"), [this](const std::string& args, const std::string&, const std::string&){ this->setPropMixedLocal(args); } },
+        { std::string("tb.struct.array/StructArrayFieldInterface/sig/sigMixed"), [this](const std::string& args, const std::string&, const std::string&){ this->onSigMixed(args); } },
+        { std::string("tb.struct.array/StructArrayFieldInterface/sig/sigStructArray"), [this](const std::string& args, const std::string&, const std::string&){ this->onSigStructArray(args); } },
+        { std::string("tb.struct.array/StructArrayFieldInterface/rpc/funcMixed/"+clientId+"/result"), [this](const std::string& args, const std::string&, const std::string& correlationData){ this->onInvokeReply(args, correlationData); } },
+        { std::string("tb.struct.array/StructArrayFieldInterface/rpc/funcStructArray/"+clientId+"/result"), [this](const std::string& args, const std::string&, const std::string& correlationData){ this->onInvokeReply(args, correlationData); } },
+    };
+};
+
+void StructArrayFieldInterfaceClient::setPropStructArray(const StructWithArrayOfStructs& propStructArray)
+{
+    if(m_client == nullptr) {
+        return;
+    }
+    static const auto topic = std::string("tb.struct.array/StructArrayFieldInterface/set/propStructArray");
+    m_client->setRemoteProperty(topic, nlohmann::json(propStructArray).dump());
+}
+
+void StructArrayFieldInterfaceClient::setPropStructArrayLocal(const std::string& args)
+{
+    nlohmann::json fields = nlohmann::json::parse(args);
+    if (fields.empty())
+    {
+        return;
+    }
+
+    const StructWithArrayOfStructs& propStructArray = fields.get<StructWithArrayOfStructs>();
+    if (m_data.m_propStructArray != propStructArray) {
+        m_data.m_propStructArray = propStructArray;
+        m_publisher->publishPropStructArrayChanged(propStructArray);
+    }
+}
+
+const StructWithArrayOfStructs& StructArrayFieldInterfaceClient::getPropStructArray() const
+{
+    return m_data.m_propStructArray;
+}
+
+void StructArrayFieldInterfaceClient::setPropEnumArray(const StructWithArrayOfEnums& propEnumArray)
+{
+    if(m_client == nullptr) {
+        return;
+    }
+    static const auto topic = std::string("tb.struct.array/StructArrayFieldInterface/set/propEnumArray");
+    m_client->setRemoteProperty(topic, nlohmann::json(propEnumArray).dump());
+}
+
+void StructArrayFieldInterfaceClient::setPropEnumArrayLocal(const std::string& args)
+{
+    nlohmann::json fields = nlohmann::json::parse(args);
+    if (fields.empty())
+    {
+        return;
+    }
+
+    const StructWithArrayOfEnums& propEnumArray = fields.get<StructWithArrayOfEnums>();
+    if (m_data.m_propEnumArray != propEnumArray) {
+        m_data.m_propEnumArray = propEnumArray;
+        m_publisher->publishPropEnumArrayChanged(propEnumArray);
+    }
+}
+
+const StructWithArrayOfEnums& StructArrayFieldInterfaceClient::getPropEnumArray() const
+{
+    return m_data.m_propEnumArray;
+}
+
+void StructArrayFieldInterfaceClient::setPropIntArray(const StructWithArrayOfInts& propIntArray)
+{
+    if(m_client == nullptr) {
+        return;
+    }
+    static const auto topic = std::string("tb.struct.array/StructArrayFieldInterface/set/propIntArray");
+    m_client->setRemoteProperty(topic, nlohmann::json(propIntArray).dump());
+}
+
+void StructArrayFieldInterfaceClient::setPropIntArrayLocal(const std::string& args)
+{
+    nlohmann::json fields = nlohmann::json::parse(args);
+    if (fields.empty())
+    {
+        return;
+    }
+
+    const StructWithArrayOfInts& propIntArray = fields.get<StructWithArrayOfInts>();
+    if (m_data.m_propIntArray != propIntArray) {
+        m_data.m_propIntArray = propIntArray;
+        m_publisher->publishPropIntArrayChanged(propIntArray);
+    }
+}
+
+const StructWithArrayOfInts& StructArrayFieldInterfaceClient::getPropIntArray() const
+{
+    return m_data.m_propIntArray;
+}
+
+void StructArrayFieldInterfaceClient::setPropMixed(const MixedStruct& propMixed)
+{
+    if(m_client == nullptr) {
+        return;
+    }
+    static const auto topic = std::string("tb.struct.array/StructArrayFieldInterface/set/propMixed");
+    m_client->setRemoteProperty(topic, nlohmann::json(propMixed).dump());
+}
+
+void StructArrayFieldInterfaceClient::setPropMixedLocal(const std::string& args)
+{
+    nlohmann::json fields = nlohmann::json::parse(args);
+    if (fields.empty())
+    {
+        return;
+    }
+
+    const MixedStruct& propMixed = fields.get<MixedStruct>();
+    if (m_data.m_propMixed != propMixed) {
+        m_data.m_propMixed = propMixed;
+        m_publisher->publishPropMixedChanged(propMixed);
+    }
+}
+
+const MixedStruct& StructArrayFieldInterfaceClient::getPropMixed() const
+{
+    return m_data.m_propMixed;
+}
+
+MixedStruct StructArrayFieldInterfaceClient::funcMixed(const MixedStruct& paramMixed)
+{
+    if(m_client == nullptr) {
+        return MixedStruct();
+    }
+    MixedStruct value(funcMixedAsync(paramMixed).get());
+    return value;
+}
+
+std::future<MixedStruct> StructArrayFieldInterfaceClient::funcMixedAsync(const MixedStruct& paramMixed, std::function<void(MixedStruct)> callback)
+{
+    if(m_client == nullptr) {
+        throw std::runtime_error("Client is not initialized");
+    }
+    return std::async(std::launch::async, [this, callback,
+                    paramMixed]()
+        {
+            std::promise<MixedStruct> resultPromise;
+            static const auto topic = std::string("tb.struct.array/StructArrayFieldInterface/rpc/funcMixed");
+            static const auto responseTopic = std::string(topic + "/" + m_client->getClientId() + "/result");
+            ApiGear::MQTT::InvokeReplyFunc responseHandler = [&resultPromise, callback](ApiGear::MQTT::InvokeReplyArg arg) {
+                const MixedStruct& value = arg.value.get<MixedStruct>();
+                resultPromise.set_value(value);
+                if (callback)
+                {
+                    callback(value);
+                }
+            };
+            auto responseId = registerResponseHandler(responseHandler);
+            m_client->invokeRemote(topic, responseTopic, nlohmann::json::array({paramMixed}).dump(), responseId);
+            return resultPromise.get_future().get();
+        }
+    );
+}
+
+StructWithArrayOfStructs StructArrayFieldInterfaceClient::funcStructArray(const StructWithArrayOfStructs& paramPoints)
+{
+    if(m_client == nullptr) {
+        return StructWithArrayOfStructs();
+    }
+    StructWithArrayOfStructs value(funcStructArrayAsync(paramPoints).get());
+    return value;
+}
+
+std::future<StructWithArrayOfStructs> StructArrayFieldInterfaceClient::funcStructArrayAsync(const StructWithArrayOfStructs& paramPoints, std::function<void(StructWithArrayOfStructs)> callback)
+{
+    if(m_client == nullptr) {
+        throw std::runtime_error("Client is not initialized");
+    }
+    return std::async(std::launch::async, [this, callback,
+                    paramPoints]()
+        {
+            std::promise<StructWithArrayOfStructs> resultPromise;
+            static const auto topic = std::string("tb.struct.array/StructArrayFieldInterface/rpc/funcStructArray");
+            static const auto responseTopic = std::string(topic + "/" + m_client->getClientId() + "/result");
+            ApiGear::MQTT::InvokeReplyFunc responseHandler = [&resultPromise, callback](ApiGear::MQTT::InvokeReplyArg arg) {
+                const StructWithArrayOfStructs& value = arg.value.get<StructWithArrayOfStructs>();
+                resultPromise.set_value(value);
+                if (callback)
+                {
+                    callback(value);
+                }
+            };
+            auto responseId = registerResponseHandler(responseHandler);
+            m_client->invokeRemote(topic, responseTopic, nlohmann::json::array({paramPoints}).dump(), responseId);
+            return resultPromise.get_future().get();
+        }
+    );
+}
+void StructArrayFieldInterfaceClient::onSigMixed(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    m_publisher->publishSigMixed(json_args[0].get<MixedStruct>());
+}
+void StructArrayFieldInterfaceClient::onSigStructArray(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    m_publisher->publishSigStructArray(json_args[0].get<StructWithArrayOfStructs>());
+}
+
+int StructArrayFieldInterfaceClient::registerResponseHandler(ApiGear::MQTT::InvokeReplyFunc handler)
+{
+    auto responseId = 0;
+    std::uniform_int_distribution<> distribution (0, 100000);
+    m_responseHandlerMutex.lock();
+    do {
+        responseId = distribution(randomNumberGenerator);
+    } while (m_responseHandlerMap.find(responseId) != m_responseHandlerMap.end());
+    m_responseHandlerMap.insert(std::pair<int, ApiGear::MQTT::InvokeReplyFunc>(responseId, handler));
+    m_responseHandlerMutex.unlock();
+
+    return responseId;
+}
+
+void StructArrayFieldInterfaceClient::onInvokeReply(const std::string& args, const std::string& correlationData)
+{
+    const int randomId = std::stoi(correlationData);
+    ApiGear::MQTT::InvokeReplyFunc responseHandler {};
+    m_responseHandlerMutex.lock();
+    if((m_responseHandlerMap.find(randomId) != m_responseHandlerMap.end()))
+    {
+        responseHandler = m_responseHandlerMap[randomId];
+        m_responseHandlerMap.erase(randomId);
+    }
+    m_responseHandlerMutex.unlock();
+    if(responseHandler) {
+        const ApiGear::MQTT::InvokeReplyArg response{nlohmann::json::parse(args)};
+        responseHandler(response);
+    }
+}
+
+bool StructArrayFieldInterfaceClient::isReady() const
+{
+    return m_isReady;
+}
+
+IStructArrayFieldInterfacePublisher& StructArrayFieldInterfaceClient::_getPublisher() const
+{
+    return *m_publisher;
+}

--- a/goldenmaster/modules/tb_struct_array/generated/mqtt/structarrayfieldinterfaceclient.h
+++ b/goldenmaster/modules/tb_struct_array/generated/mqtt/structarrayfieldinterfaceclient.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <future>
+#include "tb_struct_array/generated/api/common.h"
+#include "tb_struct_array/generated/api/tb_struct_array.h"
+#include "tb_struct_array/generated/core/structarrayfieldinterface.data.h"
+#include "apigear/mqtt/mqttclient.h"
+#include "apigear/mqtt/mqttbaseadapter.h"
+
+namespace Test {
+namespace TbStructArray {
+namespace MQTT {
+/**
+ * @brief MQTT adapter for StructArrayFieldInterface.
+ *
+ * @note Threading: property-change and signal callbacks arrive on the MQTT transport thread.
+ * Subscription management inside the publisher is thread safe, but the callbacks themselves
+ * execute without additional locking. Operation calls are not additionally synchronized —
+ * callers are responsible for thread safety of concurrent operation invocations.
+ * Property storage is not guarded by a mutex; wrap with StructArrayFieldInterfaceThreadSafeDecorator
+ * for concurrent access from multiple threads.
+ */
+class TEST_TB_STRUCT_ARRAY_EXPORT StructArrayFieldInterfaceClient : public IStructArrayFieldInterface, public ApiGear::MQTT::MqttBaseAdapter
+{
+public:
+    explicit StructArrayFieldInterfaceClient(std::shared_ptr<ApiGear::MQTT::Client> client);
+    static std::shared_ptr<StructArrayFieldInterfaceClient> create(std::shared_ptr<ApiGear::MQTT::Client> client);
+    /// Convenience factory. Unlike the NATS adapter, no post-construction init() is needed
+    /// because MqttBaseAdapter subscribes topics eagerly in the constructor.
+    virtual ~StructArrayFieldInterfaceClient() override;
+    const StructWithArrayOfStructs& getPropStructArray() const override;
+    void setPropStructArray(const StructWithArrayOfStructs& propStructArray) override;
+    const StructWithArrayOfEnums& getPropEnumArray() const override;
+    void setPropEnumArray(const StructWithArrayOfEnums& propEnumArray) override;
+    const StructWithArrayOfInts& getPropIntArray() const override;
+    void setPropIntArray(const StructWithArrayOfInts& propIntArray) override;
+    const MixedStruct& getPropMixed() const override;
+    void setPropMixed(const MixedStruct& propMixed) override;
+    MixedStruct funcMixed(const MixedStruct& paramMixed) override;
+    std::future<MixedStruct> funcMixedAsync(const MixedStruct& paramMixed, std::function<void(MixedStruct)> callback = nullptr) override;
+    StructWithArrayOfStructs funcStructArray(const StructWithArrayOfStructs& paramPoints) override;
+    std::future<StructWithArrayOfStructs> funcStructArrayAsync(const StructWithArrayOfStructs& paramPoints, std::function<void(StructWithArrayOfStructs)> callback = nullptr) override;
+    IStructArrayFieldInterfacePublisher& _getPublisher() const override;
+
+    bool isReady() const;
+
+    void onInvokeReply(const std::string& args, const std::string& correlationData);
+
+    void onConnectionStatusChanged(bool connectionStatus);
+private:
+    /// @brief factory to create the topic map which is used for bindings
+    /// @return map with all topics and corresponding function callbacks
+    std::map<std::string, ApiGear::MQTT::CallbackFunction> createTopicMap(const std::string&clientId);
+    /// @brief sets the value for the property PropStructArray coming from the service
+    /// @param args contains the param of the type StructWithArrayOfStructs
+    void setPropStructArrayLocal(const std::string& args);
+    /// @brief sets the value for the property PropEnumArray coming from the service
+    /// @param args contains the param of the type StructWithArrayOfEnums
+    void setPropEnumArrayLocal(const std::string& args);
+    /// @brief sets the value for the property PropIntArray coming from the service
+    /// @param args contains the param of the type StructWithArrayOfInts
+    void setPropIntArrayLocal(const std::string& args);
+    /// @brief sets the value for the property PropMixed coming from the service
+    /// @param args contains the param of the type MixedStruct
+    void setPropMixedLocal(const std::string& args);
+    /// @brief publishes the value for the signal SigMixed coming from the service
+    /// @param args contains the param(s) of the type(s) const MixedStruct& paramMixed
+    void onSigMixed(const std::string& args) const;
+    /// @brief publishes the value for the signal SigStructArray coming from the service
+    /// @param args contains the param(s) of the type(s) const StructWithArrayOfStructs& paramPoints
+    void onSigStructArray(const std::string& args) const;
+
+    bool m_isReady;
+    /** Local storage for properties values. */
+    StructArrayFieldInterfaceData m_data;
+    std::shared_ptr<ApiGear::MQTT::Client> m_client;
+
+    /** The publisher for StructArrayFieldInterface */
+    std::unique_ptr<IStructArrayFieldInterfacePublisher> m_publisher;
+
+    /**
+     * @brief register a response handler for an operation invocation
+     * 
+     * @param handler function to be called on return
+     * @return int unique id of the call
+     */
+    int registerResponseHandler(ApiGear::MQTT::InvokeReplyFunc handler);
+    std::mutex m_responseHandlerMutex;
+    std::map<int, ApiGear::MQTT::InvokeReplyFunc> m_responseHandlerMap;
+};
+} // namespace MQTT
+} // namespace TbStructArray
+} // namespace Test

--- a/goldenmaster/modules/tb_struct_array/generated/mqtt/structarrayfieldinterfaceservice.cpp
+++ b/goldenmaster/modules/tb_struct_array/generated/mqtt/structarrayfieldinterfaceservice.cpp
@@ -1,0 +1,150 @@
+#include "tb_struct_array/generated/mqtt/structarrayfieldinterfaceservice.h"
+#include "tb_struct_array/generated/core/tb_struct_array.json.adapter.h"
+#include <iostream>
+
+using namespace Test::TbStructArray;
+using namespace Test::TbStructArray::MQTT;
+
+StructArrayFieldInterfaceService::StructArrayFieldInterfaceService(std::shared_ptr<IStructArrayFieldInterface> impl, std::shared_ptr<ApiGear::MQTT::Service> service)
+    : MqttBaseAdapter(service, createTopicMap())
+    , m_impl(impl)
+    , m_service(service)
+{
+    m_impl->_getPublisher().subscribeToAllChanges(*this);
+
+    m_connectionStatusId = m_service->subscribeToConnectionStatus([this](bool connectionStatus){ onConnectionStatusChanged(connectionStatus); });
+}
+
+StructArrayFieldInterfaceService::~StructArrayFieldInterfaceService()
+{
+    m_impl->_getPublisher().unsubscribeFromAllChanges(*this);
+
+    m_service->unsubscribeToConnectionStatus(m_connectionStatusId);
+}
+
+std::map<std::string, ApiGear::MQTT::CallbackFunction> StructArrayFieldInterfaceService::createTopicMap()
+{
+    return {
+        {std::string("tb.struct.array/StructArrayFieldInterface/set/propStructArray"), [this](const std::string& args, const std::string&, const std::string&){ this->onSetPropStructArray(args); } },
+        {std::string("tb.struct.array/StructArrayFieldInterface/set/propEnumArray"), [this](const std::string& args, const std::string&, const std::string&){ this->onSetPropEnumArray(args); } },
+        {std::string("tb.struct.array/StructArrayFieldInterface/set/propIntArray"), [this](const std::string& args, const std::string&, const std::string&){ this->onSetPropIntArray(args); } },
+        {std::string("tb.struct.array/StructArrayFieldInterface/set/propMixed"), [this](const std::string& args, const std::string&, const std::string&){ this->onSetPropMixed(args); } },
+        {std::string("tb.struct.array/StructArrayFieldInterface/rpc/funcMixed"), [this](const std::string& args, const std::string& responseTopic, const std::string& correlationData) { this->onInvokeFuncMixed(args, responseTopic, correlationData); } },
+        {std::string("tb.struct.array/StructArrayFieldInterface/rpc/funcStructArray"), [this](const std::string& args, const std::string& responseTopic, const std::string& correlationData) { this->onInvokeFuncStructArray(args, responseTopic, correlationData); } },
+    };
+}
+
+void StructArrayFieldInterfaceService::onConnectionStatusChanged(bool connectionStatus)
+{
+    if(!connectionStatus)
+    {
+        return;
+    }
+    // send current values
+    onPropStructArrayChanged(m_impl->getPropStructArray());
+    onPropEnumArrayChanged(m_impl->getPropEnumArray());
+    onPropIntArrayChanged(m_impl->getPropIntArray());
+    onPropMixedChanged(m_impl->getPropMixed());
+}
+void StructArrayFieldInterfaceService::onSetPropStructArray(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    if (json_args.empty())
+    {
+        return;
+    }
+
+    auto propStructArray = json_args.get<StructWithArrayOfStructs>();
+    m_impl->setPropStructArray(propStructArray);
+}
+void StructArrayFieldInterfaceService::onSetPropEnumArray(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    if (json_args.empty())
+    {
+        return;
+    }
+
+    auto propEnumArray = json_args.get<StructWithArrayOfEnums>();
+    m_impl->setPropEnumArray(propEnumArray);
+}
+void StructArrayFieldInterfaceService::onSetPropIntArray(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    if (json_args.empty())
+    {
+        return;
+    }
+
+    auto propIntArray = json_args.get<StructWithArrayOfInts>();
+    m_impl->setPropIntArray(propIntArray);
+}
+void StructArrayFieldInterfaceService::onSetPropMixed(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    if (json_args.empty())
+    {
+        return;
+    }
+
+    auto propMixed = json_args.get<MixedStruct>();
+    m_impl->setPropMixed(propMixed);
+}
+void StructArrayFieldInterfaceService::onInvokeFuncMixed(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    const MixedStruct& paramMixed = json_args.at(0).get<MixedStruct>();
+    auto result = m_impl->funcMixed(paramMixed);
+    m_service->notifyInvokeResponse(responseTopic, nlohmann::json(result).dump(), correlationData);
+}
+void StructArrayFieldInterfaceService::onInvokeFuncStructArray(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    const StructWithArrayOfStructs& paramPoints = json_args.at(0).get<StructWithArrayOfStructs>();
+    auto result = m_impl->funcStructArray(paramPoints);
+    m_service->notifyInvokeResponse(responseTopic, nlohmann::json(result).dump(), correlationData);
+}
+void StructArrayFieldInterfaceService::onSigMixed(const MixedStruct& paramMixed)
+{
+    if(m_service != nullptr) {
+        const nlohmann::json& args = { paramMixed };
+        static const auto topic = std::string("tb.struct.array/StructArrayFieldInterface/sig/sigMixed");
+        m_service->notifySignal(topic, nlohmann::json(args).dump());
+    }
+}
+void StructArrayFieldInterfaceService::onSigStructArray(const StructWithArrayOfStructs& paramPoints)
+{
+    if(m_service != nullptr) {
+        const nlohmann::json& args = { paramPoints };
+        static const auto topic = std::string("tb.struct.array/StructArrayFieldInterface/sig/sigStructArray");
+        m_service->notifySignal(topic, nlohmann::json(args).dump());
+    }
+}
+void StructArrayFieldInterfaceService::onPropStructArrayChanged(const StructWithArrayOfStructs& propStructArray)
+{
+    if(m_service != nullptr) {
+        static const auto topic = std::string("tb.struct.array/StructArrayFieldInterface/prop/propStructArray");
+        m_service->notifyPropertyChange(topic, nlohmann::json(propStructArray).dump());
+    }
+}
+void StructArrayFieldInterfaceService::onPropEnumArrayChanged(const StructWithArrayOfEnums& propEnumArray)
+{
+    if(m_service != nullptr) {
+        static const auto topic = std::string("tb.struct.array/StructArrayFieldInterface/prop/propEnumArray");
+        m_service->notifyPropertyChange(topic, nlohmann::json(propEnumArray).dump());
+    }
+}
+void StructArrayFieldInterfaceService::onPropIntArrayChanged(const StructWithArrayOfInts& propIntArray)
+{
+    if(m_service != nullptr) {
+        static const auto topic = std::string("tb.struct.array/StructArrayFieldInterface/prop/propIntArray");
+        m_service->notifyPropertyChange(topic, nlohmann::json(propIntArray).dump());
+    }
+}
+void StructArrayFieldInterfaceService::onPropMixedChanged(const MixedStruct& propMixed)
+{
+    if(m_service != nullptr) {
+        static const auto topic = std::string("tb.struct.array/StructArrayFieldInterface/prop/propMixed");
+        m_service->notifyPropertyChange(topic, nlohmann::json(propMixed).dump());
+    }
+}

--- a/goldenmaster/modules/tb_struct_array/generated/mqtt/structarrayfieldinterfaceservice.h
+++ b/goldenmaster/modules/tb_struct_array/generated/mqtt/structarrayfieldinterfaceservice.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "tb_struct_array/generated/api/tb_struct_array.h"
+#include "tb_struct_array/generated/api/common.h"
+#include "apigear/mqtt/mqttservice.h"
+#include "apigear/mqtt/mqttbaseadapter.h"
+
+namespace Test {
+namespace TbStructArray {
+namespace MQTT {
+class TEST_TB_STRUCT_ARRAY_EXPORT StructArrayFieldInterfaceService : public IStructArrayFieldInterfaceSubscriber, public ApiGear::MQTT::MqttBaseAdapter
+{
+public:
+    explicit StructArrayFieldInterfaceService(std::shared_ptr<IStructArrayFieldInterface> impl, std::shared_ptr<ApiGear::MQTT::Service> service);
+    virtual ~StructArrayFieldInterfaceService() override;
+
+    // IStructArrayFieldInterfaceSubscriber interface
+    void onSigMixed(const MixedStruct& paramMixed) override;
+    void onSigStructArray(const StructWithArrayOfStructs& paramPoints) override;
+
+private:
+    /// @brief factory to create the topic map which is used for bindings
+    /// @return map with all topics and corresponding function callbacks
+    std::map<std::string, ApiGear::MQTT::CallbackFunction> createTopicMap();
+
+    void onConnectionStatusChanged(bool connectionStatus);
+    void onInvokeFuncMixed(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const;
+    void onInvokeFuncStructArray(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const;
+    void onPropStructArrayChanged(const StructWithArrayOfStructs& propStructArray) override;
+    /// @brief requests to set the value for the property PropStructArray coming from the client
+    /// @param fields contains the param of the type StructWithArrayOfStructs
+    void onSetPropStructArray(const std::string& args) const;
+    void onPropEnumArrayChanged(const StructWithArrayOfEnums& propEnumArray) override;
+    /// @brief requests to set the value for the property PropEnumArray coming from the client
+    /// @param fields contains the param of the type StructWithArrayOfEnums
+    void onSetPropEnumArray(const std::string& args) const;
+    void onPropIntArrayChanged(const StructWithArrayOfInts& propIntArray) override;
+    /// @brief requests to set the value for the property PropIntArray coming from the client
+    /// @param fields contains the param of the type StructWithArrayOfInts
+    void onSetPropIntArray(const std::string& args) const;
+    void onPropMixedChanged(const MixedStruct& propMixed) override;
+    /// @brief requests to set the value for the property PropMixed coming from the client
+    /// @param fields contains the param of the type MixedStruct
+    void onSetPropMixed(const std::string& args) const;
+
+    std::shared_ptr<IStructArrayFieldInterface> m_impl;
+    std::shared_ptr<ApiGear::MQTT::Service> m_service;
+    // id for connection status registration
+    int m_connectionStatusId;
+};
+} // namespace MQTT
+} // namespace TbStructArray
+} // namespace Test

--- a/goldenmaster/modules/tb_struct_array/generated/mqtt/tests/CMakeLists.txt
+++ b/goldenmaster/modules/tb_struct_array/generated/mqtt/tests/CMakeLists.txt
@@ -1,0 +1,43 @@
+
+cmake_minimum_required(VERSION 3.24)
+project(test_tb_struct_array_generated_mqtt)
+
+set(SPDLOG_DEBUG_ON true)
+set(SPDLOG_TRACE_ON true)
+include(CTest)
+
+enable_testing()
+find_package(apigear OPTIONAL_COMPONENTS paho-mqtt)
+find_package(tb_struct_array QUIET COMPONENTS tb_struct_array-implementation  tb_struct_array-core tb_struct_array-mqtt)
+
+find_package(Catch2 REQUIRED)
+
+set(TEST_TB_STRUCT_ARRAY_GENERATED_MQTT_SOURCES
+    test_main.cpp
+    test_structarrayfieldinterface.cpp
+    )
+
+
+include_directories(test_tb_struct_array_generated_mqtt
+    PRIVATE
+    $<BUILD_INTERFACE:${MODULES_DIR}>
+)
+
+add_executable(test_tb_struct_array_generated_mqtt ${TEST_TB_STRUCT_ARRAY_GENERATED_MQTT_SOURCES})
+add_test(NAME test_tb_struct_array_generated_mqtt COMMAND $<TARGET_FILE:test_tb_struct_array_generated_mqtt>)
+
+target_link_libraries(test_tb_struct_array_generated_mqtt PRIVATE
+    tb_struct_array-implementation
+    tb_struct_array-core
+    tb_struct_array-mqtt
+    Catch2::Catch2)
+
+list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
+include(Catch)
+
+install(TARGETS test_tb_struct_array_generated_mqtt
+    RUNTIME DESTINATION "${INSTALL_EXAMPLEDIR}"
+    BUNDLE DESTINATION "${INSTALL_EXAMPLEDIR}"
+    LIBRARY DESTINATION "${INSTALL_EXAMPLEDIR}"
+)
+

--- a/goldenmaster/modules/tb_struct_array/generated/mqtt/tests/test_main.cpp
+++ b/goldenmaster/modules/tb_struct_array/generated/mqtt/tests/test_main.cpp
@@ -1,0 +1,7 @@
+#if defined(__clang__)
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif // __clang__
+
+#define CATCH_CONFIG_MAIN
+
+#include <catch2/catch.hpp>

--- a/goldenmaster/modules/tb_struct_array/generated/mqtt/tests/test_structarrayfieldinterface.cpp
+++ b/goldenmaster/modules/tb_struct_array/generated/mqtt/tests/test_structarrayfieldinterface.cpp
@@ -1,0 +1,282 @@
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include "tb_struct_array/generated/core/test_struct_helper.h"
+#include "tb_struct_array/implementation/structarrayfieldinterface.h"
+#include "tb_struct_array/generated/mqtt/structarrayfieldinterfaceclient.h"
+#include "tb_struct_array/generated/mqtt/structarrayfieldinterfaceservice.h"
+
+
+#include "apigear/mqtt/mqttclient.h"
+#include "apigear/mqtt/mqttservice.h"
+
+// Those tests do not use network connection.
+// They are set in a way the client writes data straight into read function of server and vice versa.
+
+namespace{
+
+    int timeout = 2000;//in ms
+}
+
+using namespace Test;
+using namespace Test::TbStructArray;
+
+TEST_CASE("mqtt  tb.struct.array StructArrayFieldInterface tests")
+{
+    auto mqttservice = std::make_shared<ApiGear::MQTT::Service>("StructArrayFieldInterfacetestServer");
+    auto mqttclient = std::make_shared<ApiGear::MQTT::Client>("StructArrayFieldInterfacetestClient");
+
+    auto clientStructArrayFieldInterface = std::make_shared<Test::TbStructArray::MQTT::StructArrayFieldInterfaceClient>(mqttclient);
+    auto implStructArrayFieldInterface= std::make_shared<Test::TbStructArray::StructArrayFieldInterface>();
+    auto serviceStructArrayFieldInterface = std::make_shared<Test::TbStructArray::MQTT::StructArrayFieldInterfaceService>(implStructArrayFieldInterface, mqttservice);
+
+    mqttservice->connectToHost("");
+    mqttclient->connectToHost("");
+
+    std::condition_variable m_wait;
+    std::mutex m_waitMutex;
+    std::unique_lock<std::mutex> lock(m_waitMutex, std::defer_lock);
+
+
+    std::atomic<bool> is_serviceConnected{ false };
+    auto service_connected_id = serviceStructArrayFieldInterface->_subscribeForIsReady([&is_serviceConnected, &m_wait](auto connected)
+        {
+            if (connected)
+            {
+                is_serviceConnected = true;
+                m_wait.notify_all();
+            }
+        });
+    if (serviceStructArrayFieldInterface->_is_ready() == true)
+    {
+        is_serviceConnected = true;
+        m_wait.notify_all();
+    }
+    lock.lock();
+    m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&is_serviceConnected]() { return is_serviceConnected == true; });
+    lock.unlock();
+    REQUIRE(is_serviceConnected);
+ 
+    std::atomic<bool> is_clientConnected{ false };
+    clientStructArrayFieldInterface->_subscribeForIsReady([&is_clientConnected, &m_wait](auto connected)
+        {
+            if (connected)
+            {
+                is_clientConnected = true;
+                m_wait.notify_all();
+            }
+        });
+
+    lock.lock();
+    m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&is_clientConnected]() {return is_clientConnected  == true; });
+    lock.unlock();
+    REQUIRE(is_clientConnected);
+    SECTION("Test setting propStructArray")
+    {
+        std::atomic<bool> ispropStructArrayChanged = false;
+        clientStructArrayFieldInterface->_getPublisher().subscribeToPropStructArrayChanged(
+        [&ispropStructArrayChanged, &m_wait ](auto value){
+            ispropStructArrayChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = TbStructArray::StructWithArrayOfStructs();
+        TbStructArray::fillTestStructWithArrayOfStructs(test_value);
+        clientStructArrayFieldInterface->setPropStructArray(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropStructArrayChanged]() {return ispropStructArrayChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArrayFieldInterface->getPropStructArray() == test_value);
+        REQUIRE(clientStructArrayFieldInterface->getPropStructArray() == test_value);
+    }
+    SECTION("Test setting propEnumArray")
+    {
+        std::atomic<bool> ispropEnumArrayChanged = false;
+        clientStructArrayFieldInterface->_getPublisher().subscribeToPropEnumArrayChanged(
+        [&ispropEnumArrayChanged, &m_wait ](auto value){
+            ispropEnumArrayChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = TbStructArray::StructWithArrayOfEnums();
+        TbStructArray::fillTestStructWithArrayOfEnums(test_value);
+        clientStructArrayFieldInterface->setPropEnumArray(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropEnumArrayChanged]() {return ispropEnumArrayChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArrayFieldInterface->getPropEnumArray() == test_value);
+        REQUIRE(clientStructArrayFieldInterface->getPropEnumArray() == test_value);
+    }
+    SECTION("Test setting propIntArray")
+    {
+        std::atomic<bool> ispropIntArrayChanged = false;
+        clientStructArrayFieldInterface->_getPublisher().subscribeToPropIntArrayChanged(
+        [&ispropIntArrayChanged, &m_wait ](auto value){
+            ispropIntArrayChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = TbStructArray::StructWithArrayOfInts();
+        TbStructArray::fillTestStructWithArrayOfInts(test_value);
+        clientStructArrayFieldInterface->setPropIntArray(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropIntArrayChanged]() {return ispropIntArrayChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArrayFieldInterface->getPropIntArray() == test_value);
+        REQUIRE(clientStructArrayFieldInterface->getPropIntArray() == test_value);
+    }
+    SECTION("Test setting propMixed")
+    {
+        std::atomic<bool> ispropMixedChanged = false;
+        clientStructArrayFieldInterface->_getPublisher().subscribeToPropMixedChanged(
+        [&ispropMixedChanged, &m_wait ](auto value){
+            ispropMixedChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = TbStructArray::MixedStruct();
+        TbStructArray::fillTestMixedStruct(test_value);
+        clientStructArrayFieldInterface->setPropMixed(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropMixedChanged]() {return ispropMixedChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArrayFieldInterface->getPropMixed() == test_value);
+        REQUIRE(clientStructArrayFieldInterface->getPropMixed() == test_value);
+    }
+    SECTION("Test emit sigMixed")
+    {
+        std::atomic<bool> issigMixedEmitted = false;
+        auto local_param_mixed_struct = TbStructArray::MixedStruct();
+        TbStructArray::fillTestMixedStruct(local_param_mixed_struct);
+
+        clientStructArrayFieldInterface->_getPublisher().subscribeToSigMixed(
+        [&m_wait, &issigMixedEmitted, &local_param_mixed_struct](const TbStructArray::MixedStruct& paramMixed)
+        {
+            REQUIRE(paramMixed ==local_param_mixed_struct);
+            issigMixedEmitted  = true;
+            m_wait.notify_all();
+        });
+
+         implStructArrayFieldInterface->_getPublisher().publishSigMixed(local_param_mixed_struct);
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&issigMixedEmitted ]() {return issigMixedEmitted   == true; }));
+        lock.unlock();
+    }
+    SECTION("Test emit sigStructArray")
+    {
+        std::atomic<bool> issigStructArrayEmitted = false;
+        auto local_param_points_struct = TbStructArray::StructWithArrayOfStructs();
+        TbStructArray::fillTestStructWithArrayOfStructs(local_param_points_struct);
+
+        clientStructArrayFieldInterface->_getPublisher().subscribeToSigStructArray(
+        [&m_wait, &issigStructArrayEmitted, &local_param_points_struct](const TbStructArray::StructWithArrayOfStructs& paramPoints)
+        {
+            REQUIRE(paramPoints ==local_param_points_struct);
+            issigStructArrayEmitted  = true;
+            m_wait.notify_all();
+        });
+
+         implStructArrayFieldInterface->_getPublisher().publishSigStructArray(local_param_points_struct);
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&issigStructArrayEmitted ]() {return issigStructArrayEmitted   == true; }));
+        lock.unlock();
+    }
+    SECTION("Test method funcMixed")
+    {
+        [[maybe_unused]] auto result =  clientStructArrayFieldInterface->funcMixed(TbStructArray::MixedStruct());
+        // CHECK EFFECTS OF YOUR METHOD AFER FUTURE IS DONE
+    }
+    SECTION("Test method funcMixed async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArrayFieldInterface->funcMixedAsync(TbStructArray::MixedStruct());
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == TbStructArray::MixedStruct()); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    SECTION("Test method funcMixed async with callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArrayFieldInterface->funcMixedAsync(TbStructArray::MixedStruct(),[&finished, &m_wait](MixedStruct value){ (void) value; finished = true; m_wait.notify_all(); /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ });
+
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == TbStructArray::MixedStruct()); 
+    }
+    SECTION("Test method funcStructArray")
+    {
+        [[maybe_unused]] auto result =  clientStructArrayFieldInterface->funcStructArray(TbStructArray::StructWithArrayOfStructs());
+        // CHECK EFFECTS OF YOUR METHOD AFER FUTURE IS DONE
+    }
+    SECTION("Test method funcStructArray async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArrayFieldInterface->funcStructArrayAsync(TbStructArray::StructWithArrayOfStructs());
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == TbStructArray::StructWithArrayOfStructs()); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    SECTION("Test method funcStructArray async with callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArrayFieldInterface->funcStructArrayAsync(TbStructArray::StructWithArrayOfStructs(),[&finished, &m_wait](StructWithArrayOfStructs value){ (void) value; finished = true; m_wait.notify_all(); /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ });
+
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == TbStructArray::StructWithArrayOfStructs()); 
+    }
+
+    std::atomic<bool> serviceDisconnected{ false };
+    mqttservice->subscribeToConnectionStatus([&serviceDisconnected, &m_wait](auto isConnected) {
+        if (!isConnected)
+        {
+            serviceDisconnected = true;
+            m_wait.notify_all();
+        }
+        
+        });
+
+    mqttservice->disconnect();
+
+    lock.lock();
+    m_wait.wait_for(lock, std::chrono::milliseconds(timeout),
+        [&serviceDisconnected]() { return serviceDisconnected == true; });
+    lock.unlock();
+    REQUIRE(serviceDisconnected);
+
+    std::atomic<bool> clientDisonnected{ false };
+    mqttclient->subscribeToConnectionStatus([&clientDisonnected, &m_wait](auto isConnected) {
+        if (!isConnected)
+        {
+            clientDisonnected = true;
+            m_wait.notify_all();
+        }
+        });
+
+    mqttclient->disconnect();
+
+    lock.lock();
+    m_wait.wait_for(lock, std::chrono::milliseconds(timeout),
+        [&clientDisonnected]() { return clientDisonnected == true; });
+    lock.unlock();
+    REQUIRE(clientDisonnected);
+
+    mqttservice.reset();
+    mqttclient.reset();
+    serviceStructArrayFieldInterface.reset();
+    clientStructArrayFieldInterface.reset();
+}

--- a/goldenmaster/modules/tb_struct_array/generated/nats/CMakeLists.txt
+++ b/goldenmaster/modules/tb_struct_array/generated/nats/CMakeLists.txt
@@ -1,0 +1,46 @@
+find_package(apigear OPTIONAL_COMPONENTS nats)
+set (SOURCES_NATS
+    structarrayfieldinterfaceservice.cpp
+    structarrayfieldinterfaceclient.cpp
+)
+add_library(tb_struct_array-nats SHARED ${SOURCES_NATS})
+add_library(tb_struct_array::tb_struct_array-nats ALIAS tb_struct_array-nats)
+target_include_directories(tb_struct_array-nats
+    PUBLIC
+    $<BUILD_INTERFACE:${MODULES_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(tb_struct_array-nats
+    PRIVATE
+    tb_struct_array::tb_struct_array-core
+    PUBLIC
+    apigear::nats
+)
+# ensure maximum compiler support
+if(NOT MSVC)
+  target_compile_options(tb_struct_array-nats PRIVATE -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wnon-virtual-dtor -Woverloaded-virtual -Wcast-align -Werror -fvisibility=hidden)
+else()
+  target_compile_options(tb_struct_array-nats PRIVATE /W4 /WX /wd4251)
+endif()
+
+install(TARGETS tb_struct_array-nats
+        EXPORT Tb_struct_arrayNatsTargets)
+# install includes
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} DESTINATION include/tb_struct_array/generated FILES_MATCHING PATTERN "*.h")
+
+export(EXPORT Tb_struct_arrayNatsTargets
+  NAMESPACE tb_struct_array::
+)
+
+install(EXPORT Tb_struct_arrayNatsTargets
+  FILE Tb_struct_arrayNatsTargets.cmake
+  DESTINATION ${InstallDir}
+  NAMESPACE tb_struct_array::
+)
+
+if(BUILD_TESTING)
+enable_testing()
+if (ENABLE_NATS_TEST_FOR_NON_LINUX_OS OR ((NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin") AND (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")))
+add_subdirectory(tests)
+endif()
+endif()

--- a/goldenmaster/modules/tb_struct_array/generated/nats/structarrayfieldinterfaceclient.cpp
+++ b/goldenmaster/modules/tb_struct_array/generated/nats/structarrayfieldinterfaceclient.cpp
@@ -1,0 +1,333 @@
+#include "tb_struct_array/generated/nats/structarrayfieldinterfaceclient.h"
+#include "tb_struct_array/generated/core/structarrayfieldinterface.publisher.h"
+#include "tb_struct_array/generated/core/tb_struct_array.json.adapter.h"
+#include "apigear/utilities/logger.h"
+
+using namespace Test::TbStructArray;
+using namespace Test::TbStructArray::Nats;
+
+namespace{
+const uint32_t  expectedSingalsSubscriptions = 2;
+const uint32_t  expectedPropertiesSubscriptions = 4;
+const uint32_t  initSubscription = 1;
+const uint32_t  serviceAvailableSubscription = 1;
+constexpr uint32_t expectedSubscriptionsCount = serviceAvailableSubscription + initSubscription + expectedSingalsSubscriptions + expectedPropertiesSubscriptions;
+}
+
+std::shared_ptr<StructArrayFieldInterfaceClient> StructArrayFieldInterfaceClient::create(std::shared_ptr<ApiGear::Nats::Client> client)
+{
+    std::shared_ptr<StructArrayFieldInterfaceClient> obj(new StructArrayFieldInterfaceClient(client));
+    obj->init();
+    return obj;
+}
+
+std::shared_ptr<ApiGear::Nats::BaseAdapter> StructArrayFieldInterfaceClient::getSharedFromDerrived()
+{
+    return shared_from_this();
+}
+
+StructArrayFieldInterfaceClient::StructArrayFieldInterfaceClient(std::shared_ptr<ApiGear::Nats::Client> client)
+    :BaseAdapter(client, expectedSubscriptionsCount)
+    , m_client(client)
+    , m_publisher(std::make_unique<StructArrayFieldInterfacePublisher>())
+{}
+
+void StructArrayFieldInterfaceClient::init()
+{
+    if (m_initialized.exchange(true)) {
+        AG_LOG_WARNING("init() called more than once on " "StructArrayFieldInterfaceClient" ", ignoring");
+        return;
+    }
+    BaseAdapter::init([this](){onConnected();});
+}
+
+StructArrayFieldInterfaceClient::~StructArrayFieldInterfaceClient() = default;
+
+void StructArrayFieldInterfaceClient::onConnected()
+{
+    auto clientId = m_client->getId();
+    m_requestInitCallId = _subscribeForIsReady([this, clientId](bool is_subscribed)
+    { 
+        if(!is_subscribed)
+        {
+            return;
+        }
+        const std::string initRequestTopic = "tb.struct.array.StructArrayFieldInterface.init";
+        m_client->publish(initRequestTopic, nlohmann::json(clientId).dump());
+        _unsubscribeFromIsReady(m_requestInitCallId);
+    });
+    subscribeTopic("tb.struct.array.StructArrayFieldInterface.service.available",[this](const auto& value){ handleAvailable(value); });
+    const std::string initTopic =  "tb.struct.array.StructArrayFieldInterface.init.resp." + std::to_string(clientId);
+    subscribeTopic(initTopic,[this](const auto& value){ handleInit(value); });
+    const std::string topic_propStructArray =  "tb.struct.array.StructArrayFieldInterface.prop.propStructArray";
+    subscribeTopic(topic_propStructArray, [this](const auto& value){ setPropStructArrayLocal(_to_PropStructArray(value)); });
+    const std::string topic_propEnumArray =  "tb.struct.array.StructArrayFieldInterface.prop.propEnumArray";
+    subscribeTopic(topic_propEnumArray, [this](const auto& value){ setPropEnumArrayLocal(_to_PropEnumArray(value)); });
+    const std::string topic_propIntArray =  "tb.struct.array.StructArrayFieldInterface.prop.propIntArray";
+    subscribeTopic(topic_propIntArray, [this](const auto& value){ setPropIntArrayLocal(_to_PropIntArray(value)); });
+    const std::string topic_propMixed =  "tb.struct.array.StructArrayFieldInterface.prop.propMixed";
+    subscribeTopic(topic_propMixed, [this](const auto& value){ setPropMixedLocal(_to_PropMixed(value)); });
+    const std::string topic_sigMixed = "tb.struct.array.StructArrayFieldInterface.sig.sigMixed";
+    subscribeTopic(topic_sigMixed, [this](const auto& args){onSigMixed(args);});
+    const std::string topic_sigStructArray = "tb.struct.array.StructArrayFieldInterface.sig.sigStructArray";
+    subscribeTopic(topic_sigStructArray, [this](const auto& args){onSigStructArray(args);});
+}
+void StructArrayFieldInterfaceClient::handleAvailable(const std::string& /*empty payload*/)
+{
+    auto clientId = m_client->getId();
+    const std::string initRequestTopic = "tb.struct.array.StructArrayFieldInterface.init";
+    m_client->publish(initRequestTopic, nlohmann::json(clientId).dump());
+}
+
+void StructArrayFieldInterfaceClient::setPropStructArray(const StructWithArrayOfStructs& propStructArray)
+{
+    static const auto topic = std::string("tb.struct.array.StructArrayFieldInterface.set.propStructArray");
+    if(m_client == nullptr) {
+        return;
+    }
+    m_client->publish(topic, nlohmann::json(propStructArray).dump());
+}
+
+StructWithArrayOfStructs StructArrayFieldInterfaceClient::_to_PropStructArray(const std::string& args)
+{
+    nlohmann::json fields = nlohmann::json::parse(args);
+    if (fields.empty())
+    {
+        //AG_LOG_WARNING("error while setting the property propStructArray");
+        return StructWithArrayOfStructs();
+    }
+   return fields.get<StructWithArrayOfStructs>();
+}
+
+void StructArrayFieldInterfaceClient::setPropStructArrayLocal(const StructWithArrayOfStructs& propStructArray)
+{
+    if (m_data.m_propStructArray != propStructArray) {
+        m_data.m_propStructArray = propStructArray;
+        m_publisher->publishPropStructArrayChanged(propStructArray);
+    }
+}
+
+const StructWithArrayOfStructs& StructArrayFieldInterfaceClient::getPropStructArray() const
+{
+    return m_data.m_propStructArray;
+}
+
+void StructArrayFieldInterfaceClient::setPropEnumArray(const StructWithArrayOfEnums& propEnumArray)
+{
+    static const auto topic = std::string("tb.struct.array.StructArrayFieldInterface.set.propEnumArray");
+    if(m_client == nullptr) {
+        return;
+    }
+    m_client->publish(topic, nlohmann::json(propEnumArray).dump());
+}
+
+StructWithArrayOfEnums StructArrayFieldInterfaceClient::_to_PropEnumArray(const std::string& args)
+{
+    nlohmann::json fields = nlohmann::json::parse(args);
+    if (fields.empty())
+    {
+        //AG_LOG_WARNING("error while setting the property propEnumArray");
+        return StructWithArrayOfEnums();
+    }
+   return fields.get<StructWithArrayOfEnums>();
+}
+
+void StructArrayFieldInterfaceClient::setPropEnumArrayLocal(const StructWithArrayOfEnums& propEnumArray)
+{
+    if (m_data.m_propEnumArray != propEnumArray) {
+        m_data.m_propEnumArray = propEnumArray;
+        m_publisher->publishPropEnumArrayChanged(propEnumArray);
+    }
+}
+
+const StructWithArrayOfEnums& StructArrayFieldInterfaceClient::getPropEnumArray() const
+{
+    return m_data.m_propEnumArray;
+}
+
+void StructArrayFieldInterfaceClient::setPropIntArray(const StructWithArrayOfInts& propIntArray)
+{
+    static const auto topic = std::string("tb.struct.array.StructArrayFieldInterface.set.propIntArray");
+    if(m_client == nullptr) {
+        return;
+    }
+    m_client->publish(topic, nlohmann::json(propIntArray).dump());
+}
+
+StructWithArrayOfInts StructArrayFieldInterfaceClient::_to_PropIntArray(const std::string& args)
+{
+    nlohmann::json fields = nlohmann::json::parse(args);
+    if (fields.empty())
+    {
+        //AG_LOG_WARNING("error while setting the property propIntArray");
+        return StructWithArrayOfInts();
+    }
+   return fields.get<StructWithArrayOfInts>();
+}
+
+void StructArrayFieldInterfaceClient::setPropIntArrayLocal(const StructWithArrayOfInts& propIntArray)
+{
+    if (m_data.m_propIntArray != propIntArray) {
+        m_data.m_propIntArray = propIntArray;
+        m_publisher->publishPropIntArrayChanged(propIntArray);
+    }
+}
+
+const StructWithArrayOfInts& StructArrayFieldInterfaceClient::getPropIntArray() const
+{
+    return m_data.m_propIntArray;
+}
+
+void StructArrayFieldInterfaceClient::setPropMixed(const MixedStruct& propMixed)
+{
+    static const auto topic = std::string("tb.struct.array.StructArrayFieldInterface.set.propMixed");
+    if(m_client == nullptr) {
+        return;
+    }
+    m_client->publish(topic, nlohmann::json(propMixed).dump());
+}
+
+MixedStruct StructArrayFieldInterfaceClient::_to_PropMixed(const std::string& args)
+{
+    nlohmann::json fields = nlohmann::json::parse(args);
+    if (fields.empty())
+    {
+        //AG_LOG_WARNING("error while setting the property propMixed");
+        return MixedStruct();
+    }
+   return fields.get<MixedStruct>();
+}
+
+void StructArrayFieldInterfaceClient::setPropMixedLocal(const MixedStruct& propMixed)
+{
+    if (m_data.m_propMixed != propMixed) {
+        m_data.m_propMixed = propMixed;
+        m_publisher->publishPropMixedChanged(propMixed);
+    }
+}
+
+const MixedStruct& StructArrayFieldInterfaceClient::getPropMixed() const
+{
+    return m_data.m_propMixed;
+}
+
+void StructArrayFieldInterfaceClient::handleInit(const std::string& value)
+{
+    nlohmann::json fields = nlohmann::json::parse(value);
+    if(fields.contains("propStructArray")) {
+        setPropStructArrayLocal(fields["propStructArray"].get<StructWithArrayOfStructs>());
+    }
+    if(fields.contains("propEnumArray")) {
+        setPropEnumArrayLocal(fields["propEnumArray"].get<StructWithArrayOfEnums>());
+    }
+    if(fields.contains("propIntArray")) {
+        setPropIntArrayLocal(fields["propIntArray"].get<StructWithArrayOfInts>());
+    }
+    if(fields.contains("propMixed")) {
+        setPropMixedLocal(fields["propMixed"].get<MixedStruct>());
+    }
+}
+
+MixedStruct StructArrayFieldInterfaceClient::funcMixed(const MixedStruct& paramMixed)
+{
+    if(m_client == nullptr) {
+        return MixedStruct();
+    }
+    MixedStruct value(funcMixedAsync(paramMixed).get());
+    return value;
+}
+
+std::future<MixedStruct> StructArrayFieldInterfaceClient::funcMixedAsync(const MixedStruct& paramMixed, std::function<void(MixedStruct)> user_callback)
+{
+    if(m_client == nullptr) {
+        throw std::runtime_error("Client is not initialized");
+    }
+    static const auto topic = std::string("tb.struct.array.StructArrayFieldInterface.rpc.funcMixed");
+
+    return std::async(std::launch::async, [this, user_callback,paramMixed]()
+    {
+        std::promise<MixedStruct> resultPromise;
+        auto callback = [&resultPromise, user_callback](const auto& result)
+        {
+            if (result.empty())
+            {
+                resultPromise.set_value(MixedStruct());
+                if (user_callback)
+                {
+                    user_callback(MixedStruct());
+                }
+                return;
+            }
+            nlohmann::json field = nlohmann::json::parse(result);
+            const MixedStruct value = field.get<MixedStruct>();
+            resultPromise.set_value(value);
+            if (user_callback)
+            {
+                user_callback(value);
+            }
+        };
+
+        m_client->request(topic,  nlohmann::json::array({paramMixed}).dump(), callback);
+        return resultPromise.get_future().get();
+    });
+}
+
+StructWithArrayOfStructs StructArrayFieldInterfaceClient::funcStructArray(const StructWithArrayOfStructs& paramPoints)
+{
+    if(m_client == nullptr) {
+        return StructWithArrayOfStructs();
+    }
+    StructWithArrayOfStructs value(funcStructArrayAsync(paramPoints).get());
+    return value;
+}
+
+std::future<StructWithArrayOfStructs> StructArrayFieldInterfaceClient::funcStructArrayAsync(const StructWithArrayOfStructs& paramPoints, std::function<void(StructWithArrayOfStructs)> user_callback)
+{
+    if(m_client == nullptr) {
+        throw std::runtime_error("Client is not initialized");
+    }
+    static const auto topic = std::string("tb.struct.array.StructArrayFieldInterface.rpc.funcStructArray");
+
+    return std::async(std::launch::async, [this, user_callback,paramPoints]()
+    {
+        std::promise<StructWithArrayOfStructs> resultPromise;
+        auto callback = [&resultPromise, user_callback](const auto& result)
+        {
+            if (result.empty())
+            {
+                resultPromise.set_value(StructWithArrayOfStructs());
+                if (user_callback)
+                {
+                    user_callback(StructWithArrayOfStructs());
+                }
+                return;
+            }
+            nlohmann::json field = nlohmann::json::parse(result);
+            const StructWithArrayOfStructs value = field.get<StructWithArrayOfStructs>();
+            resultPromise.set_value(value);
+            if (user_callback)
+            {
+                user_callback(value);
+            }
+        };
+
+        m_client->request(topic,  nlohmann::json::array({paramPoints}).dump(), callback);
+        return resultPromise.get_future().get();
+    });
+}
+void StructArrayFieldInterfaceClient::onSigMixed(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    m_publisher->publishSigMixed(json_args[0].get<MixedStruct>());
+}
+void StructArrayFieldInterfaceClient::onSigStructArray(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    m_publisher->publishSigStructArray(json_args[0].get<StructWithArrayOfStructs>());
+}
+
+IStructArrayFieldInterfacePublisher& StructArrayFieldInterfaceClient::_getPublisher() const
+{
+    return *m_publisher;
+}
+

--- a/goldenmaster/modules/tb_struct_array/generated/nats/structarrayfieldinterfaceclient.h
+++ b/goldenmaster/modules/tb_struct_array/generated/nats/structarrayfieldinterfaceclient.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include "tb_struct_array/generated/api/common.h"
+#include "tb_struct_array/generated/api/tb_struct_array.h"
+#include "tb_struct_array/generated/core/structarrayfieldinterface.data.h"
+#include "apigear/nats/natsclient.h"
+#include "apigear/nats/natstypes.h"
+#include "apigear/nats/baseadapter.h"
+
+#include <atomic>
+#include <future>
+#include <unordered_map>
+
+namespace Test {
+namespace TbStructArray {
+namespace Nats {
+/**
+ * @brief NATS adapter for StructArrayFieldInterface.
+ *
+ * @note Threading: property-change and signal callbacks arrive on the NATS transport thread.
+ * Subscription management inside the publisher is thread safe, but the callbacks themselves
+ * execute without additional locking. Operation calls are not additionally synchronized —
+ * callers are responsible for thread safety of concurrent operation invocations.
+ * Property storage is not guarded by a mutex; wrap with StructArrayFieldInterfaceThreadSafeDecorator
+ * for concurrent access from multiple threads.
+ */
+class TEST_TB_STRUCT_ARRAY_EXPORT StructArrayFieldInterfaceClient : public IStructArrayFieldInterface, public ApiGear::Nats::BaseAdapter,  public std::enable_shared_from_this<StructArrayFieldInterfaceClient>
+{
+protected:
+    explicit StructArrayFieldInterfaceClient(std::shared_ptr<ApiGear::Nats::Client> client);
+public:
+    static std::shared_ptr<StructArrayFieldInterfaceClient> create(std::shared_ptr<ApiGear::Nats::Client> client);
+    virtual ~StructArrayFieldInterfaceClient() override;
+    void init();
+    const StructWithArrayOfStructs& getPropStructArray() const override;
+    void setPropStructArray(const StructWithArrayOfStructs& propStructArray) override;
+    const StructWithArrayOfEnums& getPropEnumArray() const override;
+    void setPropEnumArray(const StructWithArrayOfEnums& propEnumArray) override;
+    const StructWithArrayOfInts& getPropIntArray() const override;
+    void setPropIntArray(const StructWithArrayOfInts& propIntArray) override;
+    const MixedStruct& getPropMixed() const override;
+    void setPropMixed(const MixedStruct& propMixed) override;
+    MixedStruct funcMixed(const MixedStruct& paramMixed) override;
+    std::future<MixedStruct> funcMixedAsync(const MixedStruct& paramMixed, std::function<void(MixedStruct)> callback = nullptr) override;
+    StructWithArrayOfStructs funcStructArray(const StructWithArrayOfStructs& paramPoints) override;
+    std::future<StructWithArrayOfStructs> funcStructArrayAsync(const StructWithArrayOfStructs& paramPoints, std::function<void(StructWithArrayOfStructs)> callback = nullptr) override;
+    IStructArrayFieldInterfacePublisher& _getPublisher() const override;
+private:
+    std::shared_ptr<ApiGear::Nats::BaseAdapter> getSharedFromDerrived() override;
+    void handleAvailable(const std::string& payload);
+    void handleInit(const std::string& value);
+    /// @brief Converts incoming raw message formatted value to a value of property. 
+    /// @param args contains the param of the type StructWithArrayOfStructs
+    StructWithArrayOfStructs _to_PropStructArray(const std::string& args);
+    /// @brief sets the value for the property PropStructArray coming from the service
+    void setPropStructArrayLocal(const StructWithArrayOfStructs& propStructArray);
+    /// @brief Converts incoming raw message formatted value to a value of property. 
+    /// @param args contains the param of the type StructWithArrayOfEnums
+    StructWithArrayOfEnums _to_PropEnumArray(const std::string& args);
+    /// @brief sets the value for the property PropEnumArray coming from the service
+    void setPropEnumArrayLocal(const StructWithArrayOfEnums& propEnumArray);
+    /// @brief Converts incoming raw message formatted value to a value of property. 
+    /// @param args contains the param of the type StructWithArrayOfInts
+    StructWithArrayOfInts _to_PropIntArray(const std::string& args);
+    /// @brief sets the value for the property PropIntArray coming from the service
+    void setPropIntArrayLocal(const StructWithArrayOfInts& propIntArray);
+    /// @brief Converts incoming raw message formatted value to a value of property. 
+    /// @param args contains the param of the type MixedStruct
+    MixedStruct _to_PropMixed(const std::string& args);
+    /// @brief sets the value for the property PropMixed coming from the service
+    void setPropMixedLocal(const MixedStruct& propMixed);
+    /// @brief publishes the value for the signal SigMixed coming from the service
+    /// @param args contains the param(s) of the type(s) const MixedStruct& paramMixed
+    void onSigMixed(const std::string& args) const;
+    /// @brief publishes the value for the signal SigStructArray coming from the service
+    /// @param args contains the param(s) of the type(s) const StructWithArrayOfStructs& paramPoints
+    void onSigStructArray(const std::string& args) const;
+    /** Local storage for properties values. */
+    StructArrayFieldInterfaceData m_data;
+    uint64_t m_requestInitCallId = 0;
+    std::atomic<bool> m_initialized{false};
+    std::shared_ptr<ApiGear::Nats::Client> m_client;
+    /** The publisher for StructArrayFieldInterface */
+    std::unique_ptr<IStructArrayFieldInterfacePublisher> m_publisher;
+    void onConnected();
+
+};
+} // namespace Nats
+} // namespace TbStructArray
+} // namespace Test

--- a/goldenmaster/modules/tb_struct_array/generated/nats/structarrayfieldinterfaceservice.cpp
+++ b/goldenmaster/modules/tb_struct_array/generated/nats/structarrayfieldinterfaceservice.cpp
@@ -1,0 +1,187 @@
+#include "tb_struct_array/generated/nats/structarrayfieldinterfaceservice.h"
+#include "tb_struct_array/generated/core/tb_struct_array.json.adapter.h"
+#include "apigear/utilities/logger.h"
+#include <iostream>
+
+using namespace Test::TbStructArray;
+using namespace Test::TbStructArray::Nats;
+
+namespace{
+const uint32_t  expectedMethodSubscriptions = 2;
+const uint32_t  expectedPropertiesSubscriptions = 4;
+const uint32_t  initRespSubscription = 1;
+constexpr uint32_t expectedSubscriptionsCount = initRespSubscription + expectedMethodSubscriptions + expectedPropertiesSubscriptions;
+}
+
+StructArrayFieldInterfaceService::StructArrayFieldInterfaceService(std::shared_ptr<IStructArrayFieldInterface> impl, std::shared_ptr<ApiGear::Nats::Service> service)
+    :BaseAdapter(service, expectedSubscriptionsCount)
+    , m_impl(impl)
+    , m_service(service)
+{
+    m_impl->_getPublisher().subscribeToAllChanges(*this);
+}
+
+void StructArrayFieldInterfaceService::init()
+{
+    if (m_initialized.exchange(true)) {
+        AG_LOG_WARNING("init() called more than once on " "StructArrayFieldInterfaceService" ", ignoring");
+        return;
+    }
+    BaseAdapter::init([this](){onConnected();});
+}
+
+std::shared_ptr<StructArrayFieldInterfaceService> StructArrayFieldInterfaceService::create(std::shared_ptr<IStructArrayFieldInterface> impl, std::shared_ptr<ApiGear::Nats::Service> service)
+{
+    std::shared_ptr<StructArrayFieldInterfaceService> obj(new StructArrayFieldInterfaceService(impl, service));
+    obj->init();
+    return obj;
+}
+
+std::shared_ptr<ApiGear::Nats::BaseAdapter> StructArrayFieldInterfaceService::getSharedFromDerrived()
+{
+    return shared_from_this();
+}
+
+
+StructArrayFieldInterfaceService::~StructArrayFieldInterfaceService()
+{
+    m_impl->_getPublisher().unsubscribeFromAllChanges(*this);
+}
+
+
+void StructArrayFieldInterfaceService::onConnected()
+{
+    m_onReadySubscriptionId= _subscribeForIsReady([this](bool is_subscribed)
+    { 
+        if(!is_subscribed)
+        {
+            return;
+        }
+        const std::string topic = "tb.struct.array.StructArrayFieldInterface.service.available";
+        m_service->publish(topic, "");
+        _unsubscribeFromIsReady(m_onReadySubscriptionId);
+    });
+    subscribeTopic("tb.struct.array.StructArrayFieldInterface.set.propStructArray", [this](const auto& value){ onSetPropStructArray(value); });
+    subscribeTopic("tb.struct.array.StructArrayFieldInterface.set.propEnumArray", [this](const auto& value){ onSetPropEnumArray(value); });
+    subscribeTopic("tb.struct.array.StructArrayFieldInterface.set.propIntArray", [this](const auto& value){ onSetPropIntArray(value); });
+    subscribeTopic("tb.struct.array.StructArrayFieldInterface.set.propMixed", [this](const auto& value){ onSetPropMixed(value); });
+    subscribeRequest("tb.struct.array.StructArrayFieldInterface.rpc.funcMixed", [this](const auto& args){  return onInvokeFuncMixed(args); });
+    subscribeRequest("tb.struct.array.StructArrayFieldInterface.rpc.funcStructArray", [this](const auto& args){  return onInvokeFuncStructArray(args); });
+
+    const std::string initRequestTopic = "tb.struct.array.StructArrayFieldInterface.init";
+    subscribeTopic(initRequestTopic, [this, initRequestTopic](const auto& value){
+        nlohmann::json json_id = nlohmann::json::parse(value);
+        if (json_id.empty())
+        {
+            return;
+        }
+        auto clientId = json_id.get<uint64_t>();
+        auto topic = initRequestTopic + ".resp." +  std::to_string(clientId);
+        auto properties = getState();
+        m_service->publish(topic, properties.dump());
+        }
+    );
+
+}
+
+nlohmann::json StructArrayFieldInterfaceService::getState()
+{
+    return nlohmann::json::object({
+        { "propStructArray", m_impl->getPropStructArray() },
+        { "propEnumArray", m_impl->getPropEnumArray() },
+        { "propIntArray", m_impl->getPropIntArray() },
+        { "propMixed", m_impl->getPropMixed() }
+    });
+}
+void StructArrayFieldInterfaceService::onSetPropStructArray(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    if (json_args.empty())
+    {
+        return;
+    }
+
+    auto propStructArray = json_args.get<StructWithArrayOfStructs>();
+    m_impl->setPropStructArray(propStructArray);
+}
+void StructArrayFieldInterfaceService::onSetPropEnumArray(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    if (json_args.empty())
+    {
+        return;
+    }
+
+    auto propEnumArray = json_args.get<StructWithArrayOfEnums>();
+    m_impl->setPropEnumArray(propEnumArray);
+}
+void StructArrayFieldInterfaceService::onSetPropIntArray(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    if (json_args.empty())
+    {
+        return;
+    }
+
+    auto propIntArray = json_args.get<StructWithArrayOfInts>();
+    m_impl->setPropIntArray(propIntArray);
+}
+void StructArrayFieldInterfaceService::onSetPropMixed(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    if (json_args.empty())
+    {
+        return;
+    }
+
+    auto propMixed = json_args.get<MixedStruct>();
+    m_impl->setPropMixed(propMixed);
+}
+void StructArrayFieldInterfaceService::onSigMixed(const MixedStruct& paramMixed)
+{
+    (void) paramMixed;
+    static const std::string topic = "tb.struct.array.StructArrayFieldInterface.sig.sigMixed";
+    nlohmann::json args = { paramMixed };
+    m_service->publish(topic, nlohmann::json(args).dump());
+}
+void StructArrayFieldInterfaceService::onSigStructArray(const StructWithArrayOfStructs& paramPoints)
+{
+    (void) paramPoints;
+    static const std::string topic = "tb.struct.array.StructArrayFieldInterface.sig.sigStructArray";
+    nlohmann::json args = { paramPoints };
+    m_service->publish(topic, nlohmann::json(args).dump());
+}
+void StructArrayFieldInterfaceService::onPropStructArrayChanged(const StructWithArrayOfStructs& propStructArray)
+{
+    static const std::string topic = "tb.struct.array.StructArrayFieldInterface.prop.propStructArray";
+    m_service->publish(topic, nlohmann::json(propStructArray).dump());
+}
+void StructArrayFieldInterfaceService::onPropEnumArrayChanged(const StructWithArrayOfEnums& propEnumArray)
+{
+    static const std::string topic = "tb.struct.array.StructArrayFieldInterface.prop.propEnumArray";
+    m_service->publish(topic, nlohmann::json(propEnumArray).dump());
+}
+void StructArrayFieldInterfaceService::onPropIntArrayChanged(const StructWithArrayOfInts& propIntArray)
+{
+    static const std::string topic = "tb.struct.array.StructArrayFieldInterface.prop.propIntArray";
+    m_service->publish(topic, nlohmann::json(propIntArray).dump());
+}
+void StructArrayFieldInterfaceService::onPropMixedChanged(const MixedStruct& propMixed)
+{
+    static const std::string topic = "tb.struct.array.StructArrayFieldInterface.prop.propMixed";
+    m_service->publish(topic, nlohmann::json(propMixed).dump());
+}
+std::string StructArrayFieldInterfaceService::onInvokeFuncMixed(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    const MixedStruct& paramMixed = json_args.at(0).get<MixedStruct>();
+    auto result = m_impl->funcMixed(paramMixed);
+    return nlohmann::json(result).dump();
+}
+std::string StructArrayFieldInterfaceService::onInvokeFuncStructArray(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    const StructWithArrayOfStructs& paramPoints = json_args.at(0).get<StructWithArrayOfStructs>();
+    auto result = m_impl->funcStructArray(paramPoints);
+    return nlohmann::json(result).dump();
+}

--- a/goldenmaster/modules/tb_struct_array/generated/nats/structarrayfieldinterfaceservice.h
+++ b/goldenmaster/modules/tb_struct_array/generated/nats/structarrayfieldinterfaceservice.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "tb_struct_array/generated/api/tb_struct_array.h"
+#include "tb_struct_array/generated/api/common.h"
+#include "apigear/nats/natsservice.h"
+#include "apigear/nats/natstypes.h"
+#include "apigear/nats/baseadapter.h"
+
+#include <atomic>
+
+namespace Test {
+namespace TbStructArray {
+namespace Nats {
+class TEST_TB_STRUCT_ARRAY_EXPORT StructArrayFieldInterfaceService : public IStructArrayFieldInterfaceSubscriber, public ApiGear::Nats::BaseAdapter,  public std::enable_shared_from_this<StructArrayFieldInterfaceService>
+{
+protected:
+    explicit StructArrayFieldInterfaceService(std::shared_ptr<IStructArrayFieldInterface> impl, std::shared_ptr<ApiGear::Nats::Service> service);
+public:
+    static std::shared_ptr<StructArrayFieldInterfaceService> create(std::shared_ptr<IStructArrayFieldInterface> impl, std::shared_ptr<ApiGear::Nats::Service> service);
+    virtual ~StructArrayFieldInterfaceService() override;
+    void init();
+
+    // IStructArrayFieldInterfaceSubscriber interface
+    void onSigMixed(const MixedStruct& paramMixed) override;
+    void onSigStructArray(const StructWithArrayOfStructs& paramPoints) override;
+
+private:
+    std::shared_ptr<ApiGear::Nats::BaseAdapter> getSharedFromDerrived() override;
+    void onConnected();
+    nlohmann::json getState();
+    void onPropStructArrayChanged(const StructWithArrayOfStructs& propStructArray) override;
+    /// @brief requests to set the value for the property PropStructArray coming from the client
+    /// @param fields contains the param of the type StructWithArrayOfStructs
+    void onSetPropStructArray(const std::string& args) const;
+    void onPropEnumArrayChanged(const StructWithArrayOfEnums& propEnumArray) override;
+    /// @brief requests to set the value for the property PropEnumArray coming from the client
+    /// @param fields contains the param of the type StructWithArrayOfEnums
+    void onSetPropEnumArray(const std::string& args) const;
+    void onPropIntArrayChanged(const StructWithArrayOfInts& propIntArray) override;
+    /// @brief requests to set the value for the property PropIntArray coming from the client
+    /// @param fields contains the param of the type StructWithArrayOfInts
+    void onSetPropIntArray(const std::string& args) const;
+    void onPropMixedChanged(const MixedStruct& propMixed) override;
+    /// @brief requests to set the value for the property PropMixed coming from the client
+    /// @param fields contains the param of the type MixedStruct
+    void onSetPropMixed(const std::string& args) const;
+    std::string onInvokeFuncMixed(const std::string& args) const;
+    std::string onInvokeFuncStructArray(const std::string& args) const;
+
+    std::shared_ptr<IStructArrayFieldInterface> m_impl;
+    std::shared_ptr<ApiGear::Nats::Service> m_service;
+
+    uint64_t m_onReadySubscriptionId = 0;
+    std::atomic<bool> m_initialized{false};
+
+};
+} // namespace Nats
+} // namespace TbStructArray
+} // namespace Test

--- a/goldenmaster/modules/tb_struct_array/generated/nats/tests/CMakeLists.txt
+++ b/goldenmaster/modules/tb_struct_array/generated/nats/tests/CMakeLists.txt
@@ -1,0 +1,44 @@
+
+cmake_minimum_required(VERSION 3.24)
+project(test_tb_struct_array_generated_nats)
+
+set(SPDLOG_DEBUG_ON true)
+set(SPDLOG_TRACE_ON true)
+include(CTest)
+
+enable_testing()
+find_package(apigear OPTIONAL_COMPONENTS nats)
+find_package(tb_struct_array QUIET COMPONENTS tb_struct_array-implementation  tb_struct_array-core tb_struct_array-nats)
+
+find_package(Catch2 REQUIRED)
+
+set(TEST_TB_STRUCT_ARRAY_GENERATED_NATS_SOURCES
+    test_main.cpp
+    test_structarrayfieldinterface.cpp
+    )
+
+
+include_directories(test_tb_struct_array_generated_nats
+    PRIVATE
+    $<BUILD_INTERFACE:${MODULES_DIR}>
+)
+
+add_executable(test_tb_struct_array_generated_nats ${TEST_TB_STRUCT_ARRAY_GENERATED_NATS_SOURCES})
+add_test(NAME test_tb_struct_array_generated_nats COMMAND $<TARGET_FILE:test_tb_struct_array_generated_nats>)
+
+target_link_libraries(test_tb_struct_array_generated_nats PRIVATE
+    apigear::nats
+    tb_struct_array-implementation
+    tb_struct_array-core
+    tb_struct_array-nats
+    Catch2::Catch2)
+
+list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
+include(Catch)
+
+install(TARGETS test_tb_struct_array_generated_nats
+    RUNTIME DESTINATION "${INSTALL_EXAMPLEDIR}"
+    BUNDLE DESTINATION "${INSTALL_EXAMPLEDIR}"
+    LIBRARY DESTINATION "${INSTALL_EXAMPLEDIR}"
+)
+

--- a/goldenmaster/modules/tb_struct_array/generated/nats/tests/test_main.cpp
+++ b/goldenmaster/modules/tb_struct_array/generated/nats/tests/test_main.cpp
@@ -1,0 +1,7 @@
+#if defined(__clang__)
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif // __clang__
+
+#define CATCH_CONFIG_MAIN
+
+#include <catch2/catch.hpp>

--- a/goldenmaster/modules/tb_struct_array/generated/nats/tests/test_structarrayfieldinterface.cpp
+++ b/goldenmaster/modules/tb_struct_array/generated/nats/tests/test_structarrayfieldinterface.cpp
@@ -1,0 +1,232 @@
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include "tb_struct_array/generated/core/test_struct_helper.h"
+#include "tb_struct_array/implementation/structarrayfieldinterface.h"
+#include "tb_struct_array/generated/nats/structarrayfieldinterfaceclient.h"
+#include "tb_struct_array/generated/nats/structarrayfieldinterfaceservice.h"
+
+
+#include "apigear/nats/natsclient.h"
+#include "apigear/nats/natsservice.h"
+
+// Those tests require an external nats server, interface adapters for both client and service object side, are clients from Nats protocol pov.
+// Before running tests make sure that the server of your choice is running.
+
+namespace{
+
+    int timeout = 1000;//in ms
+}
+using namespace Test;
+using namespace Test::TbStructArray;
+
+TEST_CASE("Nats  tb.struct.array StructArrayFieldInterface tests")
+{
+    auto service = std::make_shared<ApiGear::Nats::Service>();
+
+    auto client = std::make_shared<ApiGear::Nats::Client>();
+    service->connect("nats://localhost:4222");
+    client->connect("nats://localhost:4222");
+
+    std::condition_variable m_wait;
+    std::mutex m_waitMutex;
+    std::unique_lock<std::mutex> lock(m_waitMutex, std::defer_lock);
+
+    auto implStructArrayFieldInterface = std::make_shared<Test::TbStructArray::StructArrayFieldInterface>();
+    auto serviceStructArrayFieldInterface = Nats::StructArrayFieldInterfaceService::create(implStructArrayFieldInterface, service);
+    lock.lock();
+    REQUIRE(m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [serviceStructArrayFieldInterface]() {return  serviceStructArrayFieldInterface->_is_ready();}));
+    lock.unlock();
+    service->flush();
+
+    auto clientStructArrayFieldInterface = Nats::StructArrayFieldInterfaceClient::create(client);
+    lock.lock();
+    REQUIRE(m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [clientStructArrayFieldInterface]() {return clientStructArrayFieldInterface->_is_ready(); }));
+    lock.unlock();
+    client->flush();
+    SECTION("Test setting propStructArray")
+    {
+        std::atomic<bool> ispropStructArrayChanged = false;
+        clientStructArrayFieldInterface->_getPublisher().subscribeToPropStructArrayChanged(
+        [&ispropStructArrayChanged, &m_wait ](auto value){
+            ispropStructArrayChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = TbStructArray::StructWithArrayOfStructs();
+        TbStructArray::fillTestStructWithArrayOfStructs(test_value);
+        clientStructArrayFieldInterface->setPropStructArray(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropStructArrayChanged]() {return ispropStructArrayChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArrayFieldInterface->getPropStructArray() == test_value);
+        REQUIRE(clientStructArrayFieldInterface->getPropStructArray() == test_value);
+    }
+    SECTION("Test setting propEnumArray")
+    {
+        std::atomic<bool> ispropEnumArrayChanged = false;
+        clientStructArrayFieldInterface->_getPublisher().subscribeToPropEnumArrayChanged(
+        [&ispropEnumArrayChanged, &m_wait ](auto value){
+            ispropEnumArrayChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = TbStructArray::StructWithArrayOfEnums();
+        TbStructArray::fillTestStructWithArrayOfEnums(test_value);
+        clientStructArrayFieldInterface->setPropEnumArray(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropEnumArrayChanged]() {return ispropEnumArrayChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArrayFieldInterface->getPropEnumArray() == test_value);
+        REQUIRE(clientStructArrayFieldInterface->getPropEnumArray() == test_value);
+    }
+    SECTION("Test setting propIntArray")
+    {
+        std::atomic<bool> ispropIntArrayChanged = false;
+        clientStructArrayFieldInterface->_getPublisher().subscribeToPropIntArrayChanged(
+        [&ispropIntArrayChanged, &m_wait ](auto value){
+            ispropIntArrayChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = TbStructArray::StructWithArrayOfInts();
+        TbStructArray::fillTestStructWithArrayOfInts(test_value);
+        clientStructArrayFieldInterface->setPropIntArray(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropIntArrayChanged]() {return ispropIntArrayChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArrayFieldInterface->getPropIntArray() == test_value);
+        REQUIRE(clientStructArrayFieldInterface->getPropIntArray() == test_value);
+    }
+    SECTION("Test setting propMixed")
+    {
+        std::atomic<bool> ispropMixedChanged = false;
+        clientStructArrayFieldInterface->_getPublisher().subscribeToPropMixedChanged(
+        [&ispropMixedChanged, &m_wait ](auto value){
+            ispropMixedChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = TbStructArray::MixedStruct();
+        TbStructArray::fillTestMixedStruct(test_value);
+        clientStructArrayFieldInterface->setPropMixed(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropMixedChanged]() {return ispropMixedChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArrayFieldInterface->getPropMixed() == test_value);
+        REQUIRE(clientStructArrayFieldInterface->getPropMixed() == test_value);
+    }
+    SECTION("Test emit sigMixed")
+    {
+        std::atomic<bool> issigMixedEmitted = false;
+        auto local_param_mixed_struct = TbStructArray::MixedStruct();
+        TbStructArray::fillTestMixedStruct(local_param_mixed_struct);
+
+        clientStructArrayFieldInterface->_getPublisher().subscribeToSigMixed(
+        [&m_wait, &issigMixedEmitted, &local_param_mixed_struct](const TbStructArray::MixedStruct& paramMixed)
+        {
+            REQUIRE(paramMixed ==local_param_mixed_struct);
+            issigMixedEmitted  = true;
+            m_wait.notify_all();
+        });
+
+         implStructArrayFieldInterface->_getPublisher().publishSigMixed(local_param_mixed_struct);
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&issigMixedEmitted ]() {return issigMixedEmitted   == true; }));
+        lock.unlock();
+    }
+    SECTION("Test emit sigStructArray")
+    {
+        std::atomic<bool> issigStructArrayEmitted = false;
+        auto local_param_points_struct = TbStructArray::StructWithArrayOfStructs();
+        TbStructArray::fillTestStructWithArrayOfStructs(local_param_points_struct);
+
+        clientStructArrayFieldInterface->_getPublisher().subscribeToSigStructArray(
+        [&m_wait, &issigStructArrayEmitted, &local_param_points_struct](const TbStructArray::StructWithArrayOfStructs& paramPoints)
+        {
+            REQUIRE(paramPoints ==local_param_points_struct);
+            issigStructArrayEmitted  = true;
+            m_wait.notify_all();
+        });
+
+         implStructArrayFieldInterface->_getPublisher().publishSigStructArray(local_param_points_struct);
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&issigStructArrayEmitted ]() {return issigStructArrayEmitted   == true; }));
+        lock.unlock();
+    }
+    SECTION("Test method funcMixed")
+    {
+        [[maybe_unused]] auto result = clientStructArrayFieldInterface->funcMixed(TbStructArray::MixedStruct());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcMixed async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArrayFieldInterface->funcMixedAsync(TbStructArray::MixedStruct());
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == TbStructArray::MixedStruct()); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcMixed async with callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArrayFieldInterface->funcMixedAsync(TbStructArray::MixedStruct(),
+            [&finished, &m_wait](MixedStruct value)
+            {
+                REQUIRE(value == TbStructArray::MixedStruct());
+                finished = true;
+                m_wait.notify_all();
+                /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */
+            });
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+
+        resultFuture.wait();
+    }
+    SECTION("Test method funcStructArray")
+    {
+        [[maybe_unused]] auto result = clientStructArrayFieldInterface->funcStructArray(TbStructArray::StructWithArrayOfStructs());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcStructArray async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArrayFieldInterface->funcStructArrayAsync(TbStructArray::StructWithArrayOfStructs());
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == TbStructArray::StructWithArrayOfStructs()); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcStructArray async with callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArrayFieldInterface->funcStructArrayAsync(TbStructArray::StructWithArrayOfStructs(),
+            [&finished, &m_wait](StructWithArrayOfStructs value)
+            {
+                REQUIRE(value == TbStructArray::StructWithArrayOfStructs());
+                finished = true;
+                m_wait.notify_all();
+                /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */
+            });
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+
+        resultFuture.wait();
+    }
+
+    serviceStructArrayFieldInterface.reset();
+    clientStructArrayFieldInterface.reset();
+    client->disconnect();
+    service->disconnect();
+    client.reset();
+    service.reset();
+}

--- a/goldenmaster/modules/tb_struct_array/generated/olink/CMakeLists.txt
+++ b/goldenmaster/modules/tb_struct_array/generated/olink/CMakeLists.txt
@@ -1,0 +1,48 @@
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(apigear REQUIRED COMPONENTS poco-olink)
+set (SOURCES_OLINK
+    structarrayfieldinterfaceservice.cpp
+    structarrayfieldinterfaceclient.cpp
+)
+add_library(tb_struct_array-olink SHARED ${SOURCES_OLINK})
+add_library(tb_struct_array::tb_struct_array-olink ALIAS tb_struct_array-olink)
+target_include_directories(tb_struct_array-olink
+    PUBLIC
+    $<BUILD_INTERFACE:${MODULES_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(tb_struct_array-olink
+    PRIVATE
+    tb_struct_array::tb_struct_array-core
+    PUBLIC
+    apigear::poco-olink
+)
+
+# ensure maximum compiler support
+if(NOT MSVC)
+  target_compile_options(tb_struct_array-olink PRIVATE -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wnon-virtual-dtor -Woverloaded-virtual -Wcast-align -Werror -fvisibility=hidden)
+else()
+  target_compile_options(tb_struct_array-olink PRIVATE /W4 /WX /wd4251)
+endif()
+
+install(TARGETS tb_struct_array-olink
+        EXPORT Tb_struct_arrayOLinkTargets)
+# install includes
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} DESTINATION include/tb_struct_array/generated FILES_MATCHING PATTERN "*.h")
+
+export(EXPORT Tb_struct_arrayOLinkTargets
+  NAMESPACE tb_struct_array::
+)
+
+install(EXPORT Tb_struct_arrayOLinkTargets
+  FILE Tb_struct_arrayOLinkTargets.cmake
+  DESTINATION ${InstallDir}
+  NAMESPACE tb_struct_array::
+)
+
+if(BUILD_TESTING)
+enable_testing()
+add_subdirectory(tests)
+endif()

--- a/goldenmaster/modules/tb_struct_array/generated/olink/structarrayfieldinterfaceclient.cpp
+++ b/goldenmaster/modules/tb_struct_array/generated/olink/structarrayfieldinterfaceclient.cpp
@@ -1,0 +1,263 @@
+
+
+#include "tb_struct_array/generated/olink/structarrayfieldinterfaceclient.h"
+#include "tb_struct_array/generated/core/structarrayfieldinterface.publisher.h"
+#include "tb_struct_array/generated/core/tb_struct_array.json.adapter.h"
+
+THIRD_PARTY_INCLUDES_START
+#include "olink/iclientnode.h"
+THIRD_PARTY_INCLUDES_END
+#include "apigear/utilities/logger.h"
+
+using namespace Test::TbStructArray;
+using namespace Test::TbStructArray::olink;
+
+namespace 
+{
+const std::string interfaceId = "tb.struct.array.StructArrayFieldInterface";
+}
+
+StructArrayFieldInterfaceClient::StructArrayFieldInterfaceClient()
+    : m_publisher(std::make_unique<StructArrayFieldInterfacePublisher>())
+{}
+
+void StructArrayFieldInterfaceClient::applyState(const nlohmann::json& fields) 
+{
+    if(fields.contains("propStructArray")) {
+        setPropStructArrayLocal(fields["propStructArray"].get<StructWithArrayOfStructs>());
+    }
+    if(fields.contains("propEnumArray")) {
+        setPropEnumArrayLocal(fields["propEnumArray"].get<StructWithArrayOfEnums>());
+    }
+    if(fields.contains("propIntArray")) {
+        setPropIntArrayLocal(fields["propIntArray"].get<StructWithArrayOfInts>());
+    }
+    if(fields.contains("propMixed")) {
+        setPropMixedLocal(fields["propMixed"].get<MixedStruct>());
+    }
+}
+
+void StructArrayFieldInterfaceClient::applyProperty(const std::string& propertyName, const nlohmann::json& value)
+{
+    if ( propertyName == "propStructArray") {
+        setPropStructArrayLocal(value.get<StructWithArrayOfStructs>());
+    }
+    else if ( propertyName == "propEnumArray") {
+        setPropEnumArrayLocal(value.get<StructWithArrayOfEnums>());
+    }
+    else if ( propertyName == "propIntArray") {
+        setPropIntArrayLocal(value.get<StructWithArrayOfInts>());
+    }
+    else if ( propertyName == "propMixed") {
+        setPropMixedLocal(value.get<MixedStruct>());
+    }
+}
+
+void StructArrayFieldInterfaceClient::setPropStructArray(const StructWithArrayOfStructs& propStructArray)
+{
+    if(!m_node) {
+        AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return;
+    }
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propStructArray");
+    m_node->setRemoteProperty(propertyId, propStructArray);
+}
+
+void StructArrayFieldInterfaceClient::setPropStructArrayLocal(const StructWithArrayOfStructs& propStructArray)
+{
+    {
+        std::unique_lock<std::shared_timed_mutex> lock(m_propStructArrayMutex);
+        if (m_data.m_propStructArray == propStructArray) {
+            return;
+        }
+        m_data.m_propStructArray = propStructArray;
+    }
+
+    m_publisher->publishPropStructArrayChanged(propStructArray);
+}
+
+const StructWithArrayOfStructs& StructArrayFieldInterfaceClient::getPropStructArray() const
+{
+    std::shared_lock<std::shared_timed_mutex> lock(m_propStructArrayMutex);
+    return m_data.m_propStructArray;
+}
+
+void StructArrayFieldInterfaceClient::setPropEnumArray(const StructWithArrayOfEnums& propEnumArray)
+{
+    if(!m_node) {
+        AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return;
+    }
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propEnumArray");
+    m_node->setRemoteProperty(propertyId, propEnumArray);
+}
+
+void StructArrayFieldInterfaceClient::setPropEnumArrayLocal(const StructWithArrayOfEnums& propEnumArray)
+{
+    {
+        std::unique_lock<std::shared_timed_mutex> lock(m_propEnumArrayMutex);
+        if (m_data.m_propEnumArray == propEnumArray) {
+            return;
+        }
+        m_data.m_propEnumArray = propEnumArray;
+    }
+
+    m_publisher->publishPropEnumArrayChanged(propEnumArray);
+}
+
+const StructWithArrayOfEnums& StructArrayFieldInterfaceClient::getPropEnumArray() const
+{
+    std::shared_lock<std::shared_timed_mutex> lock(m_propEnumArrayMutex);
+    return m_data.m_propEnumArray;
+}
+
+void StructArrayFieldInterfaceClient::setPropIntArray(const StructWithArrayOfInts& propIntArray)
+{
+    if(!m_node) {
+        AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return;
+    }
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propIntArray");
+    m_node->setRemoteProperty(propertyId, propIntArray);
+}
+
+void StructArrayFieldInterfaceClient::setPropIntArrayLocal(const StructWithArrayOfInts& propIntArray)
+{
+    {
+        std::unique_lock<std::shared_timed_mutex> lock(m_propIntArrayMutex);
+        if (m_data.m_propIntArray == propIntArray) {
+            return;
+        }
+        m_data.m_propIntArray = propIntArray;
+    }
+
+    m_publisher->publishPropIntArrayChanged(propIntArray);
+}
+
+const StructWithArrayOfInts& StructArrayFieldInterfaceClient::getPropIntArray() const
+{
+    std::shared_lock<std::shared_timed_mutex> lock(m_propIntArrayMutex);
+    return m_data.m_propIntArray;
+}
+
+void StructArrayFieldInterfaceClient::setPropMixed(const MixedStruct& propMixed)
+{
+    if(!m_node) {
+        AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return;
+    }
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propMixed");
+    m_node->setRemoteProperty(propertyId, propMixed);
+}
+
+void StructArrayFieldInterfaceClient::setPropMixedLocal(const MixedStruct& propMixed)
+{
+    {
+        std::unique_lock<std::shared_timed_mutex> lock(m_propMixedMutex);
+        if (m_data.m_propMixed == propMixed) {
+            return;
+        }
+        m_data.m_propMixed = propMixed;
+    }
+
+    m_publisher->publishPropMixedChanged(propMixed);
+}
+
+const MixedStruct& StructArrayFieldInterfaceClient::getPropMixed() const
+{
+    std::shared_lock<std::shared_timed_mutex> lock(m_propMixedMutex);
+    return m_data.m_propMixed;
+}
+
+MixedStruct StructArrayFieldInterfaceClient::funcMixed(const MixedStruct& paramMixed)
+{
+    return funcMixedAsync(paramMixed).get();
+}
+
+std::future<MixedStruct> StructArrayFieldInterfaceClient::funcMixedAsync(const MixedStruct& paramMixed, std::function<void(MixedStruct)> callback)
+{
+    if(!m_node) {
+        AG_LOG_WARNING("Attempt to invoke method but" + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return std::future<MixedStruct>{};
+    }
+    std::shared_ptr<std::promise<MixedStruct>> resultPromise = std::make_shared<std::promise<MixedStruct>>();
+    static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcMixed");
+    m_node->invokeRemote(operationId,
+        nlohmann::json::array({paramMixed}), [resultPromise, callback](ApiGear::ObjectLink::InvokeReplyArg arg) {
+            const MixedStruct& value = arg.value.get<MixedStruct>();
+            resultPromise->set_value(value);
+            if (callback)
+            {
+                callback(value);
+            }
+        });
+    return resultPromise->get_future();
+}
+
+StructWithArrayOfStructs StructArrayFieldInterfaceClient::funcStructArray(const StructWithArrayOfStructs& paramPoints)
+{
+    return funcStructArrayAsync(paramPoints).get();
+}
+
+std::future<StructWithArrayOfStructs> StructArrayFieldInterfaceClient::funcStructArrayAsync(const StructWithArrayOfStructs& paramPoints, std::function<void(StructWithArrayOfStructs)> callback)
+{
+    if(!m_node) {
+        AG_LOG_WARNING("Attempt to invoke method but" + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return std::future<StructWithArrayOfStructs>{};
+    }
+    std::shared_ptr<std::promise<StructWithArrayOfStructs>> resultPromise = std::make_shared<std::promise<StructWithArrayOfStructs>>();
+    static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcStructArray");
+    m_node->invokeRemote(operationId,
+        nlohmann::json::array({paramPoints}), [resultPromise, callback](ApiGear::ObjectLink::InvokeReplyArg arg) {
+            const StructWithArrayOfStructs& value = arg.value.get<StructWithArrayOfStructs>();
+            resultPromise->set_value(value);
+            if (callback)
+            {
+                callback(value);
+            }
+        });
+    return resultPromise->get_future();
+}
+
+std::string StructArrayFieldInterfaceClient::olinkObjectName()
+{
+    return interfaceId;
+}
+
+void StructArrayFieldInterfaceClient::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
+{
+    const auto& signalName = ApiGear::ObjectLink::Name::getMemberName(signalId);
+    if(signalName == "sigMixed") {
+        m_publisher->publishSigMixed(args[0].get<MixedStruct>());   
+        return;
+    }
+    if(signalName == "sigStructArray") {
+        m_publisher->publishSigStructArray(args[0].get<StructWithArrayOfStructs>());   
+        return;
+    }
+}
+
+void StructArrayFieldInterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
+{
+    applyProperty(ApiGear::ObjectLink::Name::getMemberName(propertyId), value);
+}
+void StructArrayFieldInterfaceClient::olinkOnInit(const std::string& /*name*/, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node)
+{
+    m_node = node;
+    applyState(props);
+}
+
+void StructArrayFieldInterfaceClient::olinkOnRelease()
+{
+    m_node = nullptr;
+}
+
+bool StructArrayFieldInterfaceClient::isReady() const
+{
+    return m_node != nullptr;
+}
+
+IStructArrayFieldInterfacePublisher& StructArrayFieldInterfaceClient::_getPublisher() const
+{
+    return *m_publisher;
+}

--- a/goldenmaster/modules/tb_struct_array/generated/olink/structarrayfieldinterfaceclient.h
+++ b/goldenmaster/modules/tb_struct_array/generated/olink/structarrayfieldinterfaceclient.h
@@ -1,0 +1,193 @@
+
+#pragma once
+
+#include "tb_struct_array/generated/api/common.h"
+#include "tb_struct_array/generated/api/tb_struct_array.h"
+#include "tb_struct_array/generated/core/structarrayfieldinterface.data.h"
+
+THIRD_PARTY_INCLUDES_START
+#include "olink/iobjectsink.h"
+THIRD_PARTY_INCLUDES_END
+
+#include <future>
+#include <shared_mutex>
+#include <memory>
+
+namespace ApiGear{
+namespace ObjectLink{
+class IClientNode;
+}
+}
+
+namespace Test {
+namespace TbStructArray {
+namespace olink {
+/**
+* Adapts the general OLink Client handler to a StructArrayFieldInterface publisher in a way it provides access 
+* to remote StructArrayFieldInterface services. 
+* Sends and receives data over the network with ObjectLink protocol, through the communication node. 
+* see https://objectlinkprotocol.net for ObjectLink details.
+* see https://github.com/apigear-io/objectlink-core-cpp.git for olink client node - abstraction over the network.
+* see Apigear::ObjectLink::OLinkConnection for Olink Client Handler implementation.
+*     It provides a network implementation and tools to connect StructArrayFieldInterfaceClient to it.
+* Use on client side to request changes of the StructArrayFieldInterface on the server side
+* and to subscribe for the StructArrayFieldInterface changes.
+*
+* @note Threading: property-change and signal callbacks arrive on the OLink network thread.
+* Properties are individually guarded by shared_timed_mutex (concurrent reads allowed,
+* exclusive writes). Operation calls are not synchronized by this adapter.
+*/
+class TEST_TB_STRUCT_ARRAY_EXPORT StructArrayFieldInterfaceClient : public IStructArrayFieldInterface,
+    public ApiGear::ObjectLink::IObjectSink
+{
+public:
+
+    /** ctor */
+    explicit StructArrayFieldInterfaceClient();
+    /** dtor */
+    virtual ~StructArrayFieldInterfaceClient() = default;
+    /**
+    * Property getter
+    * @return Locally stored locally value for PropStructArray.
+    */
+    const StructWithArrayOfStructs& getPropStructArray() const override;
+    /**
+    * Request setting a property on the StructArrayFieldInterface service.
+    * @param The value to which set request is send for the PropStructArray.
+    */
+    void setPropStructArray(const StructWithArrayOfStructs& propStructArray) override;
+    /**
+    * Property getter
+    * @return Locally stored locally value for PropEnumArray.
+    */
+    const StructWithArrayOfEnums& getPropEnumArray() const override;
+    /**
+    * Request setting a property on the StructArrayFieldInterface service.
+    * @param The value to which set request is send for the PropEnumArray.
+    */
+    void setPropEnumArray(const StructWithArrayOfEnums& propEnumArray) override;
+    /**
+    * Property getter
+    * @return Locally stored locally value for PropIntArray.
+    */
+    const StructWithArrayOfInts& getPropIntArray() const override;
+    /**
+    * Request setting a property on the StructArrayFieldInterface service.
+    * @param The value to which set request is send for the PropIntArray.
+    */
+    void setPropIntArray(const StructWithArrayOfInts& propIntArray) override;
+    /**
+    * Property getter
+    * @return Locally stored locally value for PropMixed.
+    */
+    const MixedStruct& getPropMixed() const override;
+    /**
+    * Request setting a property on the StructArrayFieldInterface service.
+    * @param The value to which set request is send for the PropMixed.
+    */
+    void setPropMixed(const MixedStruct& propMixed) override;
+    /**
+    * Remote call of IStructArrayFieldInterface::funcMixed on the StructArrayFieldInterface service.
+    * Uses funcMixedAsync
+    */
+    MixedStruct funcMixed(const MixedStruct& paramMixed) override;
+    /**
+    * Remote call of IStructArrayFieldInterface::funcMixed on the StructArrayFieldInterface service.
+    */
+    std::future<MixedStruct> funcMixedAsync(const MixedStruct& paramMixed, std::function<void(MixedStruct)> callback = nullptr) override;
+    /**
+    * Remote call of IStructArrayFieldInterface::funcStructArray on the StructArrayFieldInterface service.
+    * Uses funcStructArrayAsync
+    */
+    StructWithArrayOfStructs funcStructArray(const StructWithArrayOfStructs& paramPoints) override;
+    /**
+    * Remote call of IStructArrayFieldInterface::funcStructArray on the StructArrayFieldInterface service.
+    */
+    std::future<StructWithArrayOfStructs> funcStructArrayAsync(const StructWithArrayOfStructs& paramPoints, std::function<void(StructWithArrayOfStructs)> callback = nullptr) override;
+
+    /** The publisher to subscribe to. */
+    IStructArrayFieldInterfacePublisher& _getPublisher() const override;
+    
+    /**
+    * Informs if the StructArrayFieldInterfaceClient is ready to send and receive messages.
+    * @return true if StructArrayFieldInterface is operable, false otherwise.
+    */
+    bool isReady() const;
+
+    /**
+    * The name of the object for which this sink is created, object on server side has to have the same name.
+    * It serves as an identifier for the client registry, it has to be unique for the pair sink object - client node.
+    * Passed in the olink messages as an object identifier.
+    */
+    std::string olinkObjectName() override;
+    
+    /**
+    * Information about signal emission on a server side to all subscribers.
+    * @param signalId Unique identifier for the signal emitted from object.
+    * @param args The arguments for the signal.
+    */
+    void olinkOnSignal(const std::string& signalId, const nlohmann::json& args) override;
+    
+    /**
+    * Applies the information about the property changed on server side.
+    * @param propertyId Unique identifier of a changed property in object .
+    * @param value The value of the property.
+    */
+    void olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value) override;
+    
+    /** Informs this object sink that connection was is established.
+    * @param interfaceId The name of the object for which link was established.
+    * @param props Initial values obtained from the StructArrayFieldInterface service
+    * @param the initialized link endpoint for this sink.
+    */
+    void olinkOnInit(const std::string& interfaceId, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node) override;
+    /**
+    * Informs this object source that the link was disconnected and cannot be used anymore.
+    */
+    void olinkOnRelease() override;
+
+private:
+    /**
+    * Applies received data to local state and publishes changes to subscribers.
+    * @param the data received from StructArrayFieldInterface service.
+    */
+    void applyState(const nlohmann::json& fields);
+    /**
+    * Applies received property value to local state and publishes changes to subscribers.
+    * @param propertyName the name of property to be changed.
+    * @param value The value for property.
+    */
+    void applyProperty(const std::string& propertyName, const nlohmann::json& value);
+    /**  Updates local value for PropStructArray and informs subscriber about the change*/
+    void setPropStructArrayLocal(const StructWithArrayOfStructs& propStructArray);
+    /* Mutex for propStructArray property */
+    mutable std::shared_timed_mutex m_propStructArrayMutex;
+    /**  Updates local value for PropEnumArray and informs subscriber about the change*/
+    void setPropEnumArrayLocal(const StructWithArrayOfEnums& propEnumArray);
+    /* Mutex for propEnumArray property */
+    mutable std::shared_timed_mutex m_propEnumArrayMutex;
+    /**  Updates local value for PropIntArray and informs subscriber about the change*/
+    void setPropIntArrayLocal(const StructWithArrayOfInts& propIntArray);
+    /* Mutex for propIntArray property */
+    mutable std::shared_timed_mutex m_propIntArrayMutex;
+    /**  Updates local value for PropMixed and informs subscriber about the change*/
+    void setPropMixedLocal(const MixedStruct& propMixed);
+    /* Mutex for propMixed property */
+    mutable std::shared_timed_mutex m_propMixedMutex;
+
+    /** Local storage for properties values. */
+    StructArrayFieldInterfaceData m_data;
+
+    /** 
+    * An abstraction layer over the connection with service for the StructArrayFieldInterfaceClient.
+    * Handles incoming and outgoing messages.
+    * Is given when object is linked with the service.
+    */
+    ApiGear::ObjectLink::IClientNode* m_node = nullptr;
+
+    /** The publisher for StructArrayFieldInterface */
+    std::unique_ptr<IStructArrayFieldInterfacePublisher> m_publisher;
+};
+} // namespace olink
+} // namespace TbStructArray
+} // namespace Test

--- a/goldenmaster/modules/tb_struct_array/generated/olink/structarrayfieldinterfaceservice.cpp
+++ b/goldenmaster/modules/tb_struct_array/generated/olink/structarrayfieldinterfaceservice.cpp
@@ -1,0 +1,162 @@
+
+
+#include "tb_struct_array/generated/api/datastructs.api.h"
+#include "tb_struct_array/generated/olink/structarrayfieldinterfaceservice.h"
+#include "tb_struct_array/generated/core/tb_struct_array.json.adapter.h"
+
+THIRD_PARTY_INCLUDES_START
+#include "olink/iremotenode.h"
+#include "olink/remoteregistry.h"
+THIRD_PARTY_INCLUDES_END
+#include "apigear/utilities/logger.h"
+
+#include <iostream>
+
+
+using namespace Test::TbStructArray;
+using namespace Test::TbStructArray::olink;
+
+namespace 
+{
+const std::string interfaceId = "tb.struct.array.StructArrayFieldInterface";
+}
+
+StructArrayFieldInterfaceService::StructArrayFieldInterfaceService(std::shared_ptr<IStructArrayFieldInterface> StructArrayFieldInterface, ApiGear::ObjectLink::RemoteRegistry& registry)
+    : m_StructArrayFieldInterface(StructArrayFieldInterface)
+    , m_registry(registry)
+{
+    m_StructArrayFieldInterface->_getPublisher().subscribeToAllChanges(*this);
+}
+
+StructArrayFieldInterfaceService::~StructArrayFieldInterfaceService()
+{
+    m_StructArrayFieldInterface->_getPublisher().unsubscribeFromAllChanges(*this);
+}
+
+std::string StructArrayFieldInterfaceService::olinkObjectName() {
+    return interfaceId;
+}
+
+nlohmann::json StructArrayFieldInterfaceService::olinkInvoke(const std::string& methodId, const nlohmann::json& fcnArgs) {
+    AG_LOG_DEBUG("StructArrayFieldInterfaceService invoke " + methodId);
+    const auto& memberMethod = ApiGear::ObjectLink::Name::getMemberName(methodId);
+    if(memberMethod == "funcMixed") {
+        const MixedStruct& paramMixed = fcnArgs.at(0);
+        MixedStruct result = m_StructArrayFieldInterface->funcMixed(paramMixed);
+        return result;
+    }
+    if(memberMethod == "funcStructArray") {
+        const StructWithArrayOfStructs& paramPoints = fcnArgs.at(0);
+        StructWithArrayOfStructs result = m_StructArrayFieldInterface->funcStructArray(paramPoints);
+        return result;
+    }
+    return nlohmann::json();
+}
+
+void StructArrayFieldInterfaceService::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) {
+    AG_LOG_DEBUG("StructArrayFieldInterfaceService set property " + propertyId);
+    const auto& memberProperty = ApiGear::ObjectLink::Name::getMemberName(propertyId);
+    if(memberProperty == "propStructArray") {
+        StructWithArrayOfStructs propStructArray = value.get<StructWithArrayOfStructs>();
+        m_StructArrayFieldInterface->setPropStructArray(propStructArray);
+    }
+    if(memberProperty == "propEnumArray") {
+        StructWithArrayOfEnums propEnumArray = value.get<StructWithArrayOfEnums>();
+        m_StructArrayFieldInterface->setPropEnumArray(propEnumArray);
+    }
+    if(memberProperty == "propIntArray") {
+        StructWithArrayOfInts propIntArray = value.get<StructWithArrayOfInts>();
+        m_StructArrayFieldInterface->setPropIntArray(propIntArray);
+    }
+    if(memberProperty == "propMixed") {
+        MixedStruct propMixed = value.get<MixedStruct>();
+        m_StructArrayFieldInterface->setPropMixed(propMixed);
+    } 
+}
+
+void StructArrayFieldInterfaceService::olinkLinked(const std::string& objectId, ApiGear::ObjectLink::IRemoteNode* /*node*/) {
+    AG_LOG_DEBUG("StructArrayFieldInterfaceService linked " + objectId);
+}
+
+void StructArrayFieldInterfaceService::olinkUnlinked(const std::string& objectId){
+    AG_LOG_DEBUG("StructArrayFieldInterfaceService unlinked " + objectId);
+}
+
+nlohmann::json StructArrayFieldInterfaceService::olinkCollectProperties()
+{
+    return nlohmann::json::object({
+        { "propStructArray", m_StructArrayFieldInterface->getPropStructArray() },
+        { "propEnumArray", m_StructArrayFieldInterface->getPropEnumArray() },
+        { "propIntArray", m_StructArrayFieldInterface->getPropIntArray() },
+        { "propMixed", m_StructArrayFieldInterface->getPropMixed() }
+    });
+}
+void StructArrayFieldInterfaceService::onSigMixed(const MixedStruct& paramMixed)
+{
+    const nlohmann::json args = { paramMixed };
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigMixed");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
+        auto lockedNode = node.lock();
+        if(lockedNode) {
+            lockedNode->notifySignal(signalId, args);
+        }
+    }
+}
+void StructArrayFieldInterfaceService::onSigStructArray(const StructWithArrayOfStructs& paramPoints)
+{
+    const nlohmann::json args = { paramPoints };
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigStructArray");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
+        auto lockedNode = node.lock();
+        if(lockedNode) {
+            lockedNode->notifySignal(signalId, args);
+        }
+    }
+}
+void StructArrayFieldInterfaceService::onPropStructArrayChanged(const StructWithArrayOfStructs& propStructArray)
+{
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propStructArray");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
+        auto lockedNode = node.lock();
+        if(lockedNode) {
+            lockedNode->notifyPropertyChange(propertyId, propStructArray);
+        }
+    }
+}
+void StructArrayFieldInterfaceService::onPropEnumArrayChanged(const StructWithArrayOfEnums& propEnumArray)
+{
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propEnumArray");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
+        auto lockedNode = node.lock();
+        if(lockedNode) {
+            lockedNode->notifyPropertyChange(propertyId, propEnumArray);
+        }
+    }
+}
+void StructArrayFieldInterfaceService::onPropIntArrayChanged(const StructWithArrayOfInts& propIntArray)
+{
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propIntArray");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
+        auto lockedNode = node.lock();
+        if(lockedNode) {
+            lockedNode->notifyPropertyChange(propertyId, propIntArray);
+        }
+    }
+}
+void StructArrayFieldInterfaceService::onPropMixedChanged(const MixedStruct& propMixed)
+{
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propMixed");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
+        auto lockedNode = node.lock();
+        if(lockedNode) {
+            lockedNode->notifyPropertyChange(propertyId, propMixed);
+        }
+    }
+}
+

--- a/goldenmaster/modules/tb_struct_array/generated/olink/structarrayfieldinterfaceservice.h
+++ b/goldenmaster/modules/tb_struct_array/generated/olink/structarrayfieldinterfaceservice.h
@@ -1,0 +1,111 @@
+
+#pragma once
+
+#include "tb_struct_array/generated/api/tb_struct_array.h"
+#include "tb_struct_array/generated/api/common.h"
+THIRD_PARTY_INCLUDES_START
+#include "olink/iobjectsource.h"
+THIRD_PARTY_INCLUDES_END
+
+
+namespace ApiGear {
+namespace ObjectLink {
+
+class RemoteRegistry;
+class IRemoteNode;
+
+}} //namespace ApiGear::ObjectLink
+
+namespace Test {
+namespace TbStructArray {
+namespace olink {
+/**
+* Server side for StructArrayFieldInterface implements the StructArrayFieldInterface service.
+* It is a source of data for StructArrayFieldInterface clients.
+* Sends and receives data over the network with ObjectLink protocol. 
+* see https://objectlinkprotocol.net for Object Link Details
+*/
+class TEST_TB_STRUCT_ARRAY_EXPORT StructArrayFieldInterfaceService : public ApiGear::ObjectLink::IObjectSource, public IStructArrayFieldInterfaceSubscriber
+{
+public:
+    /**
+    * ctor
+    * @param StructArrayFieldInterface The service source object, the actual StructArrayFieldInterface object which is exposed for remote clients with olink.
+    * @param registry The global registry that keeps track of the object source services associated with network nodes.
+    */
+    explicit StructArrayFieldInterfaceService(std::shared_ptr<IStructArrayFieldInterface> StructArrayFieldInterface, ApiGear::ObjectLink::RemoteRegistry& registry);
+    virtual ~StructArrayFieldInterfaceService() override;
+
+    /**
+    * The name of the object for which this service is created, object on client side has to have the same name.
+    * It serves as an identifier for the source registry, it has to be unique for the pair source object - remote node.
+    * Passed in the olink messages as an object identifier.
+    */
+    std::string olinkObjectName() override;
+    /**
+    * Applies received method invocation with given arguments on the StructArrayFieldInterface object.
+    * @param name Path of the method to invoke. Contains object name and the method name.
+    * @param args Arguments required to invoke a method in json format.
+    * @return the result of the invoked method (if applicable) that needs to be sent back to the clients.
+    */
+    nlohmann::json olinkInvoke(const std::string& methodId, const nlohmann::json& args) override;
+    /**
+    * Applies received change property request to StructArrayFieldInterface object.
+    * @param name Path the property to change. Contains object name and the property name.
+    * @param args Value in json format requested to set for the property.
+    */
+    void olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) override;
+    /**
+    * Informs this service source that the link was established.
+    * @param name The name of the object for which link was established.
+    * @param the initialized link endpoint.
+    */
+    void olinkLinked(const std::string& objectId, ApiGear::ObjectLink::IRemoteNode *node) override;
+    /**
+    * Informs this service source that the link was disconnected and cannot be used anymore.
+    */
+    void olinkUnlinked(const std::string& objectId) override;
+
+    /**
+    * Gets the current state of StructArrayFieldInterface object.
+    * @return the set of properties with their current values for the StructArrayFieldInterface object in json format.
+    */
+    nlohmann::json olinkCollectProperties() override;
+    /**
+    * Forwards emitted sigMixed through network if the connection is established.
+    */
+    void onSigMixed(const MixedStruct& paramMixed) override;
+    /**
+    * Forwards emitted sigStructArray through network if the connection is established.
+    */
+    void onSigStructArray(const StructWithArrayOfStructs& paramPoints) override;
+    /**
+    * Forwards propStructArray change through network if the connection is established.
+    */
+    void onPropStructArrayChanged(const StructWithArrayOfStructs& propStructArray) override;
+    /**
+    * Forwards propEnumArray change through network if the connection is established.
+    */
+    void onPropEnumArrayChanged(const StructWithArrayOfEnums& propEnumArray) override;
+    /**
+    * Forwards propIntArray change through network if the connection is established.
+    */
+    void onPropIntArrayChanged(const StructWithArrayOfInts& propIntArray) override;
+    /**
+    * Forwards propMixed change through network if the connection is established.
+    */
+    void onPropMixedChanged(const MixedStruct& propMixed) override;
+
+private:
+    /**
+    * The StructArrayFieldInterface used for object source.
+    */
+    std::shared_ptr<IStructArrayFieldInterface> m_StructArrayFieldInterface;
+    /**
+    * A global registry that keeps track of object sources associated with their network layer nodes.
+    */
+    ApiGear::ObjectLink::RemoteRegistry& m_registry;
+};
+} // namespace olink
+} // namespace TbStructArray
+} // namespace Test

--- a/goldenmaster/modules/tb_struct_array/generated/olink/tests/CMakeLists.txt
+++ b/goldenmaster/modules/tb_struct_array/generated/olink/tests/CMakeLists.txt
@@ -1,0 +1,44 @@
+
+cmake_minimum_required(VERSION 3.24)
+project(test_tb_struct_array_generated_olink)
+
+set(SPDLOG_DEBUG_ON true)
+set(SPDLOG_TRACE_ON true)
+include(CTest)
+
+enable_testing()
+find_package(apigear OPTIONAL_COMPONENTS poco-olink)
+find_package(tb_struct_array QUIET COMPONENTS tb_struct_array-implementation  tb_struct_array-core tb_struct_array-olink)
+
+find_package(Catch2 REQUIRED)
+
+set(TEST_TB_STRUCT_ARRAY_GENERATED_OLINK_SOURCES
+    test_main.cpp
+    test_structarrayfieldinterface.cpp
+    )
+
+
+include_directories(test_tb_struct_array_generated_olink
+    PRIVATE
+    $<BUILD_INTERFACE:${MODULES_DIR}>
+)
+
+add_executable(test_tb_struct_array_generated_olink ${TEST_TB_STRUCT_ARRAY_GENERATED_OLINK_SOURCES})
+add_test(NAME test_tb_struct_array_generated_olink COMMAND $<TARGET_FILE:test_tb_struct_array_generated_olink>)
+
+target_link_libraries(test_tb_struct_array_generated_olink PRIVATE
+    poco-olink
+    tb_struct_array-implementation
+    tb_struct_array-core
+    tb_struct_array-olink
+    Catch2::Catch2)
+
+list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
+include(Catch)
+
+install(TARGETS test_tb_struct_array_generated_olink
+    RUNTIME DESTINATION "${INSTALL_EXAMPLEDIR}"
+    BUNDLE DESTINATION "${INSTALL_EXAMPLEDIR}"
+    LIBRARY DESTINATION "${INSTALL_EXAMPLEDIR}"
+)
+

--- a/goldenmaster/modules/tb_struct_array/generated/olink/tests/test_main.cpp
+++ b/goldenmaster/modules/tb_struct_array/generated/olink/tests/test_main.cpp
@@ -1,0 +1,7 @@
+#if defined(__clang__)
+#pragma clang diagnostic ignored "-Wweak-vtables"
+#endif // __clang__
+
+#define CATCH_CONFIG_MAIN
+
+#include <catch2/catch.hpp>

--- a/goldenmaster/modules/tb_struct_array/generated/olink/tests/test_structarrayfieldinterface.cpp
+++ b/goldenmaster/modules/tb_struct_array/generated/olink/tests/test_structarrayfieldinterface.cpp
@@ -1,0 +1,226 @@
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include "tb_struct_array/generated/core/test_struct_helper.h"
+#include "tb_struct_array/implementation/structarrayfieldinterface.h"
+#include "tb_struct_array/generated/olink/structarrayfieldinterfaceclient.h"
+#include "tb_struct_array/generated/olink/structarrayfieldinterfaceservice.h"
+
+
+THIRD_PARTY_INCLUDES_START
+#include "olink/clientregistry.h"
+#include "olink/clientnode.h"
+#include "olink/remotenode.h"
+#include "olink/remoteregistry.h"
+THIRD_PARTY_INCLUDES_END
+
+// Those tests do not use network connection.
+// They are set in a way the client writes data straight into read function of server and vice versa.
+
+namespace{
+
+    int timeout = 1000;//in ms
+}
+
+using namespace Test;
+using namespace Test::TbStructArray;
+
+TEST_CASE("olink  tb.struct.array StructArrayFieldInterface tests")
+{
+
+
+    ApiGear::ObjectLink::ClientRegistry client_registry;
+    auto clientNode = ApiGear::ObjectLink::ClientNode::create(client_registry);
+    auto clientStructArrayFieldInterface = std::make_shared<Test::TbStructArray::olink::StructArrayFieldInterfaceClient>();
+
+    ApiGear::ObjectLink::RemoteRegistry remote_registry;
+    auto remoteNode = ApiGear::ObjectLink::RemoteNode::createRemoteNode(remote_registry);
+    auto implStructArrayFieldInterface = std::make_shared<Test::TbStructArray::StructArrayFieldInterface>();
+    auto serviceStructArrayFieldInterface = std::make_shared<Test::TbStructArray::olink::StructArrayFieldInterfaceService>(implStructArrayFieldInterface, remote_registry);
+    remote_registry.addSource(serviceStructArrayFieldInterface);
+
+    remoteNode->onWrite([clientNode](std::string msg){clientNode->handleMessage(msg);});
+    clientNode->onWrite([remoteNode](std::string msg){remoteNode->handleMessage(msg);});
+
+    clientNode->registry().addSink(clientStructArrayFieldInterface);
+    clientNode->linkRemote(clientStructArrayFieldInterface->olinkObjectName());
+
+    std::condition_variable m_wait;
+    std::mutex m_waitMutex;
+    std::unique_lock<std::mutex> lock(m_waitMutex, std::defer_lock);
+    SECTION("Test setting propStructArray")
+    {
+        std::atomic<bool> ispropStructArrayChanged = false;
+        clientStructArrayFieldInterface->_getPublisher().subscribeToPropStructArrayChanged(
+        [&ispropStructArrayChanged, &m_wait ](auto value){
+            ispropStructArrayChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = TbStructArray::StructWithArrayOfStructs();
+        TbStructArray::fillTestStructWithArrayOfStructs(test_value);
+        clientStructArrayFieldInterface->setPropStructArray(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropStructArrayChanged]() {return ispropStructArrayChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArrayFieldInterface->getPropStructArray() == test_value);
+        REQUIRE(clientStructArrayFieldInterface->getPropStructArray() == test_value);
+    }
+    SECTION("Test setting propEnumArray")
+    {
+        std::atomic<bool> ispropEnumArrayChanged = false;
+        clientStructArrayFieldInterface->_getPublisher().subscribeToPropEnumArrayChanged(
+        [&ispropEnumArrayChanged, &m_wait ](auto value){
+            ispropEnumArrayChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = TbStructArray::StructWithArrayOfEnums();
+        TbStructArray::fillTestStructWithArrayOfEnums(test_value);
+        clientStructArrayFieldInterface->setPropEnumArray(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropEnumArrayChanged]() {return ispropEnumArrayChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArrayFieldInterface->getPropEnumArray() == test_value);
+        REQUIRE(clientStructArrayFieldInterface->getPropEnumArray() == test_value);
+    }
+    SECTION("Test setting propIntArray")
+    {
+        std::atomic<bool> ispropIntArrayChanged = false;
+        clientStructArrayFieldInterface->_getPublisher().subscribeToPropIntArrayChanged(
+        [&ispropIntArrayChanged, &m_wait ](auto value){
+            ispropIntArrayChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = TbStructArray::StructWithArrayOfInts();
+        TbStructArray::fillTestStructWithArrayOfInts(test_value);
+        clientStructArrayFieldInterface->setPropIntArray(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropIntArrayChanged]() {return ispropIntArrayChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArrayFieldInterface->getPropIntArray() == test_value);
+        REQUIRE(clientStructArrayFieldInterface->getPropIntArray() == test_value);
+    }
+    SECTION("Test setting propMixed")
+    {
+        std::atomic<bool> ispropMixedChanged = false;
+        clientStructArrayFieldInterface->_getPublisher().subscribeToPropMixedChanged(
+        [&ispropMixedChanged, &m_wait ](auto value){
+            ispropMixedChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = TbStructArray::MixedStruct();
+        TbStructArray::fillTestMixedStruct(test_value);
+        clientStructArrayFieldInterface->setPropMixed(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropMixedChanged]() {return ispropMixedChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArrayFieldInterface->getPropMixed() == test_value);
+        REQUIRE(clientStructArrayFieldInterface->getPropMixed() == test_value);
+    }
+    SECTION("Test emit sigMixed")
+    {
+        std::atomic<bool> issigMixedEmitted = false;
+        auto local_param_mixed_struct = TbStructArray::MixedStruct();
+        TbStructArray::fillTestMixedStruct(local_param_mixed_struct);
+
+        clientStructArrayFieldInterface->_getPublisher().subscribeToSigMixed(
+        [&m_wait, &issigMixedEmitted, &local_param_mixed_struct](const TbStructArray::MixedStruct& paramMixed)
+        {
+            REQUIRE(paramMixed ==local_param_mixed_struct);
+            issigMixedEmitted  = true;
+            m_wait.notify_all();
+        });
+
+         implStructArrayFieldInterface->_getPublisher().publishSigMixed(local_param_mixed_struct);
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&issigMixedEmitted ]() {return issigMixedEmitted   == true; }));
+        lock.unlock();
+    }
+    SECTION("Test emit sigStructArray")
+    {
+        std::atomic<bool> issigStructArrayEmitted = false;
+        auto local_param_points_struct = TbStructArray::StructWithArrayOfStructs();
+        TbStructArray::fillTestStructWithArrayOfStructs(local_param_points_struct);
+
+        clientStructArrayFieldInterface->_getPublisher().subscribeToSigStructArray(
+        [&m_wait, &issigStructArrayEmitted, &local_param_points_struct](const TbStructArray::StructWithArrayOfStructs& paramPoints)
+        {
+            REQUIRE(paramPoints ==local_param_points_struct);
+            issigStructArrayEmitted  = true;
+            m_wait.notify_all();
+        });
+
+         implStructArrayFieldInterface->_getPublisher().publishSigStructArray(local_param_points_struct);
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&issigStructArrayEmitted ]() {return issigStructArrayEmitted   == true; }));
+        lock.unlock();
+    }
+    SECTION("Test method funcMixed")
+    {
+        [[maybe_unused]] auto result = clientStructArrayFieldInterface->funcMixed(TbStructArray::MixedStruct());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcMixed async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArrayFieldInterface->funcMixedAsync(TbStructArray::MixedStruct());
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == TbStructArray::MixedStruct()); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    SECTION("Test method funcMixed async with a callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArrayFieldInterface->funcMixedAsync(TbStructArray::MixedStruct(),[&finished, &m_wait](MixedStruct value){ (void) value;finished = true; m_wait.notify_all(); /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ });
+         
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == TbStructArray::MixedStruct()); 
+        
+    }
+    SECTION("Test method funcStructArray")
+    {
+        [[maybe_unused]] auto result = clientStructArrayFieldInterface->funcStructArray(TbStructArray::StructWithArrayOfStructs());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcStructArray async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArrayFieldInterface->funcStructArrayAsync(TbStructArray::StructWithArrayOfStructs());
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == TbStructArray::StructWithArrayOfStructs()); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    SECTION("Test method funcStructArray async with a callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArrayFieldInterface->funcStructArrayAsync(TbStructArray::StructWithArrayOfStructs(),[&finished, &m_wait](StructWithArrayOfStructs value){ (void) value;finished = true; m_wait.notify_all(); /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ });
+         
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == TbStructArray::StructWithArrayOfStructs()); 
+        
+    }
+    clientNode->unlinkRemote(clientStructArrayFieldInterface->olinkObjectName());
+    remote_registry.removeSource(serviceStructArrayFieldInterface->olinkObjectName());
+    client_registry.removeSink(clientStructArrayFieldInterface->olinkObjectName());
+    serviceStructArrayFieldInterface.reset();
+    clientStructArrayFieldInterface.reset();
+}

--- a/goldenmaster/modules/tb_struct_array/implementation/CMakeLists.txt
+++ b/goldenmaster/modules/tb_struct_array/implementation/CMakeLists.txt
@@ -1,0 +1,68 @@
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+set (SOURCES_CORE_IMPL
+    structarrayfieldinterface.cpp
+)
+add_library(tb_struct_array-implementation SHARED ${SOURCES_CORE_IMPL})
+add_library(tb_struct_array::tb_struct_array-implementation ALIAS tb_struct_array-implementation)
+target_include_directories(tb_struct_array-implementation
+    PUBLIC
+    $<BUILD_INTERFACE:${MODULES_DIR}>
+    $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(tb_struct_array-implementation PUBLIC tb_struct_array::tb_struct_array-api PRIVATE tb_struct_array::tb_struct_array-core Threads::Threads)
+# ensure maximum compiler support
+if(NOT MSVC)
+  target_compile_options(tb_struct_array-implementation PRIVATE -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wnon-virtual-dtor -Woverloaded-virtual -Wcast-align -Werror -fvisibility=hidden)
+else()
+  target_compile_options(tb_struct_array-implementation PRIVATE /W4 /WX /wd4251)
+endif()
+
+# add test cases
+if(BUILD_TESTING)
+
+find_package(Catch2 REQUIRED)
+find_package(apigear REQUIRED utilities)
+
+set (SOURCES_TEST
+    ${CMAKE_CURRENT_SOURCE_DIR}/../generated/core/tb_struct_array.test.cpp
+    structarrayfieldinterface.test.cpp
+)
+add_executable(test_tb_struct_array
+    ${SOURCES_TEST}
+)
+target_link_libraries(test_tb_struct_array apigear::utilities tb_struct_array::tb_struct_array-implementation Catch2::Catch2)
+target_include_directories(test_tb_struct_array PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+# ensure maximum compiler support
+if(NOT MSVC)
+  target_compile_options(test_tb_struct_array PRIVATE -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wnon-virtual-dtor -Woverloaded-virtual -Wcast-align -Werror -fvisibility=hidden)
+else()
+  target_compile_options(test_tb_struct_array PRIVATE /W4 /WX /wd4251)
+endif()
+
+add_test(NAME test_tb_struct_array COMMAND $<TARGET_FILE:test_tb_struct_array>)
+endif(BUILD_TESTING)
+
+install(TARGETS tb_struct_array-implementation
+        EXPORT Tb_struct_arrayImplementationTargets)
+# install includes
+FILE(GLOB Tb_struct_array_INCLUDES *.h)
+install(FILES ${Tb_struct_array_INCLUDES}
+        DESTINATION include/tb_struct_array/implementation)
+
+export(EXPORT Tb_struct_arrayImplementationTargets
+  NAMESPACE tb_struct_array::
+)
+
+install(EXPORT Tb_struct_arrayImplementationTargets
+  FILE Tb_struct_arrayImplementationTargets.cmake
+  DESTINATION ${InstallDir}
+  NAMESPACE tb_struct_array::
+)

--- a/goldenmaster/modules/tb_struct_array/implementation/structarrayfieldinterface.cpp
+++ b/goldenmaster/modules/tb_struct_array/implementation/structarrayfieldinterface.cpp
@@ -1,0 +1,112 @@
+
+
+#include "tb_struct_array/implementation/structarrayfieldinterface.h"
+#include "tb_struct_array/generated/core/structarrayfieldinterface.publisher.h"
+#include "tb_struct_array/generated/core/structarrayfieldinterface.data.h"
+
+using namespace Test::TbStructArray;
+
+StructArrayFieldInterface::StructArrayFieldInterface()
+    : m_publisher(std::make_unique<StructArrayFieldInterfacePublisher>())
+{
+}
+StructArrayFieldInterface::~StructArrayFieldInterface()
+{
+}
+
+void StructArrayFieldInterface::setPropStructArray(const StructWithArrayOfStructs& propStructArray)
+{
+    if (m_data.m_propStructArray != propStructArray) {
+        m_data.m_propStructArray = propStructArray;
+        m_publisher->publishPropStructArrayChanged(propStructArray);
+    }
+}
+
+const StructWithArrayOfStructs& StructArrayFieldInterface::getPropStructArray() const
+{
+    return m_data.m_propStructArray;
+}
+
+void StructArrayFieldInterface::setPropEnumArray(const StructWithArrayOfEnums& propEnumArray)
+{
+    if (m_data.m_propEnumArray != propEnumArray) {
+        m_data.m_propEnumArray = propEnumArray;
+        m_publisher->publishPropEnumArrayChanged(propEnumArray);
+    }
+}
+
+const StructWithArrayOfEnums& StructArrayFieldInterface::getPropEnumArray() const
+{
+    return m_data.m_propEnumArray;
+}
+
+void StructArrayFieldInterface::setPropIntArray(const StructWithArrayOfInts& propIntArray)
+{
+    if (m_data.m_propIntArray != propIntArray) {
+        m_data.m_propIntArray = propIntArray;
+        m_publisher->publishPropIntArrayChanged(propIntArray);
+    }
+}
+
+const StructWithArrayOfInts& StructArrayFieldInterface::getPropIntArray() const
+{
+    return m_data.m_propIntArray;
+}
+
+void StructArrayFieldInterface::setPropMixed(const MixedStruct& propMixed)
+{
+    if (m_data.m_propMixed != propMixed) {
+        m_data.m_propMixed = propMixed;
+        m_publisher->publishPropMixedChanged(propMixed);
+    }
+}
+
+const MixedStruct& StructArrayFieldInterface::getPropMixed() const
+{
+    return m_data.m_propMixed;
+}
+
+MixedStruct StructArrayFieldInterface::funcMixed(const MixedStruct& paramMixed)
+{
+    (void) paramMixed; // suppress the 'Unreferenced Formal Parameter' warning.
+    // do business logic here
+    return MixedStruct();
+}
+
+std::future<MixedStruct> StructArrayFieldInterface::funcMixedAsync(const MixedStruct& paramMixed, std::function<void(MixedStruct)> callback)
+{
+    return std::async(std::launch::async, [this, callback,
+                    paramMixed]()
+        {auto result = funcMixed(paramMixed);
+            if (callback)
+            {
+                callback(result);
+            }return result;
+        }
+    );
+}
+
+StructWithArrayOfStructs StructArrayFieldInterface::funcStructArray(const StructWithArrayOfStructs& paramPoints)
+{
+    (void) paramPoints; // suppress the 'Unreferenced Formal Parameter' warning.
+    // do business logic here
+    return StructWithArrayOfStructs();
+}
+
+std::future<StructWithArrayOfStructs> StructArrayFieldInterface::funcStructArrayAsync(const StructWithArrayOfStructs& paramPoints, std::function<void(StructWithArrayOfStructs)> callback)
+{
+    return std::async(std::launch::async, [this, callback,
+                    paramPoints]()
+        {auto result = funcStructArray(paramPoints);
+            if (callback)
+            {
+                callback(result);
+            }return result;
+        }
+    );
+}
+
+IStructArrayFieldInterfacePublisher& StructArrayFieldInterface::_getPublisher() const
+{
+    return *m_publisher;
+}

--- a/goldenmaster/modules/tb_struct_array/implementation/structarrayfieldinterface.h
+++ b/goldenmaster/modules/tb_struct_array/implementation/structarrayfieldinterface.h
@@ -1,0 +1,50 @@
+
+#pragma once
+#include "tb_struct_array/generated/api/tb_struct_array.h"
+#include "tb_struct_array/generated/api/common.h"
+#include "tb_struct_array/generated/core/structarrayfieldinterface.data.h"
+#include <memory>
+
+namespace Test {
+namespace TbStructArray {
+
+/**
+* The StructArrayFieldInterface implementation.
+*/
+class TEST_TB_STRUCT_ARRAY_EXPORT StructArrayFieldInterface : public IStructArrayFieldInterface
+{
+public:
+    explicit StructArrayFieldInterface();
+    ~StructArrayFieldInterface();
+public:
+    void setPropStructArray(const StructWithArrayOfStructs& propStructArray) override;
+    const StructWithArrayOfStructs& getPropStructArray() const override;
+    
+    void setPropEnumArray(const StructWithArrayOfEnums& propEnumArray) override;
+    const StructWithArrayOfEnums& getPropEnumArray() const override;
+    
+    void setPropIntArray(const StructWithArrayOfInts& propIntArray) override;
+    const StructWithArrayOfInts& getPropIntArray() const override;
+    
+    void setPropMixed(const MixedStruct& propMixed) override;
+    const MixedStruct& getPropMixed() const override;
+    
+    MixedStruct funcMixed(const MixedStruct& paramMixed) override;
+    std::future<MixedStruct> funcMixedAsync(const MixedStruct& paramMixed, std::function<void(MixedStruct)> callback = nullptr) override;
+        
+    StructWithArrayOfStructs funcStructArray(const StructWithArrayOfStructs& paramPoints) override;
+    std::future<StructWithArrayOfStructs> funcStructArrayAsync(const StructWithArrayOfStructs& paramPoints, std::function<void(StructWithArrayOfStructs)> callback = nullptr) override;
+        
+    /**
+    * Access to a publisher, use it to subscribe for StructArrayFieldInterface changes and signal emission.
+    * @return The publisher for StructArrayFieldInterface.
+    */
+    IStructArrayFieldInterfacePublisher& _getPublisher() const override;
+private:
+    /** The publisher for the StructArrayFieldInterface. */
+    std::unique_ptr<IStructArrayFieldInterfacePublisher> m_publisher;
+    /** The helper structure to store all the properties for StructArrayFieldInterface. */
+    StructArrayFieldInterfaceData m_data;
+};
+} // namespace TbStructArray
+} // namespace Test

--- a/goldenmaster/modules/tb_struct_array/implementation/structarrayfieldinterface.test.cpp
+++ b/goldenmaster/modules/tb_struct_array/implementation/structarrayfieldinterface.test.cpp
@@ -1,0 +1,72 @@
+#include <memory>
+#include "catch2/catch.hpp"
+#include "tb_struct_array/implementation/structarrayfieldinterface.h"
+#include "apigear/utilities/fuzzy_compare.h"
+
+using namespace Test::TbStructArray;
+TEST_CASE("Testing StructArrayFieldInterface", "[StructArrayFieldInterface]"){
+    std::unique_ptr<IStructArrayFieldInterface> testStructArrayFieldInterface = std::make_unique<StructArrayFieldInterface>();
+    // setup your test
+    SECTION("Test operation funcMixed") {
+        // Do implement test here
+        testStructArrayFieldInterface->funcMixed(MixedStruct());
+    }
+
+    SECTION("Test operation async funcMixed") {
+        // Do implement test here
+
+        auto future = testStructArrayFieldInterface->funcMixedAsync(MixedStruct());
+    }
+
+    SECTION("Test operation async funcMixed with a callback") {
+        // Do implement test here
+
+        auto future = testStructArrayFieldInterface->funcMixedAsync(MixedStruct(),[](MixedStruct value){ (void)value; /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ }
+            );
+    }
+    SECTION("Test operation funcStructArray") {
+        // Do implement test here
+        testStructArrayFieldInterface->funcStructArray(StructWithArrayOfStructs());
+    }
+
+    SECTION("Test operation async funcStructArray") {
+        // Do implement test here
+
+        auto future = testStructArrayFieldInterface->funcStructArrayAsync(StructWithArrayOfStructs());
+    }
+
+    SECTION("Test operation async funcStructArray with a callback") {
+        // Do implement test here
+
+        auto future = testStructArrayFieldInterface->funcStructArrayAsync(StructWithArrayOfStructs(),[](StructWithArrayOfStructs value){ (void)value; /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ }
+            );
+    }
+    SECTION("Test property propStructArray") {
+        // Do implement test here
+        testStructArrayFieldInterface->setPropStructArray(StructWithArrayOfStructs());
+        auto actual = testStructArrayFieldInterface->getPropStructArray();
+        auto expected =  StructWithArrayOfStructs();
+        REQUIRE(actual == expected);
+    }
+    SECTION("Test property propEnumArray") {
+        // Do implement test here
+        testStructArrayFieldInterface->setPropEnumArray(StructWithArrayOfEnums());
+        auto actual = testStructArrayFieldInterface->getPropEnumArray();
+        auto expected =  StructWithArrayOfEnums();
+        REQUIRE(actual == expected);
+    }
+    SECTION("Test property propIntArray") {
+        // Do implement test here
+        testStructArrayFieldInterface->setPropIntArray(StructWithArrayOfInts());
+        auto actual = testStructArrayFieldInterface->getPropIntArray();
+        auto expected =  StructWithArrayOfInts();
+        REQUIRE(actual == expected);
+    }
+    SECTION("Test property propMixed") {
+        // Do implement test here
+        testStructArrayFieldInterface->setPropMixed(MixedStruct());
+        auto actual = testStructArrayFieldInterface->getPropMixed();
+        auto expected =  MixedStruct();
+        REQUIRE(actual == expected);
+    }
+}

--- a/goldenmaster/modules/testbed1/conan/test_package/main.cpp
+++ b/goldenmaster/modules/testbed1/conan/test_package/main.cpp
@@ -1,12 +1,14 @@
 
 #include "testbed1/implementation/structinterface.h"
 #include "testbed1/implementation/structarrayinterface.h"
+#include "testbed1/implementation/structarray2interface.h"
 
 using namespace Test::Testbed1;
 
 int main(){
     std::unique_ptr<IStructInterface> testStructInterface = std::make_unique<StructInterface>();
     std::unique_ptr<IStructArrayInterface> testStructArrayInterface = std::make_unique<StructArrayInterface>();
+    std::unique_ptr<IStructArray2Interface> testStructArray2Interface = std::make_unique<StructArray2Interface>();
 
     return 0;
 }

--- a/goldenmaster/modules/testbed1/generated/api/datastructs.api.cpp
+++ b/goldenmaster/modules/testbed1/generated/api/datastructs.api.cpp
@@ -2,6 +2,26 @@
 
 namespace Test {
 namespace Testbed1 {
+
+// ********************************************************************
+// Enumeration Enum0
+// ********************************************************************
+Enum0Enum toEnum0Enum(std::uint8_t v, bool *ok)
+{
+    if (ok != nullptr) {
+        *ok = true;
+    }
+    switch (v) {
+        case 0: return Enum0Enum::value0;
+        case 1: return Enum0Enum::value1;
+        case 2: return Enum0Enum::value2;
+        default:
+            if (ok != nullptr) {
+                *ok = false;
+            }
+            return Enum0Enum::value0;
+    }
+}
 // ********************************************************************
 // Struct StructBool
 // ********************************************************************
@@ -84,6 +104,174 @@ bool operator==(const StructString& lhs, const StructString& rhs) noexcept
 }
 
 bool operator!=(const StructString& lhs, const StructString& rhs) noexcept
+{
+    return !(lhs == rhs);
+}
+// ********************************************************************
+// Struct StructStruct
+// ********************************************************************
+StructStruct::StructStruct() = default;
+StructStruct::StructStruct(const StructString& fieldString):
+    fieldString(fieldString)
+{
+}
+
+bool operator==(const StructStruct& lhs, const StructStruct& rhs) noexcept
+{
+    return (
+        lhs.fieldString == rhs.fieldString
+
+    );
+}
+
+bool operator!=(const StructStruct& lhs, const StructStruct& rhs) noexcept
+{
+    return !(lhs == rhs);
+}
+// ********************************************************************
+// Struct StructEnum
+// ********************************************************************
+StructEnum::StructEnum() = default;
+StructEnum::StructEnum(Enum0Enum fieldEnum):
+    fieldEnum(fieldEnum)
+{
+}
+
+bool operator==(const StructEnum& lhs, const StructEnum& rhs) noexcept
+{
+    return (
+        lhs.fieldEnum == rhs.fieldEnum
+
+    );
+}
+
+bool operator!=(const StructEnum& lhs, const StructEnum& rhs) noexcept
+{
+    return !(lhs == rhs);
+}
+// ********************************************************************
+// Struct StructBoolWithArray
+// ********************************************************************
+StructBoolWithArray::StructBoolWithArray() = default;
+StructBoolWithArray::StructBoolWithArray(const std::list<bool>& fieldBool):
+    fieldBool(fieldBool)
+{
+}
+
+bool operator==(const StructBoolWithArray& lhs, const StructBoolWithArray& rhs) noexcept
+{
+    return (
+        lhs.fieldBool == rhs.fieldBool
+
+    );
+}
+
+bool operator!=(const StructBoolWithArray& lhs, const StructBoolWithArray& rhs) noexcept
+{
+    return !(lhs == rhs);
+}
+// ********************************************************************
+// Struct StructIntWithArray
+// ********************************************************************
+StructIntWithArray::StructIntWithArray() = default;
+StructIntWithArray::StructIntWithArray(const std::list<int>& fieldInt):
+    fieldInt(fieldInt)
+{
+}
+
+bool operator==(const StructIntWithArray& lhs, const StructIntWithArray& rhs) noexcept
+{
+    return (
+        lhs.fieldInt == rhs.fieldInt
+
+    );
+}
+
+bool operator!=(const StructIntWithArray& lhs, const StructIntWithArray& rhs) noexcept
+{
+    return !(lhs == rhs);
+}
+// ********************************************************************
+// Struct StructFloatWithArray
+// ********************************************************************
+StructFloatWithArray::StructFloatWithArray() = default;
+StructFloatWithArray::StructFloatWithArray(const std::list<float>& fieldFloat):
+    fieldFloat(fieldFloat)
+{
+}
+
+bool operator==(const StructFloatWithArray& lhs, const StructFloatWithArray& rhs) noexcept
+{
+    return (
+        lhs.fieldFloat == rhs.fieldFloat
+
+    );
+}
+
+bool operator!=(const StructFloatWithArray& lhs, const StructFloatWithArray& rhs) noexcept
+{
+    return !(lhs == rhs);
+}
+// ********************************************************************
+// Struct StructStringWithArray
+// ********************************************************************
+StructStringWithArray::StructStringWithArray() = default;
+StructStringWithArray::StructStringWithArray(const std::list<std::string>& fieldString):
+    fieldString(fieldString)
+{
+}
+
+bool operator==(const StructStringWithArray& lhs, const StructStringWithArray& rhs) noexcept
+{
+    return (
+        lhs.fieldString == rhs.fieldString
+
+    );
+}
+
+bool operator!=(const StructStringWithArray& lhs, const StructStringWithArray& rhs) noexcept
+{
+    return !(lhs == rhs);
+}
+// ********************************************************************
+// Struct StructStructWithArray
+// ********************************************************************
+StructStructWithArray::StructStructWithArray() = default;
+StructStructWithArray::StructStructWithArray(const std::list<StructStringWithArray>& fieldStruct):
+    fieldStruct(fieldStruct)
+{
+}
+
+bool operator==(const StructStructWithArray& lhs, const StructStructWithArray& rhs) noexcept
+{
+    return (
+        lhs.fieldStruct == rhs.fieldStruct
+
+    );
+}
+
+bool operator!=(const StructStructWithArray& lhs, const StructStructWithArray& rhs) noexcept
+{
+    return !(lhs == rhs);
+}
+// ********************************************************************
+// Struct StructEnumWithArray
+// ********************************************************************
+StructEnumWithArray::StructEnumWithArray() = default;
+StructEnumWithArray::StructEnumWithArray(const std::list<Enum0Enum>& fieldEnum):
+    fieldEnum(fieldEnum)
+{
+}
+
+bool operator==(const StructEnumWithArray& lhs, const StructEnumWithArray& rhs) noexcept
+{
+    return (
+        lhs.fieldEnum == rhs.fieldEnum
+
+    );
+}
+
+bool operator!=(const StructEnumWithArray& lhs, const StructEnumWithArray& rhs) noexcept
 {
     return !(lhs == rhs);
 }

--- a/goldenmaster/modules/testbed1/generated/api/datastructs.api.h
+++ b/goldenmaster/modules/testbed1/generated/api/datastructs.api.h
@@ -12,6 +12,24 @@ struct StructBool;
 struct StructInt;
 struct StructFloat;
 struct StructString;
+struct StructStruct;
+struct StructEnum;
+struct StructBoolWithArray;
+struct StructIntWithArray;
+struct StructFloatWithArray;
+struct StructStringWithArray;
+struct StructStructWithArray;
+struct StructEnumWithArray;
+
+/**
+ * Enumeration Enum0
+ */
+enum class Enum0Enum {
+    value0 = 0,
+    value1 = 1,
+    value2 = 2
+};
+TEST_TESTBED1_EXPORT Enum0Enum toEnum0Enum(std::uint8_t v, bool *ok);
 
 /**
  * Struct StructBool
@@ -68,5 +86,117 @@ struct TEST_TESTBED1_EXPORT StructString
 };
 bool TEST_TESTBED1_EXPORT operator==(const StructString &, const StructString &) noexcept;
 bool TEST_TESTBED1_EXPORT operator!=(const StructString &, const StructString &) noexcept;
+
+/**
+ * Struct StructStruct
+ */
+struct TEST_TESTBED1_EXPORT StructStruct
+{
+    StructStruct();
+    StructStruct(const StructString& fieldString);
+
+    StructString fieldString{};
+
+};
+bool TEST_TESTBED1_EXPORT operator==(const StructStruct &, const StructStruct &) noexcept;
+bool TEST_TESTBED1_EXPORT operator!=(const StructStruct &, const StructStruct &) noexcept;
+
+/**
+ * Struct StructEnum
+ */
+struct TEST_TESTBED1_EXPORT StructEnum
+{
+    StructEnum();
+    StructEnum(Enum0Enum fieldEnum);
+
+    Enum0Enum fieldEnum{};
+
+};
+bool TEST_TESTBED1_EXPORT operator==(const StructEnum &, const StructEnum &) noexcept;
+bool TEST_TESTBED1_EXPORT operator!=(const StructEnum &, const StructEnum &) noexcept;
+
+/**
+ * Struct StructBoolWithArray
+ */
+struct TEST_TESTBED1_EXPORT StructBoolWithArray
+{
+    StructBoolWithArray();
+    StructBoolWithArray(const std::list<bool>& fieldBool);
+
+    std::list<bool> fieldBool{};
+
+};
+bool TEST_TESTBED1_EXPORT operator==(const StructBoolWithArray &, const StructBoolWithArray &) noexcept;
+bool TEST_TESTBED1_EXPORT operator!=(const StructBoolWithArray &, const StructBoolWithArray &) noexcept;
+
+/**
+ * Struct StructIntWithArray
+ */
+struct TEST_TESTBED1_EXPORT StructIntWithArray
+{
+    StructIntWithArray();
+    StructIntWithArray(const std::list<int>& fieldInt);
+
+    std::list<int> fieldInt{};
+
+};
+bool TEST_TESTBED1_EXPORT operator==(const StructIntWithArray &, const StructIntWithArray &) noexcept;
+bool TEST_TESTBED1_EXPORT operator!=(const StructIntWithArray &, const StructIntWithArray &) noexcept;
+
+/**
+ * Struct StructFloatWithArray
+ */
+struct TEST_TESTBED1_EXPORT StructFloatWithArray
+{
+    StructFloatWithArray();
+    StructFloatWithArray(const std::list<float>& fieldFloat);
+
+    std::list<float> fieldFloat{};
+
+};
+bool TEST_TESTBED1_EXPORT operator==(const StructFloatWithArray &, const StructFloatWithArray &) noexcept;
+bool TEST_TESTBED1_EXPORT operator!=(const StructFloatWithArray &, const StructFloatWithArray &) noexcept;
+
+/**
+ * Struct StructStringWithArray
+ */
+struct TEST_TESTBED1_EXPORT StructStringWithArray
+{
+    StructStringWithArray();
+    StructStringWithArray(const std::list<std::string>& fieldString);
+
+    std::list<std::string> fieldString{};
+
+};
+bool TEST_TESTBED1_EXPORT operator==(const StructStringWithArray &, const StructStringWithArray &) noexcept;
+bool TEST_TESTBED1_EXPORT operator!=(const StructStringWithArray &, const StructStringWithArray &) noexcept;
+
+/**
+ * Struct StructStructWithArray
+ */
+struct TEST_TESTBED1_EXPORT StructStructWithArray
+{
+    StructStructWithArray();
+    StructStructWithArray(const std::list<StructStringWithArray>& fieldStruct);
+
+    std::list<StructStringWithArray> fieldStruct{};
+
+};
+bool TEST_TESTBED1_EXPORT operator==(const StructStructWithArray &, const StructStructWithArray &) noexcept;
+bool TEST_TESTBED1_EXPORT operator!=(const StructStructWithArray &, const StructStructWithArray &) noexcept;
+
+/**
+ * Struct StructEnumWithArray
+ */
+struct TEST_TESTBED1_EXPORT StructEnumWithArray
+{
+    StructEnumWithArray();
+    StructEnumWithArray(const std::list<Enum0Enum>& fieldEnum);
+
+    std::list<Enum0Enum> fieldEnum{};
+
+};
+bool TEST_TESTBED1_EXPORT operator==(const StructEnumWithArray &, const StructEnumWithArray &) noexcept;
+bool TEST_TESTBED1_EXPORT operator!=(const StructEnumWithArray &, const StructEnumWithArray &) noexcept;
 } // namespace Testbed1
 } // namespace Test

--- a/goldenmaster/modules/testbed1/generated/api/structarray2interface.api.h
+++ b/goldenmaster/modules/testbed1/generated/api/structarray2interface.api.h
@@ -1,0 +1,455 @@
+#pragma once
+
+#include <cstdint>
+#include <future>
+#include "testbed1/generated/api/common.h"
+#include "testbed1/generated/api/datastructs.api.h"
+
+namespace Test {
+namespace Testbed1 {
+
+class IStructArray2InterfaceSubscriber;
+class IStructArray2InterfacePublisher;
+
+/**
+*
+* IStructArray2Interface provides an interface for
+ *  - methods defined for your StructArray2Interface 
+ *  - property setters and getters for defined properties
+ * The IStructArray2Interface also provides an interface to access a publisher IStructArray2InterfacePublisher, a class used by IStructArray2InterfaceSubscriber clients.
+ * The implementation should notify the publisher IStructArray2InterfacePublisher about emitted signals or state changed. 
+ * The publisher responsibility is to keep its clients informed about requested changes.
+ * See also IStructArray2InterfaceSubscriber, IStructArray2InterfacePublisher
+ * and the example implementation StructArray2Interface  or the
+ */
+class TEST_TESTBED1_EXPORT IStructArray2Interface
+{
+public:
+    virtual ~IStructArray2Interface() = default;
+
+
+    virtual std::list<StructBool> funcBool(const StructBoolWithArray& paramBool) = 0;
+    /**
+    * Asynchronous version of funcBool(const StructBoolWithArray& paramBool)
+    * @return Promise of type std::list<StructBool> which is set once the function has completed
+    */
+    virtual std::future<std::list<StructBool>> funcBoolAsync(const StructBoolWithArray& paramBool, std::function<void(std::list<StructBool>)> callback = nullptr) = 0;
+
+
+    virtual std::list<StructInt> funcInt(const StructIntWithArray& paramInt) = 0;
+    /**
+    * Asynchronous version of funcInt(const StructIntWithArray& paramInt)
+    * @return Promise of type std::list<StructInt> which is set once the function has completed
+    */
+    virtual std::future<std::list<StructInt>> funcIntAsync(const StructIntWithArray& paramInt, std::function<void(std::list<StructInt>)> callback = nullptr) = 0;
+
+
+    virtual std::list<StructFloat> funcFloat(const StructFloatWithArray& paramFloat) = 0;
+    /**
+    * Asynchronous version of funcFloat(const StructFloatWithArray& paramFloat)
+    * @return Promise of type std::list<StructFloat> which is set once the function has completed
+    */
+    virtual std::future<std::list<StructFloat>> funcFloatAsync(const StructFloatWithArray& paramFloat, std::function<void(std::list<StructFloat>)> callback = nullptr) = 0;
+
+
+    virtual std::list<StructString> funcString(const StructStringWithArray& paramString) = 0;
+    /**
+    * Asynchronous version of funcString(const StructStringWithArray& paramString)
+    * @return Promise of type std::list<StructString> which is set once the function has completed
+    */
+    virtual std::future<std::list<StructString>> funcStringAsync(const StructStringWithArray& paramString, std::function<void(std::list<StructString>)> callback = nullptr) = 0;
+
+
+    virtual std::list<Enum0Enum> funcEnum(const StructEnumWithArray& paramEnum) = 0;
+    /**
+    * Asynchronous version of funcEnum(const StructEnumWithArray& paramEnum)
+    * @return Promise of type std::list<Enum0Enum> which is set once the function has completed
+    */
+    virtual std::future<std::list<Enum0Enum>> funcEnumAsync(const StructEnumWithArray& paramEnum, std::function<void(std::list<Enum0Enum>)> callback = nullptr) = 0;
+
+    /**
+    * Sets the value of the propBool property.
+    */
+    virtual void setPropBool(const StructBoolWithArray& propBool) = 0;
+    /**
+    * Gets the value of the propBool property.
+    */
+    virtual const StructBoolWithArray& getPropBool() const = 0;
+
+    /**
+    * Sets the value of the propInt property.
+    */
+    virtual void setPropInt(const StructIntWithArray& propInt) = 0;
+    /**
+    * Gets the value of the propInt property.
+    */
+    virtual const StructIntWithArray& getPropInt() const = 0;
+
+    /**
+    * Sets the value of the propFloat property.
+    */
+    virtual void setPropFloat(const StructFloatWithArray& propFloat) = 0;
+    /**
+    * Gets the value of the propFloat property.
+    */
+    virtual const StructFloatWithArray& getPropFloat() const = 0;
+
+    /**
+    * Sets the value of the propString property.
+    */
+    virtual void setPropString(const StructStringWithArray& propString) = 0;
+    /**
+    * Gets the value of the propString property.
+    */
+    virtual const StructStringWithArray& getPropString() const = 0;
+
+    /**
+    * Sets the value of the propEnum property.
+    */
+    virtual void setPropEnum(const StructEnumWithArray& propEnum) = 0;
+    /**
+    * Gets the value of the propEnum property.
+    */
+    virtual const StructEnumWithArray& getPropEnum() const = 0;
+
+    /**
+    * Access to a publisher, use it to subscribe for StructArray2Interface changes and signal emission.
+    * This function name doesn't follow the convention, because it is added to user defined interface,
+    * to avoid potentially name clashes, it has the trailing underscore in the name.
+    * @return The publisher for StructArray2Interface.
+    */
+    virtual IStructArray2InterfacePublisher& _getPublisher() const = 0;
+};
+
+
+/**
+ * The IStructArray2InterfaceSubscriber contains functions to allow informing about signals or property changes of the IStructArray2Interface implementation.
+ * The implementation for IStructArray2Interface should provide mechanism for subscription of the IStructArray2InterfaceSubscriber clients.
+ * See IStructArray2InterfacePublisher, which provides facilitation for this purpose.
+ * The implementation for IStructArray2Interface should call the IStructArray2InterfaceSubscriber interface functions on either signal emit or property change.
+ * You can use IStructArray2InterfaceSubscriber class to implement clients of the IStructArray2Interface or the network adapter - see Olink Server and Client example.
+ */
+class TEST_TESTBED1_EXPORT IStructArray2InterfaceSubscriber
+{
+public:
+    virtual ~IStructArray2InterfaceSubscriber() = default;
+    /**
+    * Called by the IStructArray2InterfacePublisher when the StructArray2Interface emits sigBool, if subscribed for the sigBool.
+    * @param paramBool 
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual void onSigBool(const StructBoolWithArray& paramBool) = 0;
+    /**
+    * Called by the IStructArray2InterfacePublisher when the StructArray2Interface emits sigInt, if subscribed for the sigInt.
+    * @param paramInt 
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual void onSigInt(const StructIntWithArray& paramInt) = 0;
+    /**
+    * Called by the IStructArray2InterfacePublisher when the StructArray2Interface emits sigFloat, if subscribed for the sigFloat.
+    * @param paramFloat 
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual void onSigFloat(const StructFloatWithArray& paramFloat) = 0;
+    /**
+    * Called by the IStructArray2InterfacePublisher when the StructArray2Interface emits sigString, if subscribed for the sigString.
+    * @param paramString 
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual void onSigString(const StructStringWithArray& paramString) = 0;
+    /**
+    * Called by the IStructArray2InterfacePublisher when propBool value has changed if subscribed for the propBool change.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual void onPropBoolChanged(const StructBoolWithArray& propBool) = 0;
+    /**
+    * Called by the IStructArray2InterfacePublisher when propInt value has changed if subscribed for the propInt change.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual void onPropIntChanged(const StructIntWithArray& propInt) = 0;
+    /**
+    * Called by the IStructArray2InterfacePublisher when propFloat value has changed if subscribed for the propFloat change.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual void onPropFloatChanged(const StructFloatWithArray& propFloat) = 0;
+    /**
+    * Called by the IStructArray2InterfacePublisher when propString value has changed if subscribed for the propString change.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual void onPropStringChanged(const StructStringWithArray& propString) = 0;
+    /**
+    * Called by the IStructArray2InterfacePublisher when propEnum value has changed if subscribed for the propEnum change.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual void onPropEnumChanged(const StructEnumWithArray& propEnum) = 0;
+};
+
+/** Callback for changes of propBool */
+using StructArray2InterfacePropBoolPropertyCb = std::function<void(const StructBoolWithArray& propBool)>;
+/** Callback for changes of propInt */
+using StructArray2InterfacePropIntPropertyCb = std::function<void(const StructIntWithArray& propInt)>;
+/** Callback for changes of propFloat */
+using StructArray2InterfacePropFloatPropertyCb = std::function<void(const StructFloatWithArray& propFloat)>;
+/** Callback for changes of propString */
+using StructArray2InterfacePropStringPropertyCb = std::function<void(const StructStringWithArray& propString)>;
+/** Callback for changes of propEnum */
+using StructArray2InterfacePropEnumPropertyCb = std::function<void(const StructEnumWithArray& propEnum)>;
+/** Callback for sigBool signal triggers */
+using StructArray2InterfaceSigBoolSignalCb = std::function<void(const StructBoolWithArray& paramBool)> ;
+/** Callback for sigInt signal triggers */
+using StructArray2InterfaceSigIntSignalCb = std::function<void(const StructIntWithArray& paramInt)> ;
+/** Callback for sigFloat signal triggers */
+using StructArray2InterfaceSigFloatSignalCb = std::function<void(const StructFloatWithArray& paramFloat)> ;
+/** Callback for sigString signal triggers */
+using StructArray2InterfaceSigStringSignalCb = std::function<void(const StructStringWithArray& paramString)> ;
+
+
+/**
+ * The IStructArray2InterfacePublisher provides an api for clients to subscribe to or unsubscribe from a signal emission 
+ * or a property change.
+ * Implement this interface to keep track of clients of your IStructArray2Interface implementation.
+ * The publisher provides two independent methods of subscription
+ *  - subscribing with a IStructArray2InterfaceSubscriber objects - for all of the changes
+ *  - subscribing any object for single type of change property or a signal
+ * The publish functions needs to be called by implementation of the IIStructArray2Interface on each state changed or signal emitted
+ * to notify all the subscribers about this change.
+ */
+class TEST_TESTBED1_EXPORT IStructArray2InterfacePublisher
+{
+public:
+    virtual ~IStructArray2InterfacePublisher() = default;
+
+    /**
+    * Use this function to subscribe for any change of the StructArray2Interface.
+    * Subscriber will be informed of any emitted signal and any property changes.
+    * This is parallel notification system to single subscription. If you will subscribe also for a single change
+    * your subscriber will be informed twice about that change, one for each subscription mechanism.
+    * @param IStructArray2InterfaceSubscriber which is subscribed in this function to any change of the StructArray2Interface.
+    */
+    virtual void subscribeToAllChanges(IStructArray2InterfaceSubscriber& subscriber) = 0;
+    /**
+    * Use this function to remove subscription to all of the changes of the StructArray2Interface.
+    * Not all subscriptions will be removed, the ones made separately for single signal or property change stay intact.
+    * Make sure to remove them.
+    * @param IStructArray2InterfaceSubscriber which subscription for any change of the StructArray2Interface is removed.
+    */
+    virtual void unsubscribeFromAllChanges(IStructArray2InterfaceSubscriber& subscriber) = 0;
+
+    /**
+    * Use this function to subscribe for propBool value changes.
+    * If your subscriber uses subscription with IStructArray2InterfaceSubscriber interface, you will get two notifications, one for each subscription mechanism.
+    * @param StructArray2InterfacePropBoolPropertyCb callback that will be executed on each change of the property.
+    * Make sure to remove subscription before the callback becomes invalid.
+    * @return subscription token for the subscription removal.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual uint64_t subscribeToPropBoolChanged(StructArray2InterfacePropBoolPropertyCb callback) = 0;
+    /**
+    * Use this function to unsubscribe from propBool property changes.
+    * If your subscriber uses subscription with IStructArray2InterfaceSubscriber interface, you will be still informed about this change,
+    * as those are two independent subscription mechanisms.
+    * @param subscription token received on subscription.
+    */
+    virtual void unsubscribeFromPropBoolChanged(uint64_t handleId) = 0;
+
+    /**
+    * Use this function to subscribe for propInt value changes.
+    * If your subscriber uses subscription with IStructArray2InterfaceSubscriber interface, you will get two notifications, one for each subscription mechanism.
+    * @param StructArray2InterfacePropIntPropertyCb callback that will be executed on each change of the property.
+    * Make sure to remove subscription before the callback becomes invalid.
+    * @return subscription token for the subscription removal.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual uint64_t subscribeToPropIntChanged(StructArray2InterfacePropIntPropertyCb callback) = 0;
+    /**
+    * Use this function to unsubscribe from propInt property changes.
+    * If your subscriber uses subscription with IStructArray2InterfaceSubscriber interface, you will be still informed about this change,
+    * as those are two independent subscription mechanisms.
+    * @param subscription token received on subscription.
+    */
+    virtual void unsubscribeFromPropIntChanged(uint64_t handleId) = 0;
+
+    /**
+    * Use this function to subscribe for propFloat value changes.
+    * If your subscriber uses subscription with IStructArray2InterfaceSubscriber interface, you will get two notifications, one for each subscription mechanism.
+    * @param StructArray2InterfacePropFloatPropertyCb callback that will be executed on each change of the property.
+    * Make sure to remove subscription before the callback becomes invalid.
+    * @return subscription token for the subscription removal.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual uint64_t subscribeToPropFloatChanged(StructArray2InterfacePropFloatPropertyCb callback) = 0;
+    /**
+    * Use this function to unsubscribe from propFloat property changes.
+    * If your subscriber uses subscription with IStructArray2InterfaceSubscriber interface, you will be still informed about this change,
+    * as those are two independent subscription mechanisms.
+    * @param subscription token received on subscription.
+    */
+    virtual void unsubscribeFromPropFloatChanged(uint64_t handleId) = 0;
+
+    /**
+    * Use this function to subscribe for propString value changes.
+    * If your subscriber uses subscription with IStructArray2InterfaceSubscriber interface, you will get two notifications, one for each subscription mechanism.
+    * @param StructArray2InterfacePropStringPropertyCb callback that will be executed on each change of the property.
+    * Make sure to remove subscription before the callback becomes invalid.
+    * @return subscription token for the subscription removal.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual uint64_t subscribeToPropStringChanged(StructArray2InterfacePropStringPropertyCb callback) = 0;
+    /**
+    * Use this function to unsubscribe from propString property changes.
+    * If your subscriber uses subscription with IStructArray2InterfaceSubscriber interface, you will be still informed about this change,
+    * as those are two independent subscription mechanisms.
+    * @param subscription token received on subscription.
+    */
+    virtual void unsubscribeFromPropStringChanged(uint64_t handleId) = 0;
+
+    /**
+    * Use this function to subscribe for propEnum value changes.
+    * If your subscriber uses subscription with IStructArray2InterfaceSubscriber interface, you will get two notifications, one for each subscription mechanism.
+    * @param StructArray2InterfacePropEnumPropertyCb callback that will be executed on each change of the property.
+    * Make sure to remove subscription before the callback becomes invalid.
+    * @return subscription token for the subscription removal.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual uint64_t subscribeToPropEnumChanged(StructArray2InterfacePropEnumPropertyCb callback) = 0;
+    /**
+    * Use this function to unsubscribe from propEnum property changes.
+    * If your subscriber uses subscription with IStructArray2InterfaceSubscriber interface, you will be still informed about this change,
+    * as those are two independent subscription mechanisms.
+    * @param subscription token received on subscription.
+    */
+    virtual void unsubscribeFromPropEnumChanged(uint64_t handleId) = 0;
+
+    /**
+    * Use this function to subscribe for sigBool signal changes.
+    * @param StructArray2InterfaceSigBoolSignalCb callback that will be executed on each signal emission.
+    * Make sure to remove subscription before the callback becomes invalid.
+    * @return subscription token for the subscription removal.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual uint64_t subscribeToSigBool(StructArray2InterfaceSigBoolSignalCb callback) = 0;
+    /**
+    * Use this function to unsubscribe from sigBool signal changes.
+    * @param subscription token received on subscription.
+    */
+    virtual void unsubscribeFromSigBool(uint64_t handleId) = 0;
+
+    /**
+    * Use this function to subscribe for sigInt signal changes.
+    * @param StructArray2InterfaceSigIntSignalCb callback that will be executed on each signal emission.
+    * Make sure to remove subscription before the callback becomes invalid.
+    * @return subscription token for the subscription removal.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual uint64_t subscribeToSigInt(StructArray2InterfaceSigIntSignalCb callback) = 0;
+    /**
+    * Use this function to unsubscribe from sigInt signal changes.
+    * @param subscription token received on subscription.
+    */
+    virtual void unsubscribeFromSigInt(uint64_t handleId) = 0;
+
+    /**
+    * Use this function to subscribe for sigFloat signal changes.
+    * @param StructArray2InterfaceSigFloatSignalCb callback that will be executed on each signal emission.
+    * Make sure to remove subscription before the callback becomes invalid.
+    * @return subscription token for the subscription removal.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual uint64_t subscribeToSigFloat(StructArray2InterfaceSigFloatSignalCb callback) = 0;
+    /**
+    * Use this function to unsubscribe from sigFloat signal changes.
+    * @param subscription token received on subscription.
+    */
+    virtual void unsubscribeFromSigFloat(uint64_t handleId) = 0;
+
+    /**
+    * Use this function to subscribe for sigString signal changes.
+    * @param StructArray2InterfaceSigStringSignalCb callback that will be executed on each signal emission.
+    * Make sure to remove subscription before the callback becomes invalid.
+    * @return subscription token for the subscription removal.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual uint64_t subscribeToSigString(StructArray2InterfaceSigStringSignalCb callback) = 0;
+    /**
+    * Use this function to unsubscribe from sigString signal changes.
+    * @param subscription token received on subscription.
+    */
+    virtual void unsubscribeFromSigString(uint64_t handleId) = 0;
+
+    /**
+    * Publishes the property changed to all subscribed clients.
+    * Needs to be invoked by the StructArray2Interface implementation when property propBool changes.
+    * @param The new value of propBool.
+    */
+    virtual void publishPropBoolChanged(const StructBoolWithArray& propBool) const = 0;
+    /**
+    * Publishes the property changed to all subscribed clients.
+    * Needs to be invoked by the StructArray2Interface implementation when property propInt changes.
+    * @param The new value of propInt.
+    */
+    virtual void publishPropIntChanged(const StructIntWithArray& propInt) const = 0;
+    /**
+    * Publishes the property changed to all subscribed clients.
+    * Needs to be invoked by the StructArray2Interface implementation when property propFloat changes.
+    * @param The new value of propFloat.
+    */
+    virtual void publishPropFloatChanged(const StructFloatWithArray& propFloat) const = 0;
+    /**
+    * Publishes the property changed to all subscribed clients.
+    * Needs to be invoked by the StructArray2Interface implementation when property propString changes.
+    * @param The new value of propString.
+    */
+    virtual void publishPropStringChanged(const StructStringWithArray& propString) const = 0;
+    /**
+    * Publishes the property changed to all subscribed clients.
+    * Needs to be invoked by the StructArray2Interface implementation when property propEnum changes.
+    * @param The new value of propEnum.
+    */
+    virtual void publishPropEnumChanged(const StructEnumWithArray& propEnum) const = 0;
+    /**
+    * Publishes the emitted signal to all subscribed clients.
+    * Needs to be invoked by the StructArray2Interface implementation when sigBool is emitted.
+    * @param paramBool 
+    */
+    virtual void publishSigBool(const StructBoolWithArray& paramBool) const = 0;
+    /**
+    * Publishes the emitted signal to all subscribed clients.
+    * Needs to be invoked by the StructArray2Interface implementation when sigInt is emitted.
+    * @param paramInt 
+    */
+    virtual void publishSigInt(const StructIntWithArray& paramInt) const = 0;
+    /**
+    * Publishes the emitted signal to all subscribed clients.
+    * Needs to be invoked by the StructArray2Interface implementation when sigFloat is emitted.
+    * @param paramFloat 
+    */
+    virtual void publishSigFloat(const StructFloatWithArray& paramFloat) const = 0;
+    /**
+    * Publishes the emitted signal to all subscribed clients.
+    * Needs to be invoked by the StructArray2Interface implementation when sigString is emitted.
+    * @param paramString 
+    */
+    virtual void publishSigString(const StructStringWithArray& paramString) const = 0;
+};
+
+
+} // namespace Testbed1
+} // namespace Test

--- a/goldenmaster/modules/testbed1/generated/api/structarrayinterface.api.h
+++ b/goldenmaster/modules/testbed1/generated/api/structarrayinterface.api.h
@@ -59,6 +59,14 @@ public:
     */
     virtual std::future<std::list<StructString>> funcStringAsync(const std::list<StructString>& paramString, std::function<void(std::list<StructString>)> callback = nullptr) = 0;
 
+
+    virtual std::list<Enum0Enum> funcEnum(const std::list<Enum0Enum>& paramEnum) = 0;
+    /**
+    * Asynchronous version of funcEnum(const std::list<Enum0Enum>& paramEnum)
+    * @return Promise of type std::list<Enum0Enum> which is set once the function has completed
+    */
+    virtual std::future<std::list<Enum0Enum>> funcEnumAsync(const std::list<Enum0Enum>& paramEnum, std::function<void(std::list<Enum0Enum>)> callback = nullptr) = 0;
+
     /**
     * Sets the value of the propBool property.
     */
@@ -94,6 +102,15 @@ public:
     * Gets the value of the propString property.
     */
     virtual const std::list<StructString>& getPropString() const = 0;
+
+    /**
+    * Sets the value of the propEnum property.
+    */
+    virtual void setPropEnum(const std::list<Enum0Enum>& propEnum) = 0;
+    /**
+    * Gets the value of the propEnum property.
+    */
+    virtual const std::list<Enum0Enum>& getPropEnum() const = 0;
 
     /**
     * Access to a publisher, use it to subscribe for StructArrayInterface changes and signal emission.
@@ -145,6 +162,13 @@ public:
     */
     virtual void onSigString(const std::list<StructString>& paramString) = 0;
     /**
+    * Called by the IStructArrayInterfacePublisher when the StructArrayInterface emits sigEnum, if subscribed for the sigEnum.
+    * @param paramEnum 
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual void onSigEnum(const std::list<Enum0Enum>& paramEnum) = 0;
+    /**
     * Called by the IStructArrayInterfacePublisher when propBool value has changed if subscribed for the propBool change.
     *
     * @warning the subscribed function shall not be blocking and must return immediately!
@@ -168,6 +192,12 @@ public:
     * @warning the subscribed function shall not be blocking and must return immediately!
     */
     virtual void onPropStringChanged(const std::list<StructString>& propString) = 0;
+    /**
+    * Called by the IStructArrayInterfacePublisher when propEnum value has changed if subscribed for the propEnum change.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual void onPropEnumChanged(const std::list<Enum0Enum>& propEnum) = 0;
 };
 
 /** Callback for changes of propBool */
@@ -178,6 +208,8 @@ using StructArrayInterfacePropIntPropertyCb = std::function<void(const std::list
 using StructArrayInterfacePropFloatPropertyCb = std::function<void(const std::list<StructFloat>& propFloat)>;
 /** Callback for changes of propString */
 using StructArrayInterfacePropStringPropertyCb = std::function<void(const std::list<StructString>& propString)>;
+/** Callback for changes of propEnum */
+using StructArrayInterfacePropEnumPropertyCb = std::function<void(const std::list<Enum0Enum>& propEnum)>;
 /** Callback for sigBool signal triggers */
 using StructArrayInterfaceSigBoolSignalCb = std::function<void(const std::list<StructBool>& paramBool)> ;
 /** Callback for sigInt signal triggers */
@@ -186,6 +218,8 @@ using StructArrayInterfaceSigIntSignalCb = std::function<void(const std::list<St
 using StructArrayInterfaceSigFloatSignalCb = std::function<void(const std::list<StructFloat>& paramFloat)> ;
 /** Callback for sigString signal triggers */
 using StructArrayInterfaceSigStringSignalCb = std::function<void(const std::list<StructString>& paramString)> ;
+/** Callback for sigEnum signal triggers */
+using StructArrayInterfaceSigEnumSignalCb = std::function<void(const std::list<Enum0Enum>& paramEnum)> ;
 
 
 /**
@@ -292,6 +326,24 @@ public:
     virtual void unsubscribeFromPropStringChanged(uint64_t handleId) = 0;
 
     /**
+    * Use this function to subscribe for propEnum value changes.
+    * If your subscriber uses subscription with IStructArrayInterfaceSubscriber interface, you will get two notifications, one for each subscription mechanism.
+    * @param StructArrayInterfacePropEnumPropertyCb callback that will be executed on each change of the property.
+    * Make sure to remove subscription before the callback becomes invalid.
+    * @return subscription token for the subscription removal.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual uint64_t subscribeToPropEnumChanged(StructArrayInterfacePropEnumPropertyCb callback) = 0;
+    /**
+    * Use this function to unsubscribe from propEnum property changes.
+    * If your subscriber uses subscription with IStructArrayInterfaceSubscriber interface, you will be still informed about this change,
+    * as those are two independent subscription mechanisms.
+    * @param subscription token received on subscription.
+    */
+    virtual void unsubscribeFromPropEnumChanged(uint64_t handleId) = 0;
+
+    /**
     * Use this function to subscribe for sigBool signal changes.
     * @param StructArrayInterfaceSigBoolSignalCb callback that will be executed on each signal emission.
     * Make sure to remove subscription before the callback becomes invalid.
@@ -352,6 +404,21 @@ public:
     virtual void unsubscribeFromSigString(uint64_t handleId) = 0;
 
     /**
+    * Use this function to subscribe for sigEnum signal changes.
+    * @param StructArrayInterfaceSigEnumSignalCb callback that will be executed on each signal emission.
+    * Make sure to remove subscription before the callback becomes invalid.
+    * @return subscription token for the subscription removal.
+    *
+    * @warning the subscribed function shall not be blocking and must return immediately!
+    */
+    virtual uint64_t subscribeToSigEnum(StructArrayInterfaceSigEnumSignalCb callback) = 0;
+    /**
+    * Use this function to unsubscribe from sigEnum signal changes.
+    * @param subscription token received on subscription.
+    */
+    virtual void unsubscribeFromSigEnum(uint64_t handleId) = 0;
+
+    /**
     * Publishes the property changed to all subscribed clients.
     * Needs to be invoked by the StructArrayInterface implementation when property propBool changes.
     * @param The new value of propBool.
@@ -376,6 +443,12 @@ public:
     */
     virtual void publishPropStringChanged(const std::list<StructString>& propString) const = 0;
     /**
+    * Publishes the property changed to all subscribed clients.
+    * Needs to be invoked by the StructArrayInterface implementation when property propEnum changes.
+    * @param The new value of propEnum.
+    */
+    virtual void publishPropEnumChanged(const std::list<Enum0Enum>& propEnum) const = 0;
+    /**
     * Publishes the emitted signal to all subscribed clients.
     * Needs to be invoked by the StructArrayInterface implementation when sigBool is emitted.
     * @param paramBool 
@@ -399,6 +472,12 @@ public:
     * @param paramString 
     */
     virtual void publishSigString(const std::list<StructString>& paramString) const = 0;
+    /**
+    * Publishes the emitted signal to all subscribed clients.
+    * Needs to be invoked by the StructArrayInterface implementation when sigEnum is emitted.
+    * @param paramEnum 
+    */
+    virtual void publishSigEnum(const std::list<Enum0Enum>& paramEnum) const = 0;
 };
 
 

--- a/goldenmaster/modules/testbed1/generated/api/testbed1.h
+++ b/goldenmaster/modules/testbed1/generated/api/testbed1.h
@@ -3,3 +3,4 @@
 #include "testbed1/generated/api/datastructs.api.h"
 #include "testbed1/generated/api/structinterface.api.h"
 #include "testbed1/generated/api/structarrayinterface.api.h"
+#include "testbed1/generated/api/structarray2interface.api.h"

--- a/goldenmaster/modules/testbed1/generated/core/CMakeLists.txt
+++ b/goldenmaster/modules/testbed1/generated/core/CMakeLists.txt
@@ -12,6 +12,8 @@ set (SOURCES_CORE_SUPPORT
     structinterface.threadsafedecorator.cpp
     structarrayinterface.publisher.cpp
     structarrayinterface.threadsafedecorator.cpp
+    structarray2interface.publisher.cpp
+    structarray2interface.threadsafedecorator.cpp
 )
 add_library(testbed1-core SHARED ${SOURCES_CORE_SUPPORT})
 add_library(testbed1::testbed1-core ALIAS testbed1-core)

--- a/goldenmaster/modules/testbed1/generated/core/structarray2interface.data.h
+++ b/goldenmaster/modules/testbed1/generated/core/structarray2interface.data.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "testbed1/generated/api/testbed1.h"
+
+
+namespace Test
+{
+namespace Testbed1
+{
+
+/**
+* A helper structure for implementations of StructArray2Interface. Stores all the properties.
+*/
+struct StructArray2InterfaceData
+{
+    StructBoolWithArray m_propBool {StructBoolWithArray()};
+    StructIntWithArray m_propInt {StructIntWithArray()};
+    StructFloatWithArray m_propFloat {StructFloatWithArray()};
+    StructStringWithArray m_propString {StructStringWithArray()};
+    StructEnumWithArray m_propEnum {StructEnumWithArray()};
+};
+
+}
+}

--- a/goldenmaster/modules/testbed1/generated/core/structarray2interface.publisher.cpp
+++ b/goldenmaster/modules/testbed1/generated/core/structarray2interface.publisher.cpp
@@ -1,0 +1,228 @@
+
+
+#include "testbed1/generated/core/structarray2interface.publisher.h"
+#include <algorithm>
+
+
+using namespace Test::Testbed1;
+
+void StructArray2InterfacePublisher::subscribeToAllChanges(IStructArray2InterfaceSubscriber& subscriber)
+{
+    std::unique_lock<std::shared_timed_mutex> lock(m_allChangesSubscribersMutex);
+    auto found = std::find_if(m_allChangesSubscribers.begin(), m_allChangesSubscribers.end(),
+                        [&subscriber](const auto element){return &(element.get()) == &subscriber;});
+    if (found == m_allChangesSubscribers.end())
+    {
+        m_allChangesSubscribers.push_back(std::reference_wrapper<IStructArray2InterfaceSubscriber>(subscriber));
+    }
+}
+
+void StructArray2InterfacePublisher::unsubscribeFromAllChanges(IStructArray2InterfaceSubscriber& subscriber)
+{
+    std::unique_lock<std::shared_timed_mutex> lock(m_allChangesSubscribersMutex);
+    auto found = std::find_if(m_allChangesSubscribers.begin(), m_allChangesSubscribers.end(),
+                        [&subscriber](const auto element){return &(element.get()) == &subscriber;});
+    if (found != m_allChangesSubscribers.end())
+    {
+        m_allChangesSubscribers.erase(found);
+    }
+}
+
+uint64_t StructArray2InterfacePublisher::subscribeToPropBoolChanged(StructArray2InterfacePropBoolPropertyCb callback)
+{
+    return PropBoolPublisher.subscribeForChange(callback);
+}
+
+void StructArray2InterfacePublisher::unsubscribeFromPropBoolChanged(uint64_t handleId)
+{
+    PropBoolPublisher.unsubscribeFromChange(handleId);
+}
+
+void StructArray2InterfacePublisher::publishPropBoolChanged(const StructBoolWithArray& propBool) const
+{
+    std::shared_lock<std::shared_timed_mutex> allChangesSubscribersLock(m_allChangesSubscribersMutex);
+    const auto allChangesSubscribers = m_allChangesSubscribers;
+    allChangesSubscribersLock.unlock();
+    for(const auto& subscriber: allChangesSubscribers)
+    {
+        subscriber.get().onPropBoolChanged(propBool);
+    }
+    PropBoolPublisher.publishChange(propBool);
+}
+
+uint64_t StructArray2InterfacePublisher::subscribeToPropIntChanged(StructArray2InterfacePropIntPropertyCb callback)
+{
+    return PropIntPublisher.subscribeForChange(callback);
+}
+
+void StructArray2InterfacePublisher::unsubscribeFromPropIntChanged(uint64_t handleId)
+{
+    PropIntPublisher.unsubscribeFromChange(handleId);
+}
+
+void StructArray2InterfacePublisher::publishPropIntChanged(const StructIntWithArray& propInt) const
+{
+    std::shared_lock<std::shared_timed_mutex> allChangesSubscribersLock(m_allChangesSubscribersMutex);
+    const auto allChangesSubscribers = m_allChangesSubscribers;
+    allChangesSubscribersLock.unlock();
+    for(const auto& subscriber: allChangesSubscribers)
+    {
+        subscriber.get().onPropIntChanged(propInt);
+    }
+    PropIntPublisher.publishChange(propInt);
+}
+
+uint64_t StructArray2InterfacePublisher::subscribeToPropFloatChanged(StructArray2InterfacePropFloatPropertyCb callback)
+{
+    return PropFloatPublisher.subscribeForChange(callback);
+}
+
+void StructArray2InterfacePublisher::unsubscribeFromPropFloatChanged(uint64_t handleId)
+{
+    PropFloatPublisher.unsubscribeFromChange(handleId);
+}
+
+void StructArray2InterfacePublisher::publishPropFloatChanged(const StructFloatWithArray& propFloat) const
+{
+    std::shared_lock<std::shared_timed_mutex> allChangesSubscribersLock(m_allChangesSubscribersMutex);
+    const auto allChangesSubscribers = m_allChangesSubscribers;
+    allChangesSubscribersLock.unlock();
+    for(const auto& subscriber: allChangesSubscribers)
+    {
+        subscriber.get().onPropFloatChanged(propFloat);
+    }
+    PropFloatPublisher.publishChange(propFloat);
+}
+
+uint64_t StructArray2InterfacePublisher::subscribeToPropStringChanged(StructArray2InterfacePropStringPropertyCb callback)
+{
+    return PropStringPublisher.subscribeForChange(callback);
+}
+
+void StructArray2InterfacePublisher::unsubscribeFromPropStringChanged(uint64_t handleId)
+{
+    PropStringPublisher.unsubscribeFromChange(handleId);
+}
+
+void StructArray2InterfacePublisher::publishPropStringChanged(const StructStringWithArray& propString) const
+{
+    std::shared_lock<std::shared_timed_mutex> allChangesSubscribersLock(m_allChangesSubscribersMutex);
+    const auto allChangesSubscribers = m_allChangesSubscribers;
+    allChangesSubscribersLock.unlock();
+    for(const auto& subscriber: allChangesSubscribers)
+    {
+        subscriber.get().onPropStringChanged(propString);
+    }
+    PropStringPublisher.publishChange(propString);
+}
+
+uint64_t StructArray2InterfacePublisher::subscribeToPropEnumChanged(StructArray2InterfacePropEnumPropertyCb callback)
+{
+    return PropEnumPublisher.subscribeForChange(callback);
+}
+
+void StructArray2InterfacePublisher::unsubscribeFromPropEnumChanged(uint64_t handleId)
+{
+    PropEnumPublisher.unsubscribeFromChange(handleId);
+}
+
+void StructArray2InterfacePublisher::publishPropEnumChanged(const StructEnumWithArray& propEnum) const
+{
+    std::shared_lock<std::shared_timed_mutex> allChangesSubscribersLock(m_allChangesSubscribersMutex);
+    const auto allChangesSubscribers = m_allChangesSubscribers;
+    allChangesSubscribersLock.unlock();
+    for(const auto& subscriber: allChangesSubscribers)
+    {
+        subscriber.get().onPropEnumChanged(propEnum);
+    }
+    PropEnumPublisher.publishChange(propEnum);
+}
+
+uint64_t StructArray2InterfacePublisher::subscribeToSigBool(StructArray2InterfaceSigBoolSignalCb callback)
+{
+    return SigBoolPublisher.subscribeForChange(callback);
+}
+
+void StructArray2InterfacePublisher::unsubscribeFromSigBool(uint64_t handleId)
+{
+    SigBoolPublisher.unsubscribeFromChange(handleId);
+}
+
+void StructArray2InterfacePublisher::publishSigBool(const StructBoolWithArray& paramBool) const
+{
+    std::shared_lock<std::shared_timed_mutex> allChangesSubscribersLock(m_allChangesSubscribersMutex);
+    const auto allChangesSubscribers = m_allChangesSubscribers;
+    allChangesSubscribersLock.unlock();
+    for(const auto& subscriber: allChangesSubscribers)
+    {
+        subscriber.get().onSigBool(paramBool);
+    }
+    SigBoolPublisher.publishChange(paramBool);
+}
+
+uint64_t StructArray2InterfacePublisher::subscribeToSigInt(StructArray2InterfaceSigIntSignalCb callback)
+{
+    return SigIntPublisher.subscribeForChange(callback);
+}
+
+void StructArray2InterfacePublisher::unsubscribeFromSigInt(uint64_t handleId)
+{
+    SigIntPublisher.unsubscribeFromChange(handleId);
+}
+
+void StructArray2InterfacePublisher::publishSigInt(const StructIntWithArray& paramInt) const
+{
+    std::shared_lock<std::shared_timed_mutex> allChangesSubscribersLock(m_allChangesSubscribersMutex);
+    const auto allChangesSubscribers = m_allChangesSubscribers;
+    allChangesSubscribersLock.unlock();
+    for(const auto& subscriber: allChangesSubscribers)
+    {
+        subscriber.get().onSigInt(paramInt);
+    }
+    SigIntPublisher.publishChange(paramInt);
+}
+
+uint64_t StructArray2InterfacePublisher::subscribeToSigFloat(StructArray2InterfaceSigFloatSignalCb callback)
+{
+    return SigFloatPublisher.subscribeForChange(callback);
+}
+
+void StructArray2InterfacePublisher::unsubscribeFromSigFloat(uint64_t handleId)
+{
+    SigFloatPublisher.unsubscribeFromChange(handleId);
+}
+
+void StructArray2InterfacePublisher::publishSigFloat(const StructFloatWithArray& paramFloat) const
+{
+    std::shared_lock<std::shared_timed_mutex> allChangesSubscribersLock(m_allChangesSubscribersMutex);
+    const auto allChangesSubscribers = m_allChangesSubscribers;
+    allChangesSubscribersLock.unlock();
+    for(const auto& subscriber: allChangesSubscribers)
+    {
+        subscriber.get().onSigFloat(paramFloat);
+    }
+    SigFloatPublisher.publishChange(paramFloat);
+}
+
+uint64_t StructArray2InterfacePublisher::subscribeToSigString(StructArray2InterfaceSigStringSignalCb callback)
+{
+    return SigStringPublisher.subscribeForChange(callback);
+}
+
+void StructArray2InterfacePublisher::unsubscribeFromSigString(uint64_t handleId)
+{
+    SigStringPublisher.unsubscribeFromChange(handleId);
+}
+
+void StructArray2InterfacePublisher::publishSigString(const StructStringWithArray& paramString) const
+{
+    std::shared_lock<std::shared_timed_mutex> allChangesSubscribersLock(m_allChangesSubscribersMutex);
+    const auto allChangesSubscribers = m_allChangesSubscribers;
+    allChangesSubscribersLock.unlock();
+    for(const auto& subscriber: allChangesSubscribers)
+    {
+        subscriber.get().onSigString(paramString);
+    }
+    SigStringPublisher.publishChange(paramString);
+}
+

--- a/goldenmaster/modules/testbed1/generated/core/structarray2interface.publisher.h
+++ b/goldenmaster/modules/testbed1/generated/core/structarray2interface.publisher.h
@@ -1,0 +1,172 @@
+#pragma once
+
+#include "testbed1/generated/api/datastructs.api.h"
+#include "testbed1/generated/api/structarray2interface.api.h"
+#include "testbed1/generated/api/common.h"
+
+#include <atomic>
+#include <vector>
+#include <map>
+#include <functional>
+#include <shared_mutex>
+#include <apigear/utilities/single_pub.hpp>
+
+namespace Test {
+namespace Testbed1 {
+
+/**
+ * The implementation of a StructArray2InterfacePublisher.
+ * Use this class to store clients of the StructArray2Interface and inform them about the change
+ * on call of the appropriate publish function.
+ *
+ * @warning Subscription management (subscribe/unsubscribe) is thread safe. However, subscriber
+ * callbacks are invoked without holding any internal lock — the subscriber itself must be
+ * thread safe if it can be called from multiple threads.
+ */
+class TEST_TESTBED1_EXPORT StructArray2InterfacePublisher : public IStructArray2InterfacePublisher
+{
+public:
+    /**
+    * Implementation of IStructArray2InterfacePublisher::subscribeToAllChanges
+    */
+    void subscribeToAllChanges(IStructArray2InterfaceSubscriber& subscriber) override;
+    /**
+    * Implementation of IStructArray2InterfacePublisher::unsubscribeFromAllChanges
+    */
+    void unsubscribeFromAllChanges(IStructArray2InterfaceSubscriber& subscriber) override;
+
+    /**
+    * Implementation of IStructArray2InterfacePublisher::subscribeToPropBoolChanged
+    */
+    uint64_t subscribeToPropBoolChanged(StructArray2InterfacePropBoolPropertyCb callback) override;
+    /**
+    * Implementation of IStructArray2InterfacePublisher::subscribeToPropBoolChanged
+    */
+    void unsubscribeFromPropBoolChanged(uint64_t handleId) override;
+
+    /**
+    * Implementation of IStructArray2InterfacePublisher::subscribeToPropIntChanged
+    */
+    uint64_t subscribeToPropIntChanged(StructArray2InterfacePropIntPropertyCb callback) override;
+    /**
+    * Implementation of IStructArray2InterfacePublisher::subscribeToPropIntChanged
+    */
+    void unsubscribeFromPropIntChanged(uint64_t handleId) override;
+
+    /**
+    * Implementation of IStructArray2InterfacePublisher::subscribeToPropFloatChanged
+    */
+    uint64_t subscribeToPropFloatChanged(StructArray2InterfacePropFloatPropertyCb callback) override;
+    /**
+    * Implementation of IStructArray2InterfacePublisher::subscribeToPropFloatChanged
+    */
+    void unsubscribeFromPropFloatChanged(uint64_t handleId) override;
+
+    /**
+    * Implementation of IStructArray2InterfacePublisher::subscribeToPropStringChanged
+    */
+    uint64_t subscribeToPropStringChanged(StructArray2InterfacePropStringPropertyCb callback) override;
+    /**
+    * Implementation of IStructArray2InterfacePublisher::subscribeToPropStringChanged
+    */
+    void unsubscribeFromPropStringChanged(uint64_t handleId) override;
+
+    /**
+    * Implementation of IStructArray2InterfacePublisher::subscribeToPropEnumChanged
+    */
+    uint64_t subscribeToPropEnumChanged(StructArray2InterfacePropEnumPropertyCb callback) override;
+    /**
+    * Implementation of IStructArray2InterfacePublisher::subscribeToPropEnumChanged
+    */
+    void unsubscribeFromPropEnumChanged(uint64_t handleId) override;
+
+    /**
+    * Implementation of IStructArray2InterfacePublisher::subscribeToSigBool
+    */
+    uint64_t subscribeToSigBool(StructArray2InterfaceSigBoolSignalCb callback) override;
+    /**
+    * Implementation of IStructArray2InterfacePublisher::unsubscribeFromSigBool
+    */
+    void unsubscribeFromSigBool(uint64_t handleId) override;
+
+    /**
+    * Implementation of IStructArray2InterfacePublisher::subscribeToSigInt
+    */
+    uint64_t subscribeToSigInt(StructArray2InterfaceSigIntSignalCb callback) override;
+    /**
+    * Implementation of IStructArray2InterfacePublisher::unsubscribeFromSigInt
+    */
+    void unsubscribeFromSigInt(uint64_t handleId) override;
+
+    /**
+    * Implementation of IStructArray2InterfacePublisher::subscribeToSigFloat
+    */
+    uint64_t subscribeToSigFloat(StructArray2InterfaceSigFloatSignalCb callback) override;
+    /**
+    * Implementation of IStructArray2InterfacePublisher::unsubscribeFromSigFloat
+    */
+    void unsubscribeFromSigFloat(uint64_t handleId) override;
+
+    /**
+    * Implementation of IStructArray2InterfacePublisher::subscribeToSigString
+    */
+    uint64_t subscribeToSigString(StructArray2InterfaceSigStringSignalCb callback) override;
+    /**
+    * Implementation of IStructArray2InterfacePublisher::unsubscribeFromSigString
+    */
+    void unsubscribeFromSigString(uint64_t handleId) override;
+
+    /**
+    * Implementation of IStructArray2InterfacePublisher::publishPropBoolChanged
+    */
+    void publishPropBoolChanged(const StructBoolWithArray& propBool) const override;
+    /**
+    * Implementation of IStructArray2InterfacePublisher::publishPropIntChanged
+    */
+    void publishPropIntChanged(const StructIntWithArray& propInt) const override;
+    /**
+    * Implementation of IStructArray2InterfacePublisher::publishPropFloatChanged
+    */
+    void publishPropFloatChanged(const StructFloatWithArray& propFloat) const override;
+    /**
+    * Implementation of IStructArray2InterfacePublisher::publishPropStringChanged
+    */
+    void publishPropStringChanged(const StructStringWithArray& propString) const override;
+    /**
+    * Implementation of IStructArray2InterfacePublisher::publishPropEnumChanged
+    */
+    void publishPropEnumChanged(const StructEnumWithArray& propEnum) const override;
+    /**
+    * Implementation of IStructArray2InterfacePublisher::publishSigBool
+    */
+    void publishSigBool(const StructBoolWithArray& paramBool) const override;
+    /**
+    * Implementation of IStructArray2InterfacePublisher::publishSigInt
+    */
+    void publishSigInt(const StructIntWithArray& paramInt) const override;
+    /**
+    * Implementation of IStructArray2InterfacePublisher::publishSigFloat
+    */
+    void publishSigFloat(const StructFloatWithArray& paramFloat) const override;
+    /**
+    * Implementation of IStructArray2InterfacePublisher::publishSigString
+    */
+    void publishSigString(const StructStringWithArray& paramString) const override;
+private:
+    // Subscribers informed about any property change or signal emitted in StructArray2Interface
+    std::vector<std::reference_wrapper<IStructArray2InterfaceSubscriber>> m_allChangesSubscribers;
+    // Mutex for m_allChangesSubscribers
+    mutable std::shared_timed_mutex m_allChangesSubscribersMutex;
+    ApiGear::Utilities::SinglePub<StructBoolWithArray> PropBoolPublisher;
+    ApiGear::Utilities::SinglePub<StructIntWithArray> PropIntPublisher;
+    ApiGear::Utilities::SinglePub<StructFloatWithArray> PropFloatPublisher;
+    ApiGear::Utilities::SinglePub<StructStringWithArray> PropStringPublisher;
+    ApiGear::Utilities::SinglePub<StructEnumWithArray> PropEnumPublisher;
+    ApiGear::Utilities::SinglePub<StructBoolWithArray> SigBoolPublisher;
+    ApiGear::Utilities::SinglePub<StructIntWithArray> SigIntPublisher;
+    ApiGear::Utilities::SinglePub<StructFloatWithArray> SigFloatPublisher;
+    ApiGear::Utilities::SinglePub<StructStringWithArray> SigStringPublisher;
+};
+
+} // namespace Testbed1
+} // namespace Test

--- a/goldenmaster/modules/testbed1/generated/core/structarray2interface.threadsafedecorator.cpp
+++ b/goldenmaster/modules/testbed1/generated/core/structarray2interface.threadsafedecorator.cpp
@@ -1,0 +1,114 @@
+
+
+#include "testbed1/generated/core/structarray2interface.threadsafedecorator.h"
+
+using namespace Test::Testbed1;
+StructArray2InterfaceThreadSafeDecorator::StructArray2InterfaceThreadSafeDecorator(std::shared_ptr<IStructArray2Interface> impl)
+    : m_impl(impl)
+{
+}
+std::list<StructBool> StructArray2InterfaceThreadSafeDecorator::funcBool(const StructBoolWithArray& paramBool)
+{
+    return m_impl->funcBool(paramBool);
+}
+
+std::future<std::list<StructBool>> StructArray2InterfaceThreadSafeDecorator::funcBoolAsync(const StructBoolWithArray& paramBool, std::function<void(std::list<StructBool>)> callback)
+{
+    return m_impl->funcBoolAsync(paramBool, callback);
+}
+std::list<StructInt> StructArray2InterfaceThreadSafeDecorator::funcInt(const StructIntWithArray& paramInt)
+{
+    return m_impl->funcInt(paramInt);
+}
+
+std::future<std::list<StructInt>> StructArray2InterfaceThreadSafeDecorator::funcIntAsync(const StructIntWithArray& paramInt, std::function<void(std::list<StructInt>)> callback)
+{
+    return m_impl->funcIntAsync(paramInt, callback);
+}
+std::list<StructFloat> StructArray2InterfaceThreadSafeDecorator::funcFloat(const StructFloatWithArray& paramFloat)
+{
+    return m_impl->funcFloat(paramFloat);
+}
+
+std::future<std::list<StructFloat>> StructArray2InterfaceThreadSafeDecorator::funcFloatAsync(const StructFloatWithArray& paramFloat, std::function<void(std::list<StructFloat>)> callback)
+{
+    return m_impl->funcFloatAsync(paramFloat, callback);
+}
+std::list<StructString> StructArray2InterfaceThreadSafeDecorator::funcString(const StructStringWithArray& paramString)
+{
+    return m_impl->funcString(paramString);
+}
+
+std::future<std::list<StructString>> StructArray2InterfaceThreadSafeDecorator::funcStringAsync(const StructStringWithArray& paramString, std::function<void(std::list<StructString>)> callback)
+{
+    return m_impl->funcStringAsync(paramString, callback);
+}
+std::list<Enum0Enum> StructArray2InterfaceThreadSafeDecorator::funcEnum(const StructEnumWithArray& paramEnum)
+{
+    return m_impl->funcEnum(paramEnum);
+}
+
+std::future<std::list<Enum0Enum>> StructArray2InterfaceThreadSafeDecorator::funcEnumAsync(const StructEnumWithArray& paramEnum, std::function<void(std::list<Enum0Enum>)> callback)
+{
+    return m_impl->funcEnumAsync(paramEnum, callback);
+}
+void StructArray2InterfaceThreadSafeDecorator::setPropBool(const StructBoolWithArray& propBool)
+{
+    std::unique_lock<std::shared_timed_mutex> lock(m_propBoolMutex);
+    m_impl->setPropBool(propBool);
+}
+
+const StructBoolWithArray& StructArray2InterfaceThreadSafeDecorator::getPropBool() const
+{
+    std::shared_lock<std::shared_timed_mutex> lock(m_propBoolMutex);
+    return m_impl->getPropBool();
+}
+void StructArray2InterfaceThreadSafeDecorator::setPropInt(const StructIntWithArray& propInt)
+{
+    std::unique_lock<std::shared_timed_mutex> lock(m_propIntMutex);
+    m_impl->setPropInt(propInt);
+}
+
+const StructIntWithArray& StructArray2InterfaceThreadSafeDecorator::getPropInt() const
+{
+    std::shared_lock<std::shared_timed_mutex> lock(m_propIntMutex);
+    return m_impl->getPropInt();
+}
+void StructArray2InterfaceThreadSafeDecorator::setPropFloat(const StructFloatWithArray& propFloat)
+{
+    std::unique_lock<std::shared_timed_mutex> lock(m_propFloatMutex);
+    m_impl->setPropFloat(propFloat);
+}
+
+const StructFloatWithArray& StructArray2InterfaceThreadSafeDecorator::getPropFloat() const
+{
+    std::shared_lock<std::shared_timed_mutex> lock(m_propFloatMutex);
+    return m_impl->getPropFloat();
+}
+void StructArray2InterfaceThreadSafeDecorator::setPropString(const StructStringWithArray& propString)
+{
+    std::unique_lock<std::shared_timed_mutex> lock(m_propStringMutex);
+    m_impl->setPropString(propString);
+}
+
+const StructStringWithArray& StructArray2InterfaceThreadSafeDecorator::getPropString() const
+{
+    std::shared_lock<std::shared_timed_mutex> lock(m_propStringMutex);
+    return m_impl->getPropString();
+}
+void StructArray2InterfaceThreadSafeDecorator::setPropEnum(const StructEnumWithArray& propEnum)
+{
+    std::unique_lock<std::shared_timed_mutex> lock(m_propEnumMutex);
+    m_impl->setPropEnum(propEnum);
+}
+
+const StructEnumWithArray& StructArray2InterfaceThreadSafeDecorator::getPropEnum() const
+{
+    std::shared_lock<std::shared_timed_mutex> lock(m_propEnumMutex);
+    return m_impl->getPropEnum();
+}
+
+IStructArray2InterfacePublisher& StructArray2InterfaceThreadSafeDecorator::_getPublisher() const
+{
+    return m_impl->_getPublisher();
+}

--- a/goldenmaster/modules/testbed1/generated/core/structarray2interface.threadsafedecorator.h
+++ b/goldenmaster/modules/testbed1/generated/core/structarray2interface.threadsafedecorator.h
@@ -1,0 +1,151 @@
+
+#pragma once
+#include "testbed1/generated/api/testbed1.h"
+#include "testbed1/generated/api/common.h"
+#include <memory>
+#include <shared_mutex>
+
+namespace Test {
+namespace Testbed1 {
+
+/**
+* @brief The StructArray2InterfaceThreadSafeDecorator can be used to make property access thread safe.
+*
+* Each property is guarded with its own @c std::shared_timed_mutex — multiple concurrent
+* get calls are allowed, but a set call is exclusive.
+*
+* @note Operation (method) calls are NOT guarded by this decorator. If the underlying
+* implementation is not thread safe, callers must coordinate access to operations themselves.
+* Operations can be locked by adding the same mutex mechanism in the concrete
+* implementation of StructArray2Interface.
+* @see StructArray2Interface
+*
+\code{.cpp}
+using namespace Test::Testbed1;
+
+std::unique_ptr<IStructArray2Interface> testStructArray2Interface = std::make_unique<StructArray2InterfaceThreadSafeDecorator>(std::make_shared<StructArray2Interface>());
+
+// Thread safe access
+auto propBool = testStructArray2Interface->getPropBool();
+testStructArray2Interface->setPropBool(StructBoolWithArray());
+auto propInt = testStructArray2Interface->getPropInt();
+testStructArray2Interface->setPropInt(StructIntWithArray());
+auto propFloat = testStructArray2Interface->getPropFloat();
+testStructArray2Interface->setPropFloat(StructFloatWithArray());
+auto propString = testStructArray2Interface->getPropString();
+testStructArray2Interface->setPropString(StructStringWithArray());
+auto propEnum = testStructArray2Interface->getPropEnum();
+testStructArray2Interface->setPropEnum(StructEnumWithArray());
+\endcode
+*/
+class TEST_TESTBED1_EXPORT StructArray2InterfaceThreadSafeDecorator : public IStructArray2Interface
+{
+public:
+    /** 
+    * ctor
+    * @param impl The StructArray2Interface object to make thread safe.
+    */
+    explicit StructArray2InterfaceThreadSafeDecorator(std::shared_ptr<IStructArray2Interface> impl);
+
+    /** 
+    * Forwards call to StructArray2Interface implementation.
+    * @warning This forward call is not made thread safe by this class.
+    */
+    std::list<StructBool> funcBool(const StructBoolWithArray& paramBool) override;
+    /** 
+    * Forwards call to StructArray2Interface implementation.
+    * @warning This forward call is not made thread safe by this class.
+    */
+    std::future<std::list<StructBool>> funcBoolAsync(const StructBoolWithArray& paramBool, std::function<void(std::list<StructBool>)> callback = nullptr) override;
+
+    /** 
+    * Forwards call to StructArray2Interface implementation.
+    * @warning This forward call is not made thread safe by this class.
+    */
+    std::list<StructInt> funcInt(const StructIntWithArray& paramInt) override;
+    /** 
+    * Forwards call to StructArray2Interface implementation.
+    * @warning This forward call is not made thread safe by this class.
+    */
+    std::future<std::list<StructInt>> funcIntAsync(const StructIntWithArray& paramInt, std::function<void(std::list<StructInt>)> callback = nullptr) override;
+
+    /** 
+    * Forwards call to StructArray2Interface implementation.
+    * @warning This forward call is not made thread safe by this class.
+    */
+    std::list<StructFloat> funcFloat(const StructFloatWithArray& paramFloat) override;
+    /** 
+    * Forwards call to StructArray2Interface implementation.
+    * @warning This forward call is not made thread safe by this class.
+    */
+    std::future<std::list<StructFloat>> funcFloatAsync(const StructFloatWithArray& paramFloat, std::function<void(std::list<StructFloat>)> callback = nullptr) override;
+
+    /** 
+    * Forwards call to StructArray2Interface implementation.
+    * @warning This forward call is not made thread safe by this class.
+    */
+    std::list<StructString> funcString(const StructStringWithArray& paramString) override;
+    /** 
+    * Forwards call to StructArray2Interface implementation.
+    * @warning This forward call is not made thread safe by this class.
+    */
+    std::future<std::list<StructString>> funcStringAsync(const StructStringWithArray& paramString, std::function<void(std::list<StructString>)> callback = nullptr) override;
+
+    /** 
+    * Forwards call to StructArray2Interface implementation.
+    * @warning This forward call is not made thread safe by this class.
+    */
+    std::list<Enum0Enum> funcEnum(const StructEnumWithArray& paramEnum) override;
+    /** 
+    * Forwards call to StructArray2Interface implementation.
+    * @warning This forward call is not made thread safe by this class.
+    */
+    std::future<std::list<Enum0Enum>> funcEnumAsync(const StructEnumWithArray& paramEnum, std::function<void(std::list<Enum0Enum>)> callback = nullptr) override;
+
+    /** Guards and forwards call to StructArray2Interface implementation. */
+    void setPropBool(const StructBoolWithArray& propBool) override;
+    /** Guards and forwards call to StructArray2Interface implementation. */
+    const StructBoolWithArray& getPropBool() const override;
+
+    /** Guards and forwards call to StructArray2Interface implementation. */
+    void setPropInt(const StructIntWithArray& propInt) override;
+    /** Guards and forwards call to StructArray2Interface implementation. */
+    const StructIntWithArray& getPropInt() const override;
+
+    /** Guards and forwards call to StructArray2Interface implementation. */
+    void setPropFloat(const StructFloatWithArray& propFloat) override;
+    /** Guards and forwards call to StructArray2Interface implementation. */
+    const StructFloatWithArray& getPropFloat() const override;
+
+    /** Guards and forwards call to StructArray2Interface implementation. */
+    void setPropString(const StructStringWithArray& propString) override;
+    /** Guards and forwards call to StructArray2Interface implementation. */
+    const StructStringWithArray& getPropString() const override;
+
+    /** Guards and forwards call to StructArray2Interface implementation. */
+    void setPropEnum(const StructEnumWithArray& propEnum) override;
+    /** Guards and forwards call to StructArray2Interface implementation. */
+    const StructEnumWithArray& getPropEnum() const override;
+
+    /**
+    * Access to a publisher, use it to subscribe for StructArray2Interface changes and signal emission.
+    * This call is thread safe.
+    * @return The publisher for StructArray2Interface.
+    */
+    IStructArray2InterfacePublisher& _getPublisher() const override;
+private:
+    /** The StructArray2Interface object which is guarded */
+    std::shared_ptr<IStructArray2Interface> m_impl;
+    // Mutex for propBool property
+    mutable std::shared_timed_mutex m_propBoolMutex;
+    // Mutex for propInt property
+    mutable std::shared_timed_mutex m_propIntMutex;
+    // Mutex for propFloat property
+    mutable std::shared_timed_mutex m_propFloatMutex;
+    // Mutex for propString property
+    mutable std::shared_timed_mutex m_propStringMutex;
+    // Mutex for propEnum property
+    mutable std::shared_timed_mutex m_propEnumMutex;
+};
+} // namespace Testbed1
+} // namespace Test

--- a/goldenmaster/modules/testbed1/generated/core/structarrayinterface.data.h
+++ b/goldenmaster/modules/testbed1/generated/core/structarrayinterface.data.h
@@ -17,6 +17,7 @@ struct StructArrayInterfaceData
     std::list<StructInt> m_propInt {std::list<StructInt>()};
     std::list<StructFloat> m_propFloat {std::list<StructFloat>()};
     std::list<StructString> m_propString {std::list<StructString>()};
+    std::list<Enum0Enum> m_propEnum {std::list<Enum0Enum>()};
 };
 
 }

--- a/goldenmaster/modules/testbed1/generated/core/structarrayinterface.publisher.cpp
+++ b/goldenmaster/modules/testbed1/generated/core/structarrayinterface.publisher.cpp
@@ -116,6 +116,28 @@ void StructArrayInterfacePublisher::publishPropStringChanged(const std::list<Str
     PropStringPublisher.publishChange(propString);
 }
 
+uint64_t StructArrayInterfacePublisher::subscribeToPropEnumChanged(StructArrayInterfacePropEnumPropertyCb callback)
+{
+    return PropEnumPublisher.subscribeForChange(callback);
+}
+
+void StructArrayInterfacePublisher::unsubscribeFromPropEnumChanged(uint64_t handleId)
+{
+    PropEnumPublisher.unsubscribeFromChange(handleId);
+}
+
+void StructArrayInterfacePublisher::publishPropEnumChanged(const std::list<Enum0Enum>& propEnum) const
+{
+    std::shared_lock<std::shared_timed_mutex> allChangesSubscribersLock(m_allChangesSubscribersMutex);
+    const auto allChangesSubscribers = m_allChangesSubscribers;
+    allChangesSubscribersLock.unlock();
+    for(const auto& subscriber: allChangesSubscribers)
+    {
+        subscriber.get().onPropEnumChanged(propEnum);
+    }
+    PropEnumPublisher.publishChange(propEnum);
+}
+
 uint64_t StructArrayInterfacePublisher::subscribeToSigBool(StructArrayInterfaceSigBoolSignalCb callback)
 {
     return SigBoolPublisher.subscribeForChange(callback);
@@ -202,5 +224,27 @@ void StructArrayInterfacePublisher::publishSigString(const std::list<StructStrin
         subscriber.get().onSigString(paramString);
     }
     SigStringPublisher.publishChange(paramString);
+}
+
+uint64_t StructArrayInterfacePublisher::subscribeToSigEnum(StructArrayInterfaceSigEnumSignalCb callback)
+{
+    return SigEnumPublisher.subscribeForChange(callback);
+}
+
+void StructArrayInterfacePublisher::unsubscribeFromSigEnum(uint64_t handleId)
+{
+    SigEnumPublisher.unsubscribeFromChange(handleId);
+}
+
+void StructArrayInterfacePublisher::publishSigEnum(const std::list<Enum0Enum>& paramEnum) const
+{
+    std::shared_lock<std::shared_timed_mutex> allChangesSubscribersLock(m_allChangesSubscribersMutex);
+    const auto allChangesSubscribers = m_allChangesSubscribers;
+    allChangesSubscribersLock.unlock();
+    for(const auto& subscriber: allChangesSubscribers)
+    {
+        subscriber.get().onSigEnum(paramEnum);
+    }
+    SigEnumPublisher.publishChange(paramEnum);
 }
 

--- a/goldenmaster/modules/testbed1/generated/core/structarrayinterface.publisher.h
+++ b/goldenmaster/modules/testbed1/generated/core/structarrayinterface.publisher.h
@@ -72,6 +72,15 @@ public:
     void unsubscribeFromPropStringChanged(uint64_t handleId) override;
 
     /**
+    * Implementation of IStructArrayInterfacePublisher::subscribeToPropEnumChanged
+    */
+    uint64_t subscribeToPropEnumChanged(StructArrayInterfacePropEnumPropertyCb callback) override;
+    /**
+    * Implementation of IStructArrayInterfacePublisher::subscribeToPropEnumChanged
+    */
+    void unsubscribeFromPropEnumChanged(uint64_t handleId) override;
+
+    /**
     * Implementation of IStructArrayInterfacePublisher::subscribeToSigBool
     */
     uint64_t subscribeToSigBool(StructArrayInterfaceSigBoolSignalCb callback) override;
@@ -108,6 +117,15 @@ public:
     void unsubscribeFromSigString(uint64_t handleId) override;
 
     /**
+    * Implementation of IStructArrayInterfacePublisher::subscribeToSigEnum
+    */
+    uint64_t subscribeToSigEnum(StructArrayInterfaceSigEnumSignalCb callback) override;
+    /**
+    * Implementation of IStructArrayInterfacePublisher::unsubscribeFromSigEnum
+    */
+    void unsubscribeFromSigEnum(uint64_t handleId) override;
+
+    /**
     * Implementation of IStructArrayInterfacePublisher::publishPropBoolChanged
     */
     void publishPropBoolChanged(const std::list<StructBool>& propBool) const override;
@@ -124,6 +142,10 @@ public:
     */
     void publishPropStringChanged(const std::list<StructString>& propString) const override;
     /**
+    * Implementation of IStructArrayInterfacePublisher::publishPropEnumChanged
+    */
+    void publishPropEnumChanged(const std::list<Enum0Enum>& propEnum) const override;
+    /**
     * Implementation of IStructArrayInterfacePublisher::publishSigBool
     */
     void publishSigBool(const std::list<StructBool>& paramBool) const override;
@@ -139,6 +161,10 @@ public:
     * Implementation of IStructArrayInterfacePublisher::publishSigString
     */
     void publishSigString(const std::list<StructString>& paramString) const override;
+    /**
+    * Implementation of IStructArrayInterfacePublisher::publishSigEnum
+    */
+    void publishSigEnum(const std::list<Enum0Enum>& paramEnum) const override;
 private:
     // Subscribers informed about any property change or signal emitted in StructArrayInterface
     std::vector<std::reference_wrapper<IStructArrayInterfaceSubscriber>> m_allChangesSubscribers;
@@ -148,10 +174,12 @@ private:
     ApiGear::Utilities::SinglePub<std::list<StructInt>> PropIntPublisher;
     ApiGear::Utilities::SinglePub<std::list<StructFloat>> PropFloatPublisher;
     ApiGear::Utilities::SinglePub<std::list<StructString>> PropStringPublisher;
+    ApiGear::Utilities::SinglePub<std::list<Enum0Enum>> PropEnumPublisher;
     ApiGear::Utilities::SinglePub<std::list<StructBool>> SigBoolPublisher;
     ApiGear::Utilities::SinglePub<std::list<StructInt>> SigIntPublisher;
     ApiGear::Utilities::SinglePub<std::list<StructFloat>> SigFloatPublisher;
     ApiGear::Utilities::SinglePub<std::list<StructString>> SigStringPublisher;
+    ApiGear::Utilities::SinglePub<std::list<Enum0Enum>> SigEnumPublisher;
 };
 
 } // namespace Testbed1

--- a/goldenmaster/modules/testbed1/generated/core/structarrayinterface.threadsafedecorator.cpp
+++ b/goldenmaster/modules/testbed1/generated/core/structarrayinterface.threadsafedecorator.cpp
@@ -43,6 +43,15 @@ std::future<std::list<StructString>> StructArrayInterfaceThreadSafeDecorator::fu
 {
     return m_impl->funcStringAsync(paramString, callback);
 }
+std::list<Enum0Enum> StructArrayInterfaceThreadSafeDecorator::funcEnum(const std::list<Enum0Enum>& paramEnum)
+{
+    return m_impl->funcEnum(paramEnum);
+}
+
+std::future<std::list<Enum0Enum>> StructArrayInterfaceThreadSafeDecorator::funcEnumAsync(const std::list<Enum0Enum>& paramEnum, std::function<void(std::list<Enum0Enum>)> callback)
+{
+    return m_impl->funcEnumAsync(paramEnum, callback);
+}
 void StructArrayInterfaceThreadSafeDecorator::setPropBool(const std::list<StructBool>& propBool)
 {
     std::unique_lock<std::shared_timed_mutex> lock(m_propBoolMutex);
@@ -86,6 +95,17 @@ const std::list<StructString>& StructArrayInterfaceThreadSafeDecorator::getPropS
 {
     std::shared_lock<std::shared_timed_mutex> lock(m_propStringMutex);
     return m_impl->getPropString();
+}
+void StructArrayInterfaceThreadSafeDecorator::setPropEnum(const std::list<Enum0Enum>& propEnum)
+{
+    std::unique_lock<std::shared_timed_mutex> lock(m_propEnumMutex);
+    m_impl->setPropEnum(propEnum);
+}
+
+const std::list<Enum0Enum>& StructArrayInterfaceThreadSafeDecorator::getPropEnum() const
+{
+    std::shared_lock<std::shared_timed_mutex> lock(m_propEnumMutex);
+    return m_impl->getPropEnum();
 }
 
 IStructArrayInterfacePublisher& StructArrayInterfaceThreadSafeDecorator::_getPublisher() const

--- a/goldenmaster/modules/testbed1/generated/core/structarrayinterface.threadsafedecorator.h
+++ b/goldenmaster/modules/testbed1/generated/core/structarrayinterface.threadsafedecorator.h
@@ -34,6 +34,8 @@ auto propFloat = testStructArrayInterface->getPropFloat();
 testStructArrayInterface->setPropFloat(std::list<StructFloat>());
 auto propString = testStructArrayInterface->getPropString();
 testStructArrayInterface->setPropString(std::list<StructString>());
+auto propEnum = testStructArrayInterface->getPropEnum();
+testStructArrayInterface->setPropEnum(std::list<Enum0Enum>());
 \endcode
 */
 class TEST_TESTBED1_EXPORT StructArrayInterfaceThreadSafeDecorator : public IStructArrayInterface
@@ -89,6 +91,17 @@ public:
     */
     std::future<std::list<StructString>> funcStringAsync(const std::list<StructString>& paramString, std::function<void(std::list<StructString>)> callback = nullptr) override;
 
+    /** 
+    * Forwards call to StructArrayInterface implementation.
+    * @warning This forward call is not made thread safe by this class.
+    */
+    std::list<Enum0Enum> funcEnum(const std::list<Enum0Enum>& paramEnum) override;
+    /** 
+    * Forwards call to StructArrayInterface implementation.
+    * @warning This forward call is not made thread safe by this class.
+    */
+    std::future<std::list<Enum0Enum>> funcEnumAsync(const std::list<Enum0Enum>& paramEnum, std::function<void(std::list<Enum0Enum>)> callback = nullptr) override;
+
     /** Guards and forwards call to StructArrayInterface implementation. */
     void setPropBool(const std::list<StructBool>& propBool) override;
     /** Guards and forwards call to StructArrayInterface implementation. */
@@ -109,6 +122,11 @@ public:
     /** Guards and forwards call to StructArrayInterface implementation. */
     const std::list<StructString>& getPropString() const override;
 
+    /** Guards and forwards call to StructArrayInterface implementation. */
+    void setPropEnum(const std::list<Enum0Enum>& propEnum) override;
+    /** Guards and forwards call to StructArrayInterface implementation. */
+    const std::list<Enum0Enum>& getPropEnum() const override;
+
     /**
     * Access to a publisher, use it to subscribe for StructArrayInterface changes and signal emission.
     * This call is thread safe.
@@ -126,6 +144,8 @@ private:
     mutable std::shared_timed_mutex m_propFloatMutex;
     // Mutex for propString property
     mutable std::shared_timed_mutex m_propStringMutex;
+    // Mutex for propEnum property
+    mutable std::shared_timed_mutex m_propEnumMutex;
 };
 } // namespace Testbed1
 } // namespace Test

--- a/goldenmaster/modules/testbed1/generated/core/test_struct_helper.cpp
+++ b/goldenmaster/modules/testbed1/generated/core/test_struct_helper.cpp
@@ -21,3 +21,62 @@ void Testbed1::fillTestStructString(Testbed1::StructString& test_struct_string)
 {
 	test_struct_string.fieldString = std::string("xyz");
 }
+
+void Testbed1::fillTestStructStruct(Testbed1::StructStruct& test_struct_struct)
+{
+	fillTestStructString(test_struct_struct.fieldString);
+}
+
+void Testbed1::fillTestStructEnum(Testbed1::StructEnum& test_struct_enum)
+{
+	test_struct_enum.fieldEnum = Testbed1::Enum0Enum::value1;
+}
+
+void Testbed1::fillTestStructBoolWithArray(Testbed1::StructBoolWithArray& test_struct_bool_with_array)
+{
+	auto local_field_bool_array = std::list<bool>();
+	auto elementfield_bool = true;
+	local_field_bool_array.push_back(elementfield_bool);
+	test_struct_bool_with_array.fieldBool = local_field_bool_array;
+}
+
+void Testbed1::fillTestStructIntWithArray(Testbed1::StructIntWithArray& test_struct_int_with_array)
+{
+	auto local_field_int_array = std::list<int>();
+	auto elementfield_int = 1;
+	local_field_int_array.push_back(elementfield_int);
+	test_struct_int_with_array.fieldInt = local_field_int_array;
+}
+
+void Testbed1::fillTestStructFloatWithArray(Testbed1::StructFloatWithArray& test_struct_float_with_array)
+{
+	auto local_field_float_array = std::list<float>();
+	auto elementfield_float = 1.1f;
+	local_field_float_array.push_back(elementfield_float);
+	test_struct_float_with_array.fieldFloat = local_field_float_array;
+}
+
+void Testbed1::fillTestStructStringWithArray(Testbed1::StructStringWithArray& test_struct_string_with_array)
+{
+	auto local_field_string_array = std::list<std::string>();
+	auto elementfield_string = std::string("xyz");
+	local_field_string_array.push_back(elementfield_string);
+	test_struct_string_with_array.fieldString = local_field_string_array;
+}
+
+void Testbed1::fillTestStructStructWithArray(Testbed1::StructStructWithArray& test_struct_struct_with_array)
+{
+	auto local_field_struct_array = std::list<Testbed1::StructStringWithArray>();
+	auto elementfield_struct = Testbed1::StructStringWithArray();
+	fillTestStructStringWithArray(elementfield_struct);
+	local_field_struct_array.push_back(elementfield_struct);
+	test_struct_struct_with_array.fieldStruct = local_field_struct_array;
+}
+
+void Testbed1::fillTestStructEnumWithArray(Testbed1::StructEnumWithArray& test_struct_enum_with_array)
+{
+	auto local_field_enum_array = std::list<Testbed1::Enum0Enum>();
+	auto elementfield_enum = Testbed1::Enum0Enum::value1;
+	local_field_enum_array.push_back(elementfield_enum);
+	test_struct_enum_with_array.fieldEnum = local_field_enum_array;
+}

--- a/goldenmaster/modules/testbed1/generated/core/test_struct_helper.h
+++ b/goldenmaster/modules/testbed1/generated/core/test_struct_helper.h
@@ -15,5 +15,21 @@ TEST_TESTBED1_EXPORT void fillTestStructFloat(StructFloat& test_struct_float);
 
 TEST_TESTBED1_EXPORT void fillTestStructString(StructString& test_struct_string);
 
+TEST_TESTBED1_EXPORT void fillTestStructStruct(StructStruct& test_struct_struct);
+
+TEST_TESTBED1_EXPORT void fillTestStructEnum(StructEnum& test_struct_enum);
+
+TEST_TESTBED1_EXPORT void fillTestStructBoolWithArray(StructBoolWithArray& test_struct_bool_with_array);
+
+TEST_TESTBED1_EXPORT void fillTestStructIntWithArray(StructIntWithArray& test_struct_int_with_array);
+
+TEST_TESTBED1_EXPORT void fillTestStructFloatWithArray(StructFloatWithArray& test_struct_float_with_array);
+
+TEST_TESTBED1_EXPORT void fillTestStructStringWithArray(StructStringWithArray& test_struct_string_with_array);
+
+TEST_TESTBED1_EXPORT void fillTestStructStructWithArray(StructStructWithArray& test_struct_struct_with_array);
+
+TEST_TESTBED1_EXPORT void fillTestStructEnumWithArray(StructEnumWithArray& test_struct_enum_with_array);
+
 }
 }

--- a/goldenmaster/modules/testbed1/generated/core/testbed1.json.adapter.cpp
+++ b/goldenmaster/modules/testbed1/generated/core/testbed1.json.adapter.cpp
@@ -70,5 +70,141 @@ std::ostream& operator<<(std::ostream& os, const StructString& obj)
     os << j.dump(4);
     return os;
 }
+void from_json(const nlohmann::json& j, StructStruct& p) {
+    p = StructStruct(
+        j.at("fieldString").get<StructString>()
+    );
+}
+void to_json(nlohmann::json& j, const StructStruct& p) {
+    j = nlohmann::json{
+        {"fieldString", p.fieldString}
+        };
+}
+
+std::ostream& operator<<(std::ostream& os, const StructStruct& obj)
+{
+    nlohmann::json j = obj;
+    os << j.dump(4);
+    return os;
+}
+void from_json(const nlohmann::json& j, StructEnum& p) {
+    p = StructEnum(
+        j.at("fieldEnum").get<Enum0Enum>()
+    );
+}
+void to_json(nlohmann::json& j, const StructEnum& p) {
+    j = nlohmann::json{
+        {"fieldEnum", p.fieldEnum}
+        };
+}
+
+std::ostream& operator<<(std::ostream& os, const StructEnum& obj)
+{
+    nlohmann::json j = obj;
+    os << j.dump(4);
+    return os;
+}
+void from_json(const nlohmann::json& j, StructBoolWithArray& p) {
+    p = StructBoolWithArray(
+        j.at("fieldBool").get<std::list<bool>>()
+    );
+}
+void to_json(nlohmann::json& j, const StructBoolWithArray& p) {
+    j = nlohmann::json{
+        {"fieldBool", p.fieldBool}
+        };
+}
+
+std::ostream& operator<<(std::ostream& os, const StructBoolWithArray& obj)
+{
+    nlohmann::json j = obj;
+    os << j.dump(4);
+    return os;
+}
+void from_json(const nlohmann::json& j, StructIntWithArray& p) {
+    p = StructIntWithArray(
+        j.at("fieldInt").get<std::list<int>>()
+    );
+}
+void to_json(nlohmann::json& j, const StructIntWithArray& p) {
+    j = nlohmann::json{
+        {"fieldInt", p.fieldInt}
+        };
+}
+
+std::ostream& operator<<(std::ostream& os, const StructIntWithArray& obj)
+{
+    nlohmann::json j = obj;
+    os << j.dump(4);
+    return os;
+}
+void from_json(const nlohmann::json& j, StructFloatWithArray& p) {
+    p = StructFloatWithArray(
+        j.at("fieldFloat").get<std::list<float>>()
+    );
+}
+void to_json(nlohmann::json& j, const StructFloatWithArray& p) {
+    j = nlohmann::json{
+        {"fieldFloat", p.fieldFloat}
+        };
+}
+
+std::ostream& operator<<(std::ostream& os, const StructFloatWithArray& obj)
+{
+    nlohmann::json j = obj;
+    os << j.dump(4);
+    return os;
+}
+void from_json(const nlohmann::json& j, StructStringWithArray& p) {
+    p = StructStringWithArray(
+        j.at("fieldString").get<std::list<std::string>>()
+    );
+}
+void to_json(nlohmann::json& j, const StructStringWithArray& p) {
+    j = nlohmann::json{
+        {"fieldString", p.fieldString}
+        };
+}
+
+std::ostream& operator<<(std::ostream& os, const StructStringWithArray& obj)
+{
+    nlohmann::json j = obj;
+    os << j.dump(4);
+    return os;
+}
+void from_json(const nlohmann::json& j, StructStructWithArray& p) {
+    p = StructStructWithArray(
+        j.at("fieldStruct").get<std::list<StructStringWithArray>>()
+    );
+}
+void to_json(nlohmann::json& j, const StructStructWithArray& p) {
+    j = nlohmann::json{
+        {"fieldStruct", p.fieldStruct}
+        };
+}
+
+std::ostream& operator<<(std::ostream& os, const StructStructWithArray& obj)
+{
+    nlohmann::json j = obj;
+    os << j.dump(4);
+    return os;
+}
+void from_json(const nlohmann::json& j, StructEnumWithArray& p) {
+    p = StructEnumWithArray(
+        j.at("fieldEnum").get<std::list<Enum0Enum>>()
+    );
+}
+void to_json(nlohmann::json& j, const StructEnumWithArray& p) {
+    j = nlohmann::json{
+        {"fieldEnum", p.fieldEnum}
+        };
+}
+
+std::ostream& operator<<(std::ostream& os, const StructEnumWithArray& obj)
+{
+    nlohmann::json j = obj;
+    os << j.dump(4);
+    return os;
+}
 } // namespace Testbed1
 } // namespace Test

--- a/goldenmaster/modules/testbed1/generated/core/testbed1.json.adapter.h
+++ b/goldenmaster/modules/testbed1/generated/core/testbed1.json.adapter.h
@@ -113,5 +113,213 @@ void TEST_TESTBED1_EXPORT to_json(nlohmann::json& j, const StructString& p);
  */
 TEST_TESTBED1_EXPORT std::ostream& operator<<(std::ostream& os, const StructString& obj);
 
+/** Function that converts json formated data into StructStruct.
+* The functions signature must follow the nlohmann from_jason function rules.
+* It is automatically called in usage j.get<class>();
+* @param j an input json formated data
+* @param p StructStruct that will be filled with data from j.
+*  In case data is malformed or not convertable to StructStruct the function will throw.
+*/
+void TEST_TESTBED1_EXPORT from_json(const nlohmann::json& j, StructStruct& p);
+/** Function that converts json formated data into StructStruct
+* The functions signature must follow the nlohmann to_jason function rules.
+* It is automatically called in usage j = p;
+* @param j a json formated data that will be filled with data from p
+* @param p an input StructStruct/'}
+' from which json data will be filled
+*/
+void TEST_TESTBED1_EXPORT to_json(nlohmann::json& j, const StructStruct& p);
+
+/**
+ * @brief Overloads the << operator to allow printing of StructStruct objects to an output stream.
+ * 
+ * @param os The output stream to write to.
+ * @param obj The StructStruct object to be printed.
+ * @return std::ostream& The modified output stream.
+ */
+TEST_TESTBED1_EXPORT std::ostream& operator<<(std::ostream& os, const StructStruct& obj);
+
+/** Function that converts json formated data into StructEnum.
+* The functions signature must follow the nlohmann from_jason function rules.
+* It is automatically called in usage j.get<class>();
+* @param j an input json formated data
+* @param p StructEnum that will be filled with data from j.
+*  In case data is malformed or not convertable to StructEnum the function will throw.
+*/
+void TEST_TESTBED1_EXPORT from_json(const nlohmann::json& j, StructEnum& p);
+/** Function that converts json formated data into StructEnum
+* The functions signature must follow the nlohmann to_jason function rules.
+* It is automatically called in usage j = p;
+* @param j a json formated data that will be filled with data from p
+* @param p an input StructEnum/'}
+' from which json data will be filled
+*/
+void TEST_TESTBED1_EXPORT to_json(nlohmann::json& j, const StructEnum& p);
+
+/**
+ * @brief Overloads the << operator to allow printing of StructEnum objects to an output stream.
+ * 
+ * @param os The output stream to write to.
+ * @param obj The StructEnum object to be printed.
+ * @return std::ostream& The modified output stream.
+ */
+TEST_TESTBED1_EXPORT std::ostream& operator<<(std::ostream& os, const StructEnum& obj);
+
+/** Function that converts json formated data into StructBoolWithArray.
+* The functions signature must follow the nlohmann from_jason function rules.
+* It is automatically called in usage j.get<class>();
+* @param j an input json formated data
+* @param p StructBoolWithArray that will be filled with data from j.
+*  In case data is malformed or not convertable to StructBoolWithArray the function will throw.
+*/
+void TEST_TESTBED1_EXPORT from_json(const nlohmann::json& j, StructBoolWithArray& p);
+/** Function that converts json formated data into StructBoolWithArray
+* The functions signature must follow the nlohmann to_jason function rules.
+* It is automatically called in usage j = p;
+* @param j a json formated data that will be filled with data from p
+* @param p an input StructBoolWithArray/'}
+' from which json data will be filled
+*/
+void TEST_TESTBED1_EXPORT to_json(nlohmann::json& j, const StructBoolWithArray& p);
+
+/**
+ * @brief Overloads the << operator to allow printing of StructBoolWithArray objects to an output stream.
+ * 
+ * @param os The output stream to write to.
+ * @param obj The StructBoolWithArray object to be printed.
+ * @return std::ostream& The modified output stream.
+ */
+TEST_TESTBED1_EXPORT std::ostream& operator<<(std::ostream& os, const StructBoolWithArray& obj);
+
+/** Function that converts json formated data into StructIntWithArray.
+* The functions signature must follow the nlohmann from_jason function rules.
+* It is automatically called in usage j.get<class>();
+* @param j an input json formated data
+* @param p StructIntWithArray that will be filled with data from j.
+*  In case data is malformed or not convertable to StructIntWithArray the function will throw.
+*/
+void TEST_TESTBED1_EXPORT from_json(const nlohmann::json& j, StructIntWithArray& p);
+/** Function that converts json formated data into StructIntWithArray
+* The functions signature must follow the nlohmann to_jason function rules.
+* It is automatically called in usage j = p;
+* @param j a json formated data that will be filled with data from p
+* @param p an input StructIntWithArray/'}
+' from which json data will be filled
+*/
+void TEST_TESTBED1_EXPORT to_json(nlohmann::json& j, const StructIntWithArray& p);
+
+/**
+ * @brief Overloads the << operator to allow printing of StructIntWithArray objects to an output stream.
+ * 
+ * @param os The output stream to write to.
+ * @param obj The StructIntWithArray object to be printed.
+ * @return std::ostream& The modified output stream.
+ */
+TEST_TESTBED1_EXPORT std::ostream& operator<<(std::ostream& os, const StructIntWithArray& obj);
+
+/** Function that converts json formated data into StructFloatWithArray.
+* The functions signature must follow the nlohmann from_jason function rules.
+* It is automatically called in usage j.get<class>();
+* @param j an input json formated data
+* @param p StructFloatWithArray that will be filled with data from j.
+*  In case data is malformed or not convertable to StructFloatWithArray the function will throw.
+*/
+void TEST_TESTBED1_EXPORT from_json(const nlohmann::json& j, StructFloatWithArray& p);
+/** Function that converts json formated data into StructFloatWithArray
+* The functions signature must follow the nlohmann to_jason function rules.
+* It is automatically called in usage j = p;
+* @param j a json formated data that will be filled with data from p
+* @param p an input StructFloatWithArray/'}
+' from which json data will be filled
+*/
+void TEST_TESTBED1_EXPORT to_json(nlohmann::json& j, const StructFloatWithArray& p);
+
+/**
+ * @brief Overloads the << operator to allow printing of StructFloatWithArray objects to an output stream.
+ * 
+ * @param os The output stream to write to.
+ * @param obj The StructFloatWithArray object to be printed.
+ * @return std::ostream& The modified output stream.
+ */
+TEST_TESTBED1_EXPORT std::ostream& operator<<(std::ostream& os, const StructFloatWithArray& obj);
+
+/** Function that converts json formated data into StructStringWithArray.
+* The functions signature must follow the nlohmann from_jason function rules.
+* It is automatically called in usage j.get<class>();
+* @param j an input json formated data
+* @param p StructStringWithArray that will be filled with data from j.
+*  In case data is malformed or not convertable to StructStringWithArray the function will throw.
+*/
+void TEST_TESTBED1_EXPORT from_json(const nlohmann::json& j, StructStringWithArray& p);
+/** Function that converts json formated data into StructStringWithArray
+* The functions signature must follow the nlohmann to_jason function rules.
+* It is automatically called in usage j = p;
+* @param j a json formated data that will be filled with data from p
+* @param p an input StructStringWithArray/'}
+' from which json data will be filled
+*/
+void TEST_TESTBED1_EXPORT to_json(nlohmann::json& j, const StructStringWithArray& p);
+
+/**
+ * @brief Overloads the << operator to allow printing of StructStringWithArray objects to an output stream.
+ * 
+ * @param os The output stream to write to.
+ * @param obj The StructStringWithArray object to be printed.
+ * @return std::ostream& The modified output stream.
+ */
+TEST_TESTBED1_EXPORT std::ostream& operator<<(std::ostream& os, const StructStringWithArray& obj);
+
+/** Function that converts json formated data into StructStructWithArray.
+* The functions signature must follow the nlohmann from_jason function rules.
+* It is automatically called in usage j.get<class>();
+* @param j an input json formated data
+* @param p StructStructWithArray that will be filled with data from j.
+*  In case data is malformed or not convertable to StructStructWithArray the function will throw.
+*/
+void TEST_TESTBED1_EXPORT from_json(const nlohmann::json& j, StructStructWithArray& p);
+/** Function that converts json formated data into StructStructWithArray
+* The functions signature must follow the nlohmann to_jason function rules.
+* It is automatically called in usage j = p;
+* @param j a json formated data that will be filled with data from p
+* @param p an input StructStructWithArray/'}
+' from which json data will be filled
+*/
+void TEST_TESTBED1_EXPORT to_json(nlohmann::json& j, const StructStructWithArray& p);
+
+/**
+ * @brief Overloads the << operator to allow printing of StructStructWithArray objects to an output stream.
+ * 
+ * @param os The output stream to write to.
+ * @param obj The StructStructWithArray object to be printed.
+ * @return std::ostream& The modified output stream.
+ */
+TEST_TESTBED1_EXPORT std::ostream& operator<<(std::ostream& os, const StructStructWithArray& obj);
+
+/** Function that converts json formated data into StructEnumWithArray.
+* The functions signature must follow the nlohmann from_jason function rules.
+* It is automatically called in usage j.get<class>();
+* @param j an input json formated data
+* @param p StructEnumWithArray that will be filled with data from j.
+*  In case data is malformed or not convertable to StructEnumWithArray the function will throw.
+*/
+void TEST_TESTBED1_EXPORT from_json(const nlohmann::json& j, StructEnumWithArray& p);
+/** Function that converts json formated data into StructEnumWithArray
+* The functions signature must follow the nlohmann to_jason function rules.
+* It is automatically called in usage j = p;
+* @param j a json formated data that will be filled with data from p
+* @param p an input StructEnumWithArray/'}
+' from which json data will be filled
+*/
+void TEST_TESTBED1_EXPORT to_json(nlohmann::json& j, const StructEnumWithArray& p);
+
+/**
+ * @brief Overloads the << operator to allow printing of StructEnumWithArray objects to an output stream.
+ * 
+ * @param os The output stream to write to.
+ * @param obj The StructEnumWithArray object to be printed.
+ * @return std::ostream& The modified output stream.
+ */
+TEST_TESTBED1_EXPORT std::ostream& operator<<(std::ostream& os, const StructEnumWithArray& obj);
+
 } // namespace Testbed1
 } // namespace Test

--- a/goldenmaster/modules/testbed1/generated/monitor/CMakeLists.txt
+++ b/goldenmaster/modules/testbed1/generated/monitor/CMakeLists.txt
@@ -7,6 +7,8 @@ set (SOURCES_MONITOR
     structinterface.tracer.cpp
     structarrayinterface.tracedecorator.cpp
     structarrayinterface.tracer.cpp
+    structarray2interface.tracedecorator.cpp
+    structarray2interface.tracer.cpp
 )
 add_library(testbed1-monitor SHARED ${SOURCES_MONITOR})
 add_library(testbed1::testbed1-monitor ALIAS testbed1-monitor)

--- a/goldenmaster/modules/testbed1/generated/monitor/structarray2interface.tracedecorator.cpp
+++ b/goldenmaster/modules/testbed1/generated/monitor/structarray2interface.tracedecorator.cpp
@@ -1,0 +1,172 @@
+
+
+#include "testbed1/generated/monitor/structarray2interface.tracedecorator.h"
+#include "testbed1/generated/monitor/structarray2interface.tracer.h"
+
+using namespace Test::Testbed1;
+StructArray2InterfaceTraceDecorator::StructArray2InterfaceTraceDecorator(IStructArray2Interface& impl, ApiGear::PocoImpl::Tracer& tracer)
+    : m_tracer(std::make_unique<StructArray2InterfaceTracer>(tracer))
+    , m_impl(impl)
+{
+        m_impl._getPublisher().subscribeToAllChanges(*this);
+}
+StructArray2InterfaceTraceDecorator::~StructArray2InterfaceTraceDecorator()
+{
+    m_impl._getPublisher().unsubscribeFromAllChanges(*this);
+}
+
+std::unique_ptr<StructArray2InterfaceTraceDecorator> StructArray2InterfaceTraceDecorator::connect(IStructArray2Interface& impl, ApiGear::PocoImpl::Tracer& tracer)
+{
+    return std::unique_ptr<StructArray2InterfaceTraceDecorator>(new StructArray2InterfaceTraceDecorator(impl, tracer));
+}
+std::list<StructBool> StructArray2InterfaceTraceDecorator::funcBool(const StructBoolWithArray& paramBool)
+{
+    m_tracer->trace_funcBool(paramBool);
+    return m_impl.funcBool(paramBool);
+}
+std::future<std::list<StructBool>> StructArray2InterfaceTraceDecorator::funcBoolAsync(const StructBoolWithArray& paramBool, std::function<void(std::list<StructBool>)> callback)
+{
+    m_tracer->trace_funcBool(paramBool);
+    return m_impl.funcBoolAsync(paramBool, callback);
+}
+std::list<StructInt> StructArray2InterfaceTraceDecorator::funcInt(const StructIntWithArray& paramInt)
+{
+    m_tracer->trace_funcInt(paramInt);
+    return m_impl.funcInt(paramInt);
+}
+std::future<std::list<StructInt>> StructArray2InterfaceTraceDecorator::funcIntAsync(const StructIntWithArray& paramInt, std::function<void(std::list<StructInt>)> callback)
+{
+    m_tracer->trace_funcInt(paramInt);
+    return m_impl.funcIntAsync(paramInt, callback);
+}
+std::list<StructFloat> StructArray2InterfaceTraceDecorator::funcFloat(const StructFloatWithArray& paramFloat)
+{
+    m_tracer->trace_funcFloat(paramFloat);
+    return m_impl.funcFloat(paramFloat);
+}
+std::future<std::list<StructFloat>> StructArray2InterfaceTraceDecorator::funcFloatAsync(const StructFloatWithArray& paramFloat, std::function<void(std::list<StructFloat>)> callback)
+{
+    m_tracer->trace_funcFloat(paramFloat);
+    return m_impl.funcFloatAsync(paramFloat, callback);
+}
+std::list<StructString> StructArray2InterfaceTraceDecorator::funcString(const StructStringWithArray& paramString)
+{
+    m_tracer->trace_funcString(paramString);
+    return m_impl.funcString(paramString);
+}
+std::future<std::list<StructString>> StructArray2InterfaceTraceDecorator::funcStringAsync(const StructStringWithArray& paramString, std::function<void(std::list<StructString>)> callback)
+{
+    m_tracer->trace_funcString(paramString);
+    return m_impl.funcStringAsync(paramString, callback);
+}
+std::list<Enum0Enum> StructArray2InterfaceTraceDecorator::funcEnum(const StructEnumWithArray& paramEnum)
+{
+    m_tracer->trace_funcEnum(paramEnum);
+    return m_impl.funcEnum(paramEnum);
+}
+std::future<std::list<Enum0Enum>> StructArray2InterfaceTraceDecorator::funcEnumAsync(const StructEnumWithArray& paramEnum, std::function<void(std::list<Enum0Enum>)> callback)
+{
+    m_tracer->trace_funcEnum(paramEnum);
+    return m_impl.funcEnumAsync(paramEnum, callback);
+}
+void StructArray2InterfaceTraceDecorator::setPropBool(const StructBoolWithArray& propBool)
+{
+    m_impl.setPropBool(propBool);
+}
+
+const StructBoolWithArray& StructArray2InterfaceTraceDecorator::getPropBool() const
+{
+    return m_impl.getPropBool();
+}
+void StructArray2InterfaceTraceDecorator::setPropInt(const StructIntWithArray& propInt)
+{
+    m_impl.setPropInt(propInt);
+}
+
+const StructIntWithArray& StructArray2InterfaceTraceDecorator::getPropInt() const
+{
+    return m_impl.getPropInt();
+}
+void StructArray2InterfaceTraceDecorator::setPropFloat(const StructFloatWithArray& propFloat)
+{
+    m_impl.setPropFloat(propFloat);
+}
+
+const StructFloatWithArray& StructArray2InterfaceTraceDecorator::getPropFloat() const
+{
+    return m_impl.getPropFloat();
+}
+void StructArray2InterfaceTraceDecorator::setPropString(const StructStringWithArray& propString)
+{
+    m_impl.setPropString(propString);
+}
+
+const StructStringWithArray& StructArray2InterfaceTraceDecorator::getPropString() const
+{
+    return m_impl.getPropString();
+}
+void StructArray2InterfaceTraceDecorator::setPropEnum(const StructEnumWithArray& propEnum)
+{
+    m_impl.setPropEnum(propEnum);
+}
+
+const StructEnumWithArray& StructArray2InterfaceTraceDecorator::getPropEnum() const
+{
+    return m_impl.getPropEnum();
+}
+void StructArray2InterfaceTraceDecorator::onSigBool(const StructBoolWithArray& paramBool)
+{
+    m_tracer->trace_sigBool(paramBool);
+}
+
+void StructArray2InterfaceTraceDecorator::onSigInt(const StructIntWithArray& paramInt)
+{
+    m_tracer->trace_sigInt(paramInt);
+}
+
+void StructArray2InterfaceTraceDecorator::onSigFloat(const StructFloatWithArray& paramFloat)
+{
+    m_tracer->trace_sigFloat(paramFloat);
+}
+
+void StructArray2InterfaceTraceDecorator::onSigString(const StructStringWithArray& paramString)
+{
+    m_tracer->trace_sigString(paramString);
+}
+
+void StructArray2InterfaceTraceDecorator::onPropBoolChanged(const StructBoolWithArray& propBool)
+{
+    (void) propBool; // suppress the 'Unreferenced Formal Parameter' warning.
+    m_tracer->capture_state(this);
+}
+
+void StructArray2InterfaceTraceDecorator::onPropIntChanged(const StructIntWithArray& propInt)
+{
+    (void) propInt; // suppress the 'Unreferenced Formal Parameter' warning.
+    m_tracer->capture_state(this);
+}
+
+void StructArray2InterfaceTraceDecorator::onPropFloatChanged(const StructFloatWithArray& propFloat)
+{
+    (void) propFloat; // suppress the 'Unreferenced Formal Parameter' warning.
+    m_tracer->capture_state(this);
+}
+
+void StructArray2InterfaceTraceDecorator::onPropStringChanged(const StructStringWithArray& propString)
+{
+    (void) propString; // suppress the 'Unreferenced Formal Parameter' warning.
+    m_tracer->capture_state(this);
+}
+
+void StructArray2InterfaceTraceDecorator::onPropEnumChanged(const StructEnumWithArray& propEnum)
+{
+    (void) propEnum; // suppress the 'Unreferenced Formal Parameter' warning.
+    m_tracer->capture_state(this);
+}
+
+
+
+IStructArray2InterfacePublisher& StructArray2InterfaceTraceDecorator::_getPublisher() const
+{
+    return m_impl._getPublisher();
+}

--- a/goldenmaster/modules/testbed1/generated/monitor/structarray2interface.tracedecorator.h
+++ b/goldenmaster/modules/testbed1/generated/monitor/structarray2interface.tracedecorator.h
@@ -1,0 +1,136 @@
+
+#pragma once
+#include "testbed1/generated/api/testbed1.h"
+#include "testbed1/generated/api/common.h"
+#include <memory>
+
+namespace ApiGear { namespace PocoImpl { class Tracer; } }
+
+namespace Test {
+namespace Testbed1 {
+
+class StructArray2InterfaceTracer;
+
+class TEST_TESTBED1_EXPORT StructArray2InterfaceTraceDecorator : public IStructArray2Interface, public IStructArray2InterfaceSubscriber
+{
+protected:
+    /** 
+    * ctor
+    * Subscribes for signal emission.
+    * @param impl The StructArray2Interface object to trace.
+    * @param tracer A Poco tracer to which traces are put, wrapped with relevant object info.
+    */
+    explicit StructArray2InterfaceTraceDecorator(IStructArray2Interface& impl, ApiGear::PocoImpl::Tracer& tracer);
+public:
+    /** 
+    * Use this function to get the StructArray2InterfaceTraceDecorator object.
+    * @param impl The StructArray2Interface object to trace.
+    * @param tracer A Poco tracer to which traces are put, wrapped with relevant object info.
+    */
+    static std::unique_ptr<StructArray2InterfaceTraceDecorator> connect(IStructArray2Interface& impl, ApiGear::PocoImpl::Tracer& tracer);
+    /**
+    * dtor
+    * Unsubscribes from signal emission.
+    */
+    virtual ~StructArray2InterfaceTraceDecorator();
+
+    /** Traces funcBool and forwards call to StructArray2Interface implementation. */
+    std::list<StructBool> funcBool(const StructBoolWithArray& paramBool) override;
+    /** Traces funcBool and forwards call to StructArray2Interface implementation. */
+    std::future<std::list<StructBool>> funcBoolAsync(const StructBoolWithArray& paramBool, std::function<void(std::list<StructBool>)> callback = nullptr) override;
+    
+    /** Traces funcInt and forwards call to StructArray2Interface implementation. */
+    std::list<StructInt> funcInt(const StructIntWithArray& paramInt) override;
+    /** Traces funcInt and forwards call to StructArray2Interface implementation. */
+    std::future<std::list<StructInt>> funcIntAsync(const StructIntWithArray& paramInt, std::function<void(std::list<StructInt>)> callback = nullptr) override;
+    
+    /** Traces funcFloat and forwards call to StructArray2Interface implementation. */
+    std::list<StructFloat> funcFloat(const StructFloatWithArray& paramFloat) override;
+    /** Traces funcFloat and forwards call to StructArray2Interface implementation. */
+    std::future<std::list<StructFloat>> funcFloatAsync(const StructFloatWithArray& paramFloat, std::function<void(std::list<StructFloat>)> callback = nullptr) override;
+    
+    /** Traces funcString and forwards call to StructArray2Interface implementation. */
+    std::list<StructString> funcString(const StructStringWithArray& paramString) override;
+    /** Traces funcString and forwards call to StructArray2Interface implementation. */
+    std::future<std::list<StructString>> funcStringAsync(const StructStringWithArray& paramString, std::function<void(std::list<StructString>)> callback = nullptr) override;
+    
+    /** Traces funcEnum and forwards call to StructArray2Interface implementation. */
+    std::list<Enum0Enum> funcEnum(const StructEnumWithArray& paramEnum) override;
+    /** Traces funcEnum and forwards call to StructArray2Interface implementation. */
+    std::future<std::list<Enum0Enum>> funcEnumAsync(const StructEnumWithArray& paramEnum, std::function<void(std::list<Enum0Enum>)> callback = nullptr) override;
+    
+    /** Forwards call to StructArray2Interface implementation. */
+    void setPropBool(const StructBoolWithArray& propBool) override;
+    /** Forwards call to StructArray2Interface implementation. */
+    const StructBoolWithArray& getPropBool() const override;
+    
+    /** Forwards call to StructArray2Interface implementation. */
+    void setPropInt(const StructIntWithArray& propInt) override;
+    /** Forwards call to StructArray2Interface implementation. */
+    const StructIntWithArray& getPropInt() const override;
+    
+    /** Forwards call to StructArray2Interface implementation. */
+    void setPropFloat(const StructFloatWithArray& propFloat) override;
+    /** Forwards call to StructArray2Interface implementation. */
+    const StructFloatWithArray& getPropFloat() const override;
+    
+    /** Forwards call to StructArray2Interface implementation. */
+    void setPropString(const StructStringWithArray& propString) override;
+    /** Forwards call to StructArray2Interface implementation. */
+    const StructStringWithArray& getPropString() const override;
+    
+    /** Forwards call to StructArray2Interface implementation. */
+    void setPropEnum(const StructEnumWithArray& propEnum) override;
+    /** Forwards call to StructArray2Interface implementation. */
+    const StructEnumWithArray& getPropEnum() const override;
+    
+    /**
+    Traces sigBool emission.
+    */
+    void onSigBool(const StructBoolWithArray& paramBool) override;
+    /**
+    Traces sigInt emission.
+    */
+    void onSigInt(const StructIntWithArray& paramInt) override;
+    /**
+    Traces sigFloat emission.
+    */
+    void onSigFloat(const StructFloatWithArray& paramFloat) override;
+    /**
+    Traces sigString emission.
+    */
+    void onSigString(const StructStringWithArray& paramString) override;
+    /**
+    Traces propBool changed.
+    */
+    void onPropBoolChanged(const StructBoolWithArray& propBool) override;
+    /**
+    Traces propInt changed.
+    */
+    void onPropIntChanged(const StructIntWithArray& propInt) override;
+    /**
+    Traces propFloat changed.
+    */
+    void onPropFloatChanged(const StructFloatWithArray& propFloat) override;
+    /**
+    Traces propString changed.
+    */
+    void onPropStringChanged(const StructStringWithArray& propString) override;
+    /**
+    Traces propEnum changed.
+    */
+    void onPropEnumChanged(const StructEnumWithArray& propEnum) override;
+
+    /**
+    * Access to a publisher, use it to subscribe for StructArray2Interface changes and signal emission.
+    * @return The publisher for StructArray2Interface.
+    */
+    IStructArray2InterfacePublisher& _getPublisher() const override;
+private:
+    /** A tracer that provides the traces for given StructArray2Interface object. */
+    std::unique_ptr<StructArray2InterfaceTracer> m_tracer;
+    /** The StructArray2Interface object which is traced */
+    IStructArray2Interface& m_impl;
+};
+} // namespace Testbed1
+} // namespace Test

--- a/goldenmaster/modules/testbed1/generated/monitor/structarray2interface.tracer.cpp
+++ b/goldenmaster/modules/testbed1/generated/monitor/structarray2interface.tracer.cpp
@@ -1,0 +1,80 @@
+#include "apigear/tracer/tracer.h"
+#include "testbed1/generated/core/testbed1.json.adapter.h"
+#include "testbed1/generated/monitor/structarray2interface.tracer.h"
+
+using namespace Test::Testbed1;
+
+StructArray2InterfaceTracer::StructArray2InterfaceTracer(ApiGear::PocoImpl::Tracer& tracer)
+    : m_tracer(tracer)
+{
+}
+
+void StructArray2InterfaceTracer::capture_state(IStructArray2Interface* obj)
+{
+    nlohmann::json fields_;
+    fields_["propBool"] = obj->getPropBool();
+    fields_["propInt"] = obj->getPropInt();
+    fields_["propFloat"] = obj->getPropFloat();
+    fields_["propString"] = obj->getPropString();
+    fields_["propEnum"] = obj->getPropEnum();
+    m_tracer.state("testbed1.StructArray2Interface#_state", fields_);
+}
+
+void StructArray2InterfaceTracer::trace_funcBool(const StructBoolWithArray& paramBool)
+{
+    nlohmann::json fields_;
+    fields_["paramBool"] = paramBool;
+    m_tracer.call("testbed1.StructArray2Interface#funcBool", fields_);
+}
+
+void StructArray2InterfaceTracer::trace_funcInt(const StructIntWithArray& paramInt)
+{
+    nlohmann::json fields_;
+    fields_["paramInt"] = paramInt;
+    m_tracer.call("testbed1.StructArray2Interface#funcInt", fields_);
+}
+
+void StructArray2InterfaceTracer::trace_funcFloat(const StructFloatWithArray& paramFloat)
+{
+    nlohmann::json fields_;
+    fields_["paramFloat"] = paramFloat;
+    m_tracer.call("testbed1.StructArray2Interface#funcFloat", fields_);
+}
+
+void StructArray2InterfaceTracer::trace_funcString(const StructStringWithArray& paramString)
+{
+    nlohmann::json fields_;
+    fields_["paramString"] = paramString;
+    m_tracer.call("testbed1.StructArray2Interface#funcString", fields_);
+}
+
+void StructArray2InterfaceTracer::trace_funcEnum(const StructEnumWithArray& paramEnum)
+{
+    nlohmann::json fields_;
+    fields_["paramEnum"] = paramEnum;
+    m_tracer.call("testbed1.StructArray2Interface#funcEnum", fields_);
+}
+void StructArray2InterfaceTracer::trace_sigBool(const StructBoolWithArray& paramBool)
+{
+    nlohmann::json fields_;
+    fields_["paramBool"] = paramBool;
+    m_tracer.signal("testbed1.StructArray2Interface#sigBool", fields_);
+}
+void StructArray2InterfaceTracer::trace_sigInt(const StructIntWithArray& paramInt)
+{
+    nlohmann::json fields_;
+    fields_["paramInt"] = paramInt;
+    m_tracer.signal("testbed1.StructArray2Interface#sigInt", fields_);
+}
+void StructArray2InterfaceTracer::trace_sigFloat(const StructFloatWithArray& paramFloat)
+{
+    nlohmann::json fields_;
+    fields_["paramFloat"] = paramFloat;
+    m_tracer.signal("testbed1.StructArray2Interface#sigFloat", fields_);
+}
+void StructArray2InterfaceTracer::trace_sigString(const StructStringWithArray& paramString)
+{
+    nlohmann::json fields_;
+    fields_["paramString"] = paramString;
+    m_tracer.signal("testbed1.StructArray2Interface#sigString", fields_);
+}

--- a/goldenmaster/modules/testbed1/generated/monitor/structarray2interface.tracer.h
+++ b/goldenmaster/modules/testbed1/generated/monitor/structarray2interface.tracer.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "testbed1/generated/api/testbed1.h"
+
+namespace ApiGear { namespace PocoImpl { class Tracer; } }
+
+namespace Test {
+namespace Testbed1 {
+
+/**
+* A helper class for tracing.
+* Builds the trace info with state and operations specific for StructArray2Interface and pass to PocoImpl::Tracer.
+*/
+class StructArray2InterfaceTracer
+{
+public:
+  /**
+  * ctor
+  * @param tracer A tracer object to which the information about the state and operations is put.
+  */
+  StructArray2InterfaceTracer(ApiGear::PocoImpl::Tracer& tracer);
+  /** dtor */
+  virtual ~StructArray2InterfaceTracer() = default;
+  /**
+  * Prepares the StructArray2Interface object state in a nlohmann::json format and puts to a tracer.
+  * @param The StructArray2Interface object to trace.
+  */
+  void capture_state(IStructArray2Interface* obj);
+  /**
+  * Prepares information about the funcBool call in a nlohmann::json format and puts to a tracer.
+  * @param The StructArray2Interface object to trace.
+  */
+  void trace_funcBool(const StructBoolWithArray& paramBool);
+  /**
+  * Prepares information about the funcInt call in a nlohmann::json format and puts to a tracer.
+  * @param The StructArray2Interface object to trace.
+  */
+  void trace_funcInt(const StructIntWithArray& paramInt);
+  /**
+  * Prepares information about the funcFloat call in a nlohmann::json format and puts to a tracer.
+  * @param The StructArray2Interface object to trace.
+  */
+  void trace_funcFloat(const StructFloatWithArray& paramFloat);
+  /**
+  * Prepares information about the funcString call in a nlohmann::json format and puts to a tracer.
+  * @param The StructArray2Interface object to trace.
+  */
+  void trace_funcString(const StructStringWithArray& paramString);
+  /**
+  * Prepares information about the funcEnum call in a nlohmann::json format and puts to a tracer.
+  * @param The StructArray2Interface object to trace.
+  */
+  void trace_funcEnum(const StructEnumWithArray& paramEnum);
+  /**
+  * Prepares information about the sigBool call in a nlohmann::json format and puts to a tracer.
+  * @param The StructArray2Interface object to trace.
+  */
+  void trace_sigBool(const StructBoolWithArray& paramBool);
+  /**
+  * Prepares information about the sigInt call in a nlohmann::json format and puts to a tracer.
+  * @param The StructArray2Interface object to trace.
+  */
+  void trace_sigInt(const StructIntWithArray& paramInt);
+  /**
+  * Prepares information about the sigFloat call in a nlohmann::json format and puts to a tracer.
+  * @param The StructArray2Interface object to trace.
+  */
+  void trace_sigFloat(const StructFloatWithArray& paramFloat);
+  /**
+  * Prepares information about the sigString call in a nlohmann::json format and puts to a tracer.
+  * @param The StructArray2Interface object to trace.
+  */
+  void trace_sigString(const StructStringWithArray& paramString);
+private:
+  /**
+  * A tracer object to which the information about the state and operations is put.
+  */
+  ApiGear::PocoImpl::Tracer& m_tracer;
+};
+
+} // namespace Testbed1
+} // namespace Test

--- a/goldenmaster/modules/testbed1/generated/monitor/structarrayinterface.tracedecorator.cpp
+++ b/goldenmaster/modules/testbed1/generated/monitor/structarrayinterface.tracedecorator.cpp
@@ -59,6 +59,16 @@ std::future<std::list<StructString>> StructArrayInterfaceTraceDecorator::funcStr
     m_tracer->trace_funcString(paramString);
     return m_impl.funcStringAsync(paramString, callback);
 }
+std::list<Enum0Enum> StructArrayInterfaceTraceDecorator::funcEnum(const std::list<Enum0Enum>& paramEnum)
+{
+    m_tracer->trace_funcEnum(paramEnum);
+    return m_impl.funcEnum(paramEnum);
+}
+std::future<std::list<Enum0Enum>> StructArrayInterfaceTraceDecorator::funcEnumAsync(const std::list<Enum0Enum>& paramEnum, std::function<void(std::list<Enum0Enum>)> callback)
+{
+    m_tracer->trace_funcEnum(paramEnum);
+    return m_impl.funcEnumAsync(paramEnum, callback);
+}
 void StructArrayInterfaceTraceDecorator::setPropBool(const std::list<StructBool>& propBool)
 {
     m_impl.setPropBool(propBool);
@@ -95,6 +105,15 @@ const std::list<StructString>& StructArrayInterfaceTraceDecorator::getPropString
 {
     return m_impl.getPropString();
 }
+void StructArrayInterfaceTraceDecorator::setPropEnum(const std::list<Enum0Enum>& propEnum)
+{
+    m_impl.setPropEnum(propEnum);
+}
+
+const std::list<Enum0Enum>& StructArrayInterfaceTraceDecorator::getPropEnum() const
+{
+    return m_impl.getPropEnum();
+}
 void StructArrayInterfaceTraceDecorator::onSigBool(const std::list<StructBool>& paramBool)
 {
     m_tracer->trace_sigBool(paramBool);
@@ -113,6 +132,11 @@ void StructArrayInterfaceTraceDecorator::onSigFloat(const std::list<StructFloat>
 void StructArrayInterfaceTraceDecorator::onSigString(const std::list<StructString>& paramString)
 {
     m_tracer->trace_sigString(paramString);
+}
+
+void StructArrayInterfaceTraceDecorator::onSigEnum(const std::list<Enum0Enum>& paramEnum)
+{
+    m_tracer->trace_sigEnum(paramEnum);
 }
 
 void StructArrayInterfaceTraceDecorator::onPropBoolChanged(const std::list<StructBool>& propBool)
@@ -136,6 +160,12 @@ void StructArrayInterfaceTraceDecorator::onPropFloatChanged(const std::list<Stru
 void StructArrayInterfaceTraceDecorator::onPropStringChanged(const std::list<StructString>& propString)
 {
     (void) propString; // suppress the 'Unreferenced Formal Parameter' warning.
+    m_tracer->capture_state(this);
+}
+
+void StructArrayInterfaceTraceDecorator::onPropEnumChanged(const std::list<Enum0Enum>& propEnum)
+{
+    (void) propEnum; // suppress the 'Unreferenced Formal Parameter' warning.
     m_tracer->capture_state(this);
 }
 

--- a/goldenmaster/modules/testbed1/generated/monitor/structarrayinterface.tracedecorator.h
+++ b/goldenmaster/modules/testbed1/generated/monitor/structarrayinterface.tracedecorator.h
@@ -54,6 +54,11 @@ public:
     /** Traces funcString and forwards call to StructArrayInterface implementation. */
     std::future<std::list<StructString>> funcStringAsync(const std::list<StructString>& paramString, std::function<void(std::list<StructString>)> callback = nullptr) override;
     
+    /** Traces funcEnum and forwards call to StructArrayInterface implementation. */
+    std::list<Enum0Enum> funcEnum(const std::list<Enum0Enum>& paramEnum) override;
+    /** Traces funcEnum and forwards call to StructArrayInterface implementation. */
+    std::future<std::list<Enum0Enum>> funcEnumAsync(const std::list<Enum0Enum>& paramEnum, std::function<void(std::list<Enum0Enum>)> callback = nullptr) override;
+    
     /** Forwards call to StructArrayInterface implementation. */
     void setPropBool(const std::list<StructBool>& propBool) override;
     /** Forwards call to StructArrayInterface implementation. */
@@ -74,6 +79,11 @@ public:
     /** Forwards call to StructArrayInterface implementation. */
     const std::list<StructString>& getPropString() const override;
     
+    /** Forwards call to StructArrayInterface implementation. */
+    void setPropEnum(const std::list<Enum0Enum>& propEnum) override;
+    /** Forwards call to StructArrayInterface implementation. */
+    const std::list<Enum0Enum>& getPropEnum() const override;
+    
     /**
     Traces sigBool emission.
     */
@@ -91,6 +101,10 @@ public:
     */
     void onSigString(const std::list<StructString>& paramString) override;
     /**
+    Traces sigEnum emission.
+    */
+    void onSigEnum(const std::list<Enum0Enum>& paramEnum) override;
+    /**
     Traces propBool changed.
     */
     void onPropBoolChanged(const std::list<StructBool>& propBool) override;
@@ -106,6 +120,10 @@ public:
     Traces propString changed.
     */
     void onPropStringChanged(const std::list<StructString>& propString) override;
+    /**
+    Traces propEnum changed.
+    */
+    void onPropEnumChanged(const std::list<Enum0Enum>& propEnum) override;
 
     /**
     * Access to a publisher, use it to subscribe for StructArrayInterface changes and signal emission.

--- a/goldenmaster/modules/testbed1/generated/monitor/structarrayinterface.tracer.cpp
+++ b/goldenmaster/modules/testbed1/generated/monitor/structarrayinterface.tracer.cpp
@@ -16,6 +16,7 @@ void StructArrayInterfaceTracer::capture_state(IStructArrayInterface* obj)
     fields_["propInt"] = obj->getPropInt();
     fields_["propFloat"] = obj->getPropFloat();
     fields_["propString"] = obj->getPropString();
+    fields_["propEnum"] = obj->getPropEnum();
     m_tracer.state("testbed1.StructArrayInterface#_state", fields_);
 }
 
@@ -46,6 +47,13 @@ void StructArrayInterfaceTracer::trace_funcString(const std::list<StructString>&
     fields_["paramString"] = paramString;
     m_tracer.call("testbed1.StructArrayInterface#funcString", fields_);
 }
+
+void StructArrayInterfaceTracer::trace_funcEnum(const std::list<Enum0Enum>& paramEnum)
+{
+    nlohmann::json fields_;
+    fields_["paramEnum"] = paramEnum;
+    m_tracer.call("testbed1.StructArrayInterface#funcEnum", fields_);
+}
 void StructArrayInterfaceTracer::trace_sigBool(const std::list<StructBool>& paramBool)
 {
     nlohmann::json fields_;
@@ -69,4 +77,10 @@ void StructArrayInterfaceTracer::trace_sigString(const std::list<StructString>& 
     nlohmann::json fields_;
     fields_["paramString"] = paramString;
     m_tracer.signal("testbed1.StructArrayInterface#sigString", fields_);
+}
+void StructArrayInterfaceTracer::trace_sigEnum(const std::list<Enum0Enum>& paramEnum)
+{
+    nlohmann::json fields_;
+    fields_["paramEnum"] = paramEnum;
+    m_tracer.signal("testbed1.StructArrayInterface#sigEnum", fields_);
 }

--- a/goldenmaster/modules/testbed1/generated/monitor/structarrayinterface.tracer.h
+++ b/goldenmaster/modules/testbed1/generated/monitor/structarrayinterface.tracer.h
@@ -47,6 +47,11 @@ public:
   */
   void trace_funcString(const std::list<StructString>& paramString);
   /**
+  * Prepares information about the funcEnum call in a nlohmann::json format and puts to a tracer.
+  * @param The StructArrayInterface object to trace.
+  */
+  void trace_funcEnum(const std::list<Enum0Enum>& paramEnum);
+  /**
   * Prepares information about the sigBool call in a nlohmann::json format and puts to a tracer.
   * @param The StructArrayInterface object to trace.
   */
@@ -66,6 +71,11 @@ public:
   * @param The StructArrayInterface object to trace.
   */
   void trace_sigString(const std::list<StructString>& paramString);
+  /**
+  * Prepares information about the sigEnum call in a nlohmann::json format and puts to a tracer.
+  * @param The StructArrayInterface object to trace.
+  */
+  void trace_sigEnum(const std::list<Enum0Enum>& paramEnum);
 private:
   /**
   * A tracer object to which the information about the state and operations is put.

--- a/goldenmaster/modules/testbed1/generated/mqtt/CMakeLists.txt
+++ b/goldenmaster/modules/testbed1/generated/mqtt/CMakeLists.txt
@@ -4,6 +4,8 @@ set (SOURCES_MQTT
     structinterfaceclient.cpp
     structarrayinterfaceservice.cpp
     structarrayinterfaceclient.cpp
+    structarray2interfaceservice.cpp
+    structarray2interfaceclient.cpp
 )
 add_library(testbed1-mqtt SHARED ${SOURCES_MQTT})
 add_library(testbed1::testbed1-mqtt ALIAS testbed1-mqtt)

--- a/goldenmaster/modules/testbed1/generated/mqtt/structarray2interfaceclient.cpp
+++ b/goldenmaster/modules/testbed1/generated/mqtt/structarray2interfaceclient.cpp
@@ -1,0 +1,428 @@
+#include "testbed1/generated/mqtt/structarray2interfaceclient.h"
+#include "testbed1/generated/core/structarray2interface.publisher.h"
+#include "testbed1/generated/core/testbed1.json.adapter.h"
+#include <random>
+
+using namespace Test::Testbed1;
+using namespace Test::Testbed1::MQTT;
+
+namespace {
+    std::mt19937 randomNumberGenerator (std::random_device{}());
+}
+
+StructArray2InterfaceClient::StructArray2InterfaceClient(std::shared_ptr<ApiGear::MQTT::Client> client)
+    : MqttBaseAdapter(client, createTopicMap(client->getClientId()))
+    , m_client(client)
+    , m_publisher(std::make_unique<StructArray2InterfacePublisher>())
+{
+}
+
+std::shared_ptr<StructArray2InterfaceClient> StructArray2InterfaceClient::create(std::shared_ptr<ApiGear::MQTT::Client> client)
+{
+    return std::make_shared<StructArray2InterfaceClient>(client);
+}
+
+StructArray2InterfaceClient::~StructArray2InterfaceClient()
+{
+}
+
+std::map<std::string, ApiGear::MQTT::CallbackFunction> StructArray2InterfaceClient::createTopicMap(const std::string& clientId)
+{
+    return {
+        { std::string("testbed1/StructArray2Interface/prop/propBool"), [this](const std::string& args, const std::string&, const std::string&){ this->setPropBoolLocal(args); } },
+        { std::string("testbed1/StructArray2Interface/prop/propInt"), [this](const std::string& args, const std::string&, const std::string&){ this->setPropIntLocal(args); } },
+        { std::string("testbed1/StructArray2Interface/prop/propFloat"), [this](const std::string& args, const std::string&, const std::string&){ this->setPropFloatLocal(args); } },
+        { std::string("testbed1/StructArray2Interface/prop/propString"), [this](const std::string& args, const std::string&, const std::string&){ this->setPropStringLocal(args); } },
+        { std::string("testbed1/StructArray2Interface/prop/propEnum"), [this](const std::string& args, const std::string&, const std::string&){ this->setPropEnumLocal(args); } },
+        { std::string("testbed1/StructArray2Interface/sig/sigBool"), [this](const std::string& args, const std::string&, const std::string&){ this->onSigBool(args); } },
+        { std::string("testbed1/StructArray2Interface/sig/sigInt"), [this](const std::string& args, const std::string&, const std::string&){ this->onSigInt(args); } },
+        { std::string("testbed1/StructArray2Interface/sig/sigFloat"), [this](const std::string& args, const std::string&, const std::string&){ this->onSigFloat(args); } },
+        { std::string("testbed1/StructArray2Interface/sig/sigString"), [this](const std::string& args, const std::string&, const std::string&){ this->onSigString(args); } },
+        { std::string("testbed1/StructArray2Interface/rpc/funcBool/"+clientId+"/result"), [this](const std::string& args, const std::string&, const std::string& correlationData){ this->onInvokeReply(args, correlationData); } },
+        { std::string("testbed1/StructArray2Interface/rpc/funcInt/"+clientId+"/result"), [this](const std::string& args, const std::string&, const std::string& correlationData){ this->onInvokeReply(args, correlationData); } },
+        { std::string("testbed1/StructArray2Interface/rpc/funcFloat/"+clientId+"/result"), [this](const std::string& args, const std::string&, const std::string& correlationData){ this->onInvokeReply(args, correlationData); } },
+        { std::string("testbed1/StructArray2Interface/rpc/funcString/"+clientId+"/result"), [this](const std::string& args, const std::string&, const std::string& correlationData){ this->onInvokeReply(args, correlationData); } },
+        { std::string("testbed1/StructArray2Interface/rpc/funcEnum/"+clientId+"/result"), [this](const std::string& args, const std::string&, const std::string& correlationData){ this->onInvokeReply(args, correlationData); } },
+    };
+};
+
+void StructArray2InterfaceClient::setPropBool(const StructBoolWithArray& propBool)
+{
+    if(m_client == nullptr) {
+        return;
+    }
+    static const auto topic = std::string("testbed1/StructArray2Interface/set/propBool");
+    m_client->setRemoteProperty(topic, nlohmann::json(propBool).dump());
+}
+
+void StructArray2InterfaceClient::setPropBoolLocal(const std::string& args)
+{
+    nlohmann::json fields = nlohmann::json::parse(args);
+    if (fields.empty())
+    {
+        return;
+    }
+
+    const StructBoolWithArray& propBool = fields.get<StructBoolWithArray>();
+    if (m_data.m_propBool != propBool) {
+        m_data.m_propBool = propBool;
+        m_publisher->publishPropBoolChanged(propBool);
+    }
+}
+
+const StructBoolWithArray& StructArray2InterfaceClient::getPropBool() const
+{
+    return m_data.m_propBool;
+}
+
+void StructArray2InterfaceClient::setPropInt(const StructIntWithArray& propInt)
+{
+    if(m_client == nullptr) {
+        return;
+    }
+    static const auto topic = std::string("testbed1/StructArray2Interface/set/propInt");
+    m_client->setRemoteProperty(topic, nlohmann::json(propInt).dump());
+}
+
+void StructArray2InterfaceClient::setPropIntLocal(const std::string& args)
+{
+    nlohmann::json fields = nlohmann::json::parse(args);
+    if (fields.empty())
+    {
+        return;
+    }
+
+    const StructIntWithArray& propInt = fields.get<StructIntWithArray>();
+    if (m_data.m_propInt != propInt) {
+        m_data.m_propInt = propInt;
+        m_publisher->publishPropIntChanged(propInt);
+    }
+}
+
+const StructIntWithArray& StructArray2InterfaceClient::getPropInt() const
+{
+    return m_data.m_propInt;
+}
+
+void StructArray2InterfaceClient::setPropFloat(const StructFloatWithArray& propFloat)
+{
+    if(m_client == nullptr) {
+        return;
+    }
+    static const auto topic = std::string("testbed1/StructArray2Interface/set/propFloat");
+    m_client->setRemoteProperty(topic, nlohmann::json(propFloat).dump());
+}
+
+void StructArray2InterfaceClient::setPropFloatLocal(const std::string& args)
+{
+    nlohmann::json fields = nlohmann::json::parse(args);
+    if (fields.empty())
+    {
+        return;
+    }
+
+    const StructFloatWithArray& propFloat = fields.get<StructFloatWithArray>();
+    if (m_data.m_propFloat != propFloat) {
+        m_data.m_propFloat = propFloat;
+        m_publisher->publishPropFloatChanged(propFloat);
+    }
+}
+
+const StructFloatWithArray& StructArray2InterfaceClient::getPropFloat() const
+{
+    return m_data.m_propFloat;
+}
+
+void StructArray2InterfaceClient::setPropString(const StructStringWithArray& propString)
+{
+    if(m_client == nullptr) {
+        return;
+    }
+    static const auto topic = std::string("testbed1/StructArray2Interface/set/propString");
+    m_client->setRemoteProperty(topic, nlohmann::json(propString).dump());
+}
+
+void StructArray2InterfaceClient::setPropStringLocal(const std::string& args)
+{
+    nlohmann::json fields = nlohmann::json::parse(args);
+    if (fields.empty())
+    {
+        return;
+    }
+
+    const StructStringWithArray& propString = fields.get<StructStringWithArray>();
+    if (m_data.m_propString != propString) {
+        m_data.m_propString = propString;
+        m_publisher->publishPropStringChanged(propString);
+    }
+}
+
+const StructStringWithArray& StructArray2InterfaceClient::getPropString() const
+{
+    return m_data.m_propString;
+}
+
+void StructArray2InterfaceClient::setPropEnum(const StructEnumWithArray& propEnum)
+{
+    if(m_client == nullptr) {
+        return;
+    }
+    static const auto topic = std::string("testbed1/StructArray2Interface/set/propEnum");
+    m_client->setRemoteProperty(topic, nlohmann::json(propEnum).dump());
+}
+
+void StructArray2InterfaceClient::setPropEnumLocal(const std::string& args)
+{
+    nlohmann::json fields = nlohmann::json::parse(args);
+    if (fields.empty())
+    {
+        return;
+    }
+
+    const StructEnumWithArray& propEnum = fields.get<StructEnumWithArray>();
+    if (m_data.m_propEnum != propEnum) {
+        m_data.m_propEnum = propEnum;
+        m_publisher->publishPropEnumChanged(propEnum);
+    }
+}
+
+const StructEnumWithArray& StructArray2InterfaceClient::getPropEnum() const
+{
+    return m_data.m_propEnum;
+}
+
+std::list<StructBool> StructArray2InterfaceClient::funcBool(const StructBoolWithArray& paramBool)
+{
+    if(m_client == nullptr) {
+        return std::list<StructBool>();
+    }
+    std::list<StructBool> value(funcBoolAsync(paramBool).get());
+    return value;
+}
+
+std::future<std::list<StructBool>> StructArray2InterfaceClient::funcBoolAsync(const StructBoolWithArray& paramBool, std::function<void(std::list<StructBool>)> callback)
+{
+    if(m_client == nullptr) {
+        throw std::runtime_error("Client is not initialized");
+    }
+    return std::async(std::launch::async, [this, callback,
+                    paramBool]()
+        {
+            std::promise<std::list<StructBool>> resultPromise;
+            static const auto topic = std::string("testbed1/StructArray2Interface/rpc/funcBool");
+            static const auto responseTopic = std::string(topic + "/" + m_client->getClientId() + "/result");
+            ApiGear::MQTT::InvokeReplyFunc responseHandler = [&resultPromise, callback](ApiGear::MQTT::InvokeReplyArg arg) {
+                const std::list<StructBool>& value = arg.value.get<std::list<StructBool>>();
+                resultPromise.set_value(value);
+                if (callback)
+                {
+                    callback(value);
+                }
+            };
+            auto responseId = registerResponseHandler(responseHandler);
+            m_client->invokeRemote(topic, responseTopic, nlohmann::json::array({paramBool}).dump(), responseId);
+            return resultPromise.get_future().get();
+        }
+    );
+}
+
+std::list<StructInt> StructArray2InterfaceClient::funcInt(const StructIntWithArray& paramInt)
+{
+    if(m_client == nullptr) {
+        return std::list<StructInt>();
+    }
+    std::list<StructInt> value(funcIntAsync(paramInt).get());
+    return value;
+}
+
+std::future<std::list<StructInt>> StructArray2InterfaceClient::funcIntAsync(const StructIntWithArray& paramInt, std::function<void(std::list<StructInt>)> callback)
+{
+    if(m_client == nullptr) {
+        throw std::runtime_error("Client is not initialized");
+    }
+    return std::async(std::launch::async, [this, callback,
+                    paramInt]()
+        {
+            std::promise<std::list<StructInt>> resultPromise;
+            static const auto topic = std::string("testbed1/StructArray2Interface/rpc/funcInt");
+            static const auto responseTopic = std::string(topic + "/" + m_client->getClientId() + "/result");
+            ApiGear::MQTT::InvokeReplyFunc responseHandler = [&resultPromise, callback](ApiGear::MQTT::InvokeReplyArg arg) {
+                const std::list<StructInt>& value = arg.value.get<std::list<StructInt>>();
+                resultPromise.set_value(value);
+                if (callback)
+                {
+                    callback(value);
+                }
+            };
+            auto responseId = registerResponseHandler(responseHandler);
+            m_client->invokeRemote(topic, responseTopic, nlohmann::json::array({paramInt}).dump(), responseId);
+            return resultPromise.get_future().get();
+        }
+    );
+}
+
+std::list<StructFloat> StructArray2InterfaceClient::funcFloat(const StructFloatWithArray& paramFloat)
+{
+    if(m_client == nullptr) {
+        return std::list<StructFloat>();
+    }
+    std::list<StructFloat> value(funcFloatAsync(paramFloat).get());
+    return value;
+}
+
+std::future<std::list<StructFloat>> StructArray2InterfaceClient::funcFloatAsync(const StructFloatWithArray& paramFloat, std::function<void(std::list<StructFloat>)> callback)
+{
+    if(m_client == nullptr) {
+        throw std::runtime_error("Client is not initialized");
+    }
+    return std::async(std::launch::async, [this, callback,
+                    paramFloat]()
+        {
+            std::promise<std::list<StructFloat>> resultPromise;
+            static const auto topic = std::string("testbed1/StructArray2Interface/rpc/funcFloat");
+            static const auto responseTopic = std::string(topic + "/" + m_client->getClientId() + "/result");
+            ApiGear::MQTT::InvokeReplyFunc responseHandler = [&resultPromise, callback](ApiGear::MQTT::InvokeReplyArg arg) {
+                const std::list<StructFloat>& value = arg.value.get<std::list<StructFloat>>();
+                resultPromise.set_value(value);
+                if (callback)
+                {
+                    callback(value);
+                }
+            };
+            auto responseId = registerResponseHandler(responseHandler);
+            m_client->invokeRemote(topic, responseTopic, nlohmann::json::array({paramFloat}).dump(), responseId);
+            return resultPromise.get_future().get();
+        }
+    );
+}
+
+std::list<StructString> StructArray2InterfaceClient::funcString(const StructStringWithArray& paramString)
+{
+    if(m_client == nullptr) {
+        return std::list<StructString>();
+    }
+    std::list<StructString> value(funcStringAsync(paramString).get());
+    return value;
+}
+
+std::future<std::list<StructString>> StructArray2InterfaceClient::funcStringAsync(const StructStringWithArray& paramString, std::function<void(std::list<StructString>)> callback)
+{
+    if(m_client == nullptr) {
+        throw std::runtime_error("Client is not initialized");
+    }
+    return std::async(std::launch::async, [this, callback,
+                    paramString]()
+        {
+            std::promise<std::list<StructString>> resultPromise;
+            static const auto topic = std::string("testbed1/StructArray2Interface/rpc/funcString");
+            static const auto responseTopic = std::string(topic + "/" + m_client->getClientId() + "/result");
+            ApiGear::MQTT::InvokeReplyFunc responseHandler = [&resultPromise, callback](ApiGear::MQTT::InvokeReplyArg arg) {
+                const std::list<StructString>& value = arg.value.get<std::list<StructString>>();
+                resultPromise.set_value(value);
+                if (callback)
+                {
+                    callback(value);
+                }
+            };
+            auto responseId = registerResponseHandler(responseHandler);
+            m_client->invokeRemote(topic, responseTopic, nlohmann::json::array({paramString}).dump(), responseId);
+            return resultPromise.get_future().get();
+        }
+    );
+}
+
+std::list<Enum0Enum> StructArray2InterfaceClient::funcEnum(const StructEnumWithArray& paramEnum)
+{
+    if(m_client == nullptr) {
+        return std::list<Enum0Enum>();
+    }
+    std::list<Enum0Enum> value(funcEnumAsync(paramEnum).get());
+    return value;
+}
+
+std::future<std::list<Enum0Enum>> StructArray2InterfaceClient::funcEnumAsync(const StructEnumWithArray& paramEnum, std::function<void(std::list<Enum0Enum>)> callback)
+{
+    if(m_client == nullptr) {
+        throw std::runtime_error("Client is not initialized");
+    }
+    return std::async(std::launch::async, [this, callback,
+                    paramEnum]()
+        {
+            std::promise<std::list<Enum0Enum>> resultPromise;
+            static const auto topic = std::string("testbed1/StructArray2Interface/rpc/funcEnum");
+            static const auto responseTopic = std::string(topic + "/" + m_client->getClientId() + "/result");
+            ApiGear::MQTT::InvokeReplyFunc responseHandler = [&resultPromise, callback](ApiGear::MQTT::InvokeReplyArg arg) {
+                const std::list<Enum0Enum>& value = arg.value.get<std::list<Enum0Enum>>();
+                resultPromise.set_value(value);
+                if (callback)
+                {
+                    callback(value);
+                }
+            };
+            auto responseId = registerResponseHandler(responseHandler);
+            m_client->invokeRemote(topic, responseTopic, nlohmann::json::array({paramEnum}).dump(), responseId);
+            return resultPromise.get_future().get();
+        }
+    );
+}
+void StructArray2InterfaceClient::onSigBool(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    m_publisher->publishSigBool(json_args[0].get<StructBoolWithArray>());
+}
+void StructArray2InterfaceClient::onSigInt(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    m_publisher->publishSigInt(json_args[0].get<StructIntWithArray>());
+}
+void StructArray2InterfaceClient::onSigFloat(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    m_publisher->publishSigFloat(json_args[0].get<StructFloatWithArray>());
+}
+void StructArray2InterfaceClient::onSigString(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    m_publisher->publishSigString(json_args[0].get<StructStringWithArray>());
+}
+
+int StructArray2InterfaceClient::registerResponseHandler(ApiGear::MQTT::InvokeReplyFunc handler)
+{
+    auto responseId = 0;
+    std::uniform_int_distribution<> distribution (0, 100000);
+    m_responseHandlerMutex.lock();
+    do {
+        responseId = distribution(randomNumberGenerator);
+    } while (m_responseHandlerMap.find(responseId) != m_responseHandlerMap.end());
+    m_responseHandlerMap.insert(std::pair<int, ApiGear::MQTT::InvokeReplyFunc>(responseId, handler));
+    m_responseHandlerMutex.unlock();
+
+    return responseId;
+}
+
+void StructArray2InterfaceClient::onInvokeReply(const std::string& args, const std::string& correlationData)
+{
+    const int randomId = std::stoi(correlationData);
+    ApiGear::MQTT::InvokeReplyFunc responseHandler {};
+    m_responseHandlerMutex.lock();
+    if((m_responseHandlerMap.find(randomId) != m_responseHandlerMap.end()))
+    {
+        responseHandler = m_responseHandlerMap[randomId];
+        m_responseHandlerMap.erase(randomId);
+    }
+    m_responseHandlerMutex.unlock();
+    if(responseHandler) {
+        const ApiGear::MQTT::InvokeReplyArg response{nlohmann::json::parse(args)};
+        responseHandler(response);
+    }
+}
+
+bool StructArray2InterfaceClient::isReady() const
+{
+    return m_isReady;
+}
+
+IStructArray2InterfacePublisher& StructArray2InterfaceClient::_getPublisher() const
+{
+    return *m_publisher;
+}

--- a/goldenmaster/modules/testbed1/generated/mqtt/structarray2interfaceclient.h
+++ b/goldenmaster/modules/testbed1/generated/mqtt/structarray2interfaceclient.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <future>
+#include "testbed1/generated/api/common.h"
+#include "testbed1/generated/api/testbed1.h"
+#include "testbed1/generated/core/structarray2interface.data.h"
+#include "apigear/mqtt/mqttclient.h"
+#include "apigear/mqtt/mqttbaseadapter.h"
+
+namespace Test {
+namespace Testbed1 {
+namespace MQTT {
+/**
+ * @brief MQTT adapter for StructArray2Interface.
+ *
+ * @note Threading: property-change and signal callbacks arrive on the MQTT transport thread.
+ * Subscription management inside the publisher is thread safe, but the callbacks themselves
+ * execute without additional locking. Operation calls are not additionally synchronized —
+ * callers are responsible for thread safety of concurrent operation invocations.
+ * Property storage is not guarded by a mutex; wrap with StructArray2InterfaceThreadSafeDecorator
+ * for concurrent access from multiple threads.
+ */
+class TEST_TESTBED1_EXPORT StructArray2InterfaceClient : public IStructArray2Interface, public ApiGear::MQTT::MqttBaseAdapter
+{
+public:
+    explicit StructArray2InterfaceClient(std::shared_ptr<ApiGear::MQTT::Client> client);
+    static std::shared_ptr<StructArray2InterfaceClient> create(std::shared_ptr<ApiGear::MQTT::Client> client);
+    /// Convenience factory. Unlike the NATS adapter, no post-construction init() is needed
+    /// because MqttBaseAdapter subscribes topics eagerly in the constructor.
+    virtual ~StructArray2InterfaceClient() override;
+    const StructBoolWithArray& getPropBool() const override;
+    void setPropBool(const StructBoolWithArray& propBool) override;
+    const StructIntWithArray& getPropInt() const override;
+    void setPropInt(const StructIntWithArray& propInt) override;
+    const StructFloatWithArray& getPropFloat() const override;
+    void setPropFloat(const StructFloatWithArray& propFloat) override;
+    const StructStringWithArray& getPropString() const override;
+    void setPropString(const StructStringWithArray& propString) override;
+    const StructEnumWithArray& getPropEnum() const override;
+    void setPropEnum(const StructEnumWithArray& propEnum) override;
+    std::list<StructBool> funcBool(const StructBoolWithArray& paramBool) override;
+    std::future<std::list<StructBool>> funcBoolAsync(const StructBoolWithArray& paramBool, std::function<void(std::list<StructBool>)> callback = nullptr) override;
+    std::list<StructInt> funcInt(const StructIntWithArray& paramInt) override;
+    std::future<std::list<StructInt>> funcIntAsync(const StructIntWithArray& paramInt, std::function<void(std::list<StructInt>)> callback = nullptr) override;
+    std::list<StructFloat> funcFloat(const StructFloatWithArray& paramFloat) override;
+    std::future<std::list<StructFloat>> funcFloatAsync(const StructFloatWithArray& paramFloat, std::function<void(std::list<StructFloat>)> callback = nullptr) override;
+    std::list<StructString> funcString(const StructStringWithArray& paramString) override;
+    std::future<std::list<StructString>> funcStringAsync(const StructStringWithArray& paramString, std::function<void(std::list<StructString>)> callback = nullptr) override;
+    std::list<Enum0Enum> funcEnum(const StructEnumWithArray& paramEnum) override;
+    std::future<std::list<Enum0Enum>> funcEnumAsync(const StructEnumWithArray& paramEnum, std::function<void(std::list<Enum0Enum>)> callback = nullptr) override;
+    IStructArray2InterfacePublisher& _getPublisher() const override;
+
+    bool isReady() const;
+
+    void onInvokeReply(const std::string& args, const std::string& correlationData);
+
+    void onConnectionStatusChanged(bool connectionStatus);
+private:
+    /// @brief factory to create the topic map which is used for bindings
+    /// @return map with all topics and corresponding function callbacks
+    std::map<std::string, ApiGear::MQTT::CallbackFunction> createTopicMap(const std::string&clientId);
+    /// @brief sets the value for the property PropBool coming from the service
+    /// @param args contains the param of the type StructBoolWithArray
+    void setPropBoolLocal(const std::string& args);
+    /// @brief sets the value for the property PropInt coming from the service
+    /// @param args contains the param of the type StructIntWithArray
+    void setPropIntLocal(const std::string& args);
+    /// @brief sets the value for the property PropFloat coming from the service
+    /// @param args contains the param of the type StructFloatWithArray
+    void setPropFloatLocal(const std::string& args);
+    /// @brief sets the value for the property PropString coming from the service
+    /// @param args contains the param of the type StructStringWithArray
+    void setPropStringLocal(const std::string& args);
+    /// @brief sets the value for the property PropEnum coming from the service
+    /// @param args contains the param of the type StructEnumWithArray
+    void setPropEnumLocal(const std::string& args);
+    /// @brief publishes the value for the signal SigBool coming from the service
+    /// @param args contains the param(s) of the type(s) const StructBoolWithArray& paramBool
+    void onSigBool(const std::string& args) const;
+    /// @brief publishes the value for the signal SigInt coming from the service
+    /// @param args contains the param(s) of the type(s) const StructIntWithArray& paramInt
+    void onSigInt(const std::string& args) const;
+    /// @brief publishes the value for the signal SigFloat coming from the service
+    /// @param args contains the param(s) of the type(s) const StructFloatWithArray& paramFloat
+    void onSigFloat(const std::string& args) const;
+    /// @brief publishes the value for the signal SigString coming from the service
+    /// @param args contains the param(s) of the type(s) const StructStringWithArray& paramString
+    void onSigString(const std::string& args) const;
+
+    bool m_isReady;
+    /** Local storage for properties values. */
+    StructArray2InterfaceData m_data;
+    std::shared_ptr<ApiGear::MQTT::Client> m_client;
+
+    /** The publisher for StructArray2Interface */
+    std::unique_ptr<IStructArray2InterfacePublisher> m_publisher;
+
+    /**
+     * @brief register a response handler for an operation invocation
+     * 
+     * @param handler function to be called on return
+     * @return int unique id of the call
+     */
+    int registerResponseHandler(ApiGear::MQTT::InvokeReplyFunc handler);
+    std::mutex m_responseHandlerMutex;
+    std::map<int, ApiGear::MQTT::InvokeReplyFunc> m_responseHandlerMap;
+};
+} // namespace MQTT
+} // namespace Testbed1
+} // namespace Test

--- a/goldenmaster/modules/testbed1/generated/mqtt/structarray2interfaceservice.cpp
+++ b/goldenmaster/modules/testbed1/generated/mqtt/structarray2interfaceservice.cpp
@@ -1,0 +1,210 @@
+#include "testbed1/generated/mqtt/structarray2interfaceservice.h"
+#include "testbed1/generated/core/testbed1.json.adapter.h"
+#include <iostream>
+
+using namespace Test::Testbed1;
+using namespace Test::Testbed1::MQTT;
+
+StructArray2InterfaceService::StructArray2InterfaceService(std::shared_ptr<IStructArray2Interface> impl, std::shared_ptr<ApiGear::MQTT::Service> service)
+    : MqttBaseAdapter(service, createTopicMap())
+    , m_impl(impl)
+    , m_service(service)
+{
+    m_impl->_getPublisher().subscribeToAllChanges(*this);
+
+    m_connectionStatusId = m_service->subscribeToConnectionStatus([this](bool connectionStatus){ onConnectionStatusChanged(connectionStatus); });
+}
+
+StructArray2InterfaceService::~StructArray2InterfaceService()
+{
+    m_impl->_getPublisher().unsubscribeFromAllChanges(*this);
+
+    m_service->unsubscribeToConnectionStatus(m_connectionStatusId);
+}
+
+std::map<std::string, ApiGear::MQTT::CallbackFunction> StructArray2InterfaceService::createTopicMap()
+{
+    return {
+        {std::string("testbed1/StructArray2Interface/set/propBool"), [this](const std::string& args, const std::string&, const std::string&){ this->onSetPropBool(args); } },
+        {std::string("testbed1/StructArray2Interface/set/propInt"), [this](const std::string& args, const std::string&, const std::string&){ this->onSetPropInt(args); } },
+        {std::string("testbed1/StructArray2Interface/set/propFloat"), [this](const std::string& args, const std::string&, const std::string&){ this->onSetPropFloat(args); } },
+        {std::string("testbed1/StructArray2Interface/set/propString"), [this](const std::string& args, const std::string&, const std::string&){ this->onSetPropString(args); } },
+        {std::string("testbed1/StructArray2Interface/set/propEnum"), [this](const std::string& args, const std::string&, const std::string&){ this->onSetPropEnum(args); } },
+        {std::string("testbed1/StructArray2Interface/rpc/funcBool"), [this](const std::string& args, const std::string& responseTopic, const std::string& correlationData) { this->onInvokeFuncBool(args, responseTopic, correlationData); } },
+        {std::string("testbed1/StructArray2Interface/rpc/funcInt"), [this](const std::string& args, const std::string& responseTopic, const std::string& correlationData) { this->onInvokeFuncInt(args, responseTopic, correlationData); } },
+        {std::string("testbed1/StructArray2Interface/rpc/funcFloat"), [this](const std::string& args, const std::string& responseTopic, const std::string& correlationData) { this->onInvokeFuncFloat(args, responseTopic, correlationData); } },
+        {std::string("testbed1/StructArray2Interface/rpc/funcString"), [this](const std::string& args, const std::string& responseTopic, const std::string& correlationData) { this->onInvokeFuncString(args, responseTopic, correlationData); } },
+        {std::string("testbed1/StructArray2Interface/rpc/funcEnum"), [this](const std::string& args, const std::string& responseTopic, const std::string& correlationData) { this->onInvokeFuncEnum(args, responseTopic, correlationData); } },
+    };
+}
+
+void StructArray2InterfaceService::onConnectionStatusChanged(bool connectionStatus)
+{
+    if(!connectionStatus)
+    {
+        return;
+    }
+    // send current values
+    onPropBoolChanged(m_impl->getPropBool());
+    onPropIntChanged(m_impl->getPropInt());
+    onPropFloatChanged(m_impl->getPropFloat());
+    onPropStringChanged(m_impl->getPropString());
+    onPropEnumChanged(m_impl->getPropEnum());
+}
+void StructArray2InterfaceService::onSetPropBool(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    if (json_args.empty())
+    {
+        return;
+    }
+
+    auto propBool = json_args.get<StructBoolWithArray>();
+    m_impl->setPropBool(propBool);
+}
+void StructArray2InterfaceService::onSetPropInt(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    if (json_args.empty())
+    {
+        return;
+    }
+
+    auto propInt = json_args.get<StructIntWithArray>();
+    m_impl->setPropInt(propInt);
+}
+void StructArray2InterfaceService::onSetPropFloat(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    if (json_args.empty())
+    {
+        return;
+    }
+
+    auto propFloat = json_args.get<StructFloatWithArray>();
+    m_impl->setPropFloat(propFloat);
+}
+void StructArray2InterfaceService::onSetPropString(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    if (json_args.empty())
+    {
+        return;
+    }
+
+    auto propString = json_args.get<StructStringWithArray>();
+    m_impl->setPropString(propString);
+}
+void StructArray2InterfaceService::onSetPropEnum(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    if (json_args.empty())
+    {
+        return;
+    }
+
+    auto propEnum = json_args.get<StructEnumWithArray>();
+    m_impl->setPropEnum(propEnum);
+}
+void StructArray2InterfaceService::onInvokeFuncBool(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    const StructBoolWithArray& paramBool = json_args.at(0).get<StructBoolWithArray>();
+    auto result = m_impl->funcBool(paramBool);
+    m_service->notifyInvokeResponse(responseTopic, nlohmann::json(result).dump(), correlationData);
+}
+void StructArray2InterfaceService::onInvokeFuncInt(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    const StructIntWithArray& paramInt = json_args.at(0).get<StructIntWithArray>();
+    auto result = m_impl->funcInt(paramInt);
+    m_service->notifyInvokeResponse(responseTopic, nlohmann::json(result).dump(), correlationData);
+}
+void StructArray2InterfaceService::onInvokeFuncFloat(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    const StructFloatWithArray& paramFloat = json_args.at(0).get<StructFloatWithArray>();
+    auto result = m_impl->funcFloat(paramFloat);
+    m_service->notifyInvokeResponse(responseTopic, nlohmann::json(result).dump(), correlationData);
+}
+void StructArray2InterfaceService::onInvokeFuncString(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    const StructStringWithArray& paramString = json_args.at(0).get<StructStringWithArray>();
+    auto result = m_impl->funcString(paramString);
+    m_service->notifyInvokeResponse(responseTopic, nlohmann::json(result).dump(), correlationData);
+}
+void StructArray2InterfaceService::onInvokeFuncEnum(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    const StructEnumWithArray& paramEnum = json_args.at(0).get<StructEnumWithArray>();
+    auto result = m_impl->funcEnum(paramEnum);
+    m_service->notifyInvokeResponse(responseTopic, nlohmann::json(result).dump(), correlationData);
+}
+void StructArray2InterfaceService::onSigBool(const StructBoolWithArray& paramBool)
+{
+    if(m_service != nullptr) {
+        const nlohmann::json& args = { paramBool };
+        static const auto topic = std::string("testbed1/StructArray2Interface/sig/sigBool");
+        m_service->notifySignal(topic, nlohmann::json(args).dump());
+    }
+}
+void StructArray2InterfaceService::onSigInt(const StructIntWithArray& paramInt)
+{
+    if(m_service != nullptr) {
+        const nlohmann::json& args = { paramInt };
+        static const auto topic = std::string("testbed1/StructArray2Interface/sig/sigInt");
+        m_service->notifySignal(topic, nlohmann::json(args).dump());
+    }
+}
+void StructArray2InterfaceService::onSigFloat(const StructFloatWithArray& paramFloat)
+{
+    if(m_service != nullptr) {
+        const nlohmann::json& args = { paramFloat };
+        static const auto topic = std::string("testbed1/StructArray2Interface/sig/sigFloat");
+        m_service->notifySignal(topic, nlohmann::json(args).dump());
+    }
+}
+void StructArray2InterfaceService::onSigString(const StructStringWithArray& paramString)
+{
+    if(m_service != nullptr) {
+        const nlohmann::json& args = { paramString };
+        static const auto topic = std::string("testbed1/StructArray2Interface/sig/sigString");
+        m_service->notifySignal(topic, nlohmann::json(args).dump());
+    }
+}
+void StructArray2InterfaceService::onPropBoolChanged(const StructBoolWithArray& propBool)
+{
+    if(m_service != nullptr) {
+        static const auto topic = std::string("testbed1/StructArray2Interface/prop/propBool");
+        m_service->notifyPropertyChange(topic, nlohmann::json(propBool).dump());
+    }
+}
+void StructArray2InterfaceService::onPropIntChanged(const StructIntWithArray& propInt)
+{
+    if(m_service != nullptr) {
+        static const auto topic = std::string("testbed1/StructArray2Interface/prop/propInt");
+        m_service->notifyPropertyChange(topic, nlohmann::json(propInt).dump());
+    }
+}
+void StructArray2InterfaceService::onPropFloatChanged(const StructFloatWithArray& propFloat)
+{
+    if(m_service != nullptr) {
+        static const auto topic = std::string("testbed1/StructArray2Interface/prop/propFloat");
+        m_service->notifyPropertyChange(topic, nlohmann::json(propFloat).dump());
+    }
+}
+void StructArray2InterfaceService::onPropStringChanged(const StructStringWithArray& propString)
+{
+    if(m_service != nullptr) {
+        static const auto topic = std::string("testbed1/StructArray2Interface/prop/propString");
+        m_service->notifyPropertyChange(topic, nlohmann::json(propString).dump());
+    }
+}
+void StructArray2InterfaceService::onPropEnumChanged(const StructEnumWithArray& propEnum)
+{
+    if(m_service != nullptr) {
+        static const auto topic = std::string("testbed1/StructArray2Interface/prop/propEnum");
+        m_service->notifyPropertyChange(topic, nlohmann::json(propEnum).dump());
+    }
+}

--- a/goldenmaster/modules/testbed1/generated/mqtt/structarray2interfaceservice.h
+++ b/goldenmaster/modules/testbed1/generated/mqtt/structarray2interfaceservice.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "testbed1/generated/api/testbed1.h"
+#include "testbed1/generated/api/common.h"
+#include "apigear/mqtt/mqttservice.h"
+#include "apigear/mqtt/mqttbaseadapter.h"
+
+namespace Test {
+namespace Testbed1 {
+namespace MQTT {
+class TEST_TESTBED1_EXPORT StructArray2InterfaceService : public IStructArray2InterfaceSubscriber, public ApiGear::MQTT::MqttBaseAdapter
+{
+public:
+    explicit StructArray2InterfaceService(std::shared_ptr<IStructArray2Interface> impl, std::shared_ptr<ApiGear::MQTT::Service> service);
+    virtual ~StructArray2InterfaceService() override;
+
+    // IStructArray2InterfaceSubscriber interface
+    void onSigBool(const StructBoolWithArray& paramBool) override;
+    void onSigInt(const StructIntWithArray& paramInt) override;
+    void onSigFloat(const StructFloatWithArray& paramFloat) override;
+    void onSigString(const StructStringWithArray& paramString) override;
+
+private:
+    /// @brief factory to create the topic map which is used for bindings
+    /// @return map with all topics and corresponding function callbacks
+    std::map<std::string, ApiGear::MQTT::CallbackFunction> createTopicMap();
+
+    void onConnectionStatusChanged(bool connectionStatus);
+    void onInvokeFuncBool(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const;
+    void onInvokeFuncInt(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const;
+    void onInvokeFuncFloat(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const;
+    void onInvokeFuncString(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const;
+    void onInvokeFuncEnum(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const;
+    void onPropBoolChanged(const StructBoolWithArray& propBool) override;
+    /// @brief requests to set the value for the property PropBool coming from the client
+    /// @param fields contains the param of the type StructBoolWithArray
+    void onSetPropBool(const std::string& args) const;
+    void onPropIntChanged(const StructIntWithArray& propInt) override;
+    /// @brief requests to set the value for the property PropInt coming from the client
+    /// @param fields contains the param of the type StructIntWithArray
+    void onSetPropInt(const std::string& args) const;
+    void onPropFloatChanged(const StructFloatWithArray& propFloat) override;
+    /// @brief requests to set the value for the property PropFloat coming from the client
+    /// @param fields contains the param of the type StructFloatWithArray
+    void onSetPropFloat(const std::string& args) const;
+    void onPropStringChanged(const StructStringWithArray& propString) override;
+    /// @brief requests to set the value for the property PropString coming from the client
+    /// @param fields contains the param of the type StructStringWithArray
+    void onSetPropString(const std::string& args) const;
+    void onPropEnumChanged(const StructEnumWithArray& propEnum) override;
+    /// @brief requests to set the value for the property PropEnum coming from the client
+    /// @param fields contains the param of the type StructEnumWithArray
+    void onSetPropEnum(const std::string& args) const;
+
+    std::shared_ptr<IStructArray2Interface> m_impl;
+    std::shared_ptr<ApiGear::MQTT::Service> m_service;
+    // id for connection status registration
+    int m_connectionStatusId;
+};
+} // namespace MQTT
+} // namespace Testbed1
+} // namespace Test

--- a/goldenmaster/modules/testbed1/generated/mqtt/structarrayinterfaceclient.cpp
+++ b/goldenmaster/modules/testbed1/generated/mqtt/structarrayinterfaceclient.cpp
@@ -33,14 +33,17 @@ std::map<std::string, ApiGear::MQTT::CallbackFunction> StructArrayInterfaceClien
         { std::string("testbed1/StructArrayInterface/prop/propInt"), [this](const std::string& args, const std::string&, const std::string&){ this->setPropIntLocal(args); } },
         { std::string("testbed1/StructArrayInterface/prop/propFloat"), [this](const std::string& args, const std::string&, const std::string&){ this->setPropFloatLocal(args); } },
         { std::string("testbed1/StructArrayInterface/prop/propString"), [this](const std::string& args, const std::string&, const std::string&){ this->setPropStringLocal(args); } },
+        { std::string("testbed1/StructArrayInterface/prop/propEnum"), [this](const std::string& args, const std::string&, const std::string&){ this->setPropEnumLocal(args); } },
         { std::string("testbed1/StructArrayInterface/sig/sigBool"), [this](const std::string& args, const std::string&, const std::string&){ this->onSigBool(args); } },
         { std::string("testbed1/StructArrayInterface/sig/sigInt"), [this](const std::string& args, const std::string&, const std::string&){ this->onSigInt(args); } },
         { std::string("testbed1/StructArrayInterface/sig/sigFloat"), [this](const std::string& args, const std::string&, const std::string&){ this->onSigFloat(args); } },
         { std::string("testbed1/StructArrayInterface/sig/sigString"), [this](const std::string& args, const std::string&, const std::string&){ this->onSigString(args); } },
+        { std::string("testbed1/StructArrayInterface/sig/sigEnum"), [this](const std::string& args, const std::string&, const std::string&){ this->onSigEnum(args); } },
         { std::string("testbed1/StructArrayInterface/rpc/funcBool/"+clientId+"/result"), [this](const std::string& args, const std::string&, const std::string& correlationData){ this->onInvokeReply(args, correlationData); } },
         { std::string("testbed1/StructArrayInterface/rpc/funcInt/"+clientId+"/result"), [this](const std::string& args, const std::string&, const std::string& correlationData){ this->onInvokeReply(args, correlationData); } },
         { std::string("testbed1/StructArrayInterface/rpc/funcFloat/"+clientId+"/result"), [this](const std::string& args, const std::string&, const std::string& correlationData){ this->onInvokeReply(args, correlationData); } },
         { std::string("testbed1/StructArrayInterface/rpc/funcString/"+clientId+"/result"), [this](const std::string& args, const std::string&, const std::string& correlationData){ this->onInvokeReply(args, correlationData); } },
+        { std::string("testbed1/StructArrayInterface/rpc/funcEnum/"+clientId+"/result"), [this](const std::string& args, const std::string&, const std::string& correlationData){ this->onInvokeReply(args, correlationData); } },
     };
 };
 
@@ -158,6 +161,35 @@ void StructArrayInterfaceClient::setPropStringLocal(const std::string& args)
 const std::list<StructString>& StructArrayInterfaceClient::getPropString() const
 {
     return m_data.m_propString;
+}
+
+void StructArrayInterfaceClient::setPropEnum(const std::list<Enum0Enum>& propEnum)
+{
+    if(m_client == nullptr) {
+        return;
+    }
+    static const auto topic = std::string("testbed1/StructArrayInterface/set/propEnum");
+    m_client->setRemoteProperty(topic, nlohmann::json(propEnum).dump());
+}
+
+void StructArrayInterfaceClient::setPropEnumLocal(const std::string& args)
+{
+    nlohmann::json fields = nlohmann::json::parse(args);
+    if (fields.empty())
+    {
+        return;
+    }
+
+    const std::list<Enum0Enum>& propEnum = fields.get<std::list<Enum0Enum>>();
+    if (m_data.m_propEnum != propEnum) {
+        m_data.m_propEnum = propEnum;
+        m_publisher->publishPropEnumChanged(propEnum);
+    }
+}
+
+const std::list<Enum0Enum>& StructArrayInterfaceClient::getPropEnum() const
+{
+    return m_data.m_propEnum;
 }
 
 std::list<StructBool> StructArrayInterfaceClient::funcBool(const std::list<StructBool>& paramBool)
@@ -299,6 +331,41 @@ std::future<std::list<StructString>> StructArrayInterfaceClient::funcStringAsync
         }
     );
 }
+
+std::list<Enum0Enum> StructArrayInterfaceClient::funcEnum(const std::list<Enum0Enum>& paramEnum)
+{
+    if(m_client == nullptr) {
+        return std::list<Enum0Enum>();
+    }
+    std::list<Enum0Enum> value(funcEnumAsync(paramEnum).get());
+    return value;
+}
+
+std::future<std::list<Enum0Enum>> StructArrayInterfaceClient::funcEnumAsync(const std::list<Enum0Enum>& paramEnum, std::function<void(std::list<Enum0Enum>)> callback)
+{
+    if(m_client == nullptr) {
+        throw std::runtime_error("Client is not initialized");
+    }
+    return std::async(std::launch::async, [this, callback,
+                    paramEnum]()
+        {
+            std::promise<std::list<Enum0Enum>> resultPromise;
+            static const auto topic = std::string("testbed1/StructArrayInterface/rpc/funcEnum");
+            static const auto responseTopic = std::string(topic + "/" + m_client->getClientId() + "/result");
+            ApiGear::MQTT::InvokeReplyFunc responseHandler = [&resultPromise, callback](ApiGear::MQTT::InvokeReplyArg arg) {
+                const std::list<Enum0Enum>& value = arg.value.get<std::list<Enum0Enum>>();
+                resultPromise.set_value(value);
+                if (callback)
+                {
+                    callback(value);
+                }
+            };
+            auto responseId = registerResponseHandler(responseHandler);
+            m_client->invokeRemote(topic, responseTopic, nlohmann::json::array({paramEnum}).dump(), responseId);
+            return resultPromise.get_future().get();
+        }
+    );
+}
 void StructArrayInterfaceClient::onSigBool(const std::string& args) const
 {
     nlohmann::json json_args = nlohmann::json::parse(args);
@@ -318,6 +385,11 @@ void StructArrayInterfaceClient::onSigString(const std::string& args) const
 {
     nlohmann::json json_args = nlohmann::json::parse(args);
     m_publisher->publishSigString(json_args[0].get<std::list<StructString>>());
+}
+void StructArrayInterfaceClient::onSigEnum(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    m_publisher->publishSigEnum(json_args[0].get<std::list<Enum0Enum>>());
 }
 
 int StructArrayInterfaceClient::registerResponseHandler(ApiGear::MQTT::InvokeReplyFunc handler)

--- a/goldenmaster/modules/testbed1/generated/mqtt/structarrayinterfaceclient.h
+++ b/goldenmaster/modules/testbed1/generated/mqtt/structarrayinterfaceclient.h
@@ -36,6 +36,8 @@ public:
     void setPropFloat(const std::list<StructFloat>& propFloat) override;
     const std::list<StructString>& getPropString() const override;
     void setPropString(const std::list<StructString>& propString) override;
+    const std::list<Enum0Enum>& getPropEnum() const override;
+    void setPropEnum(const std::list<Enum0Enum>& propEnum) override;
     std::list<StructBool> funcBool(const std::list<StructBool>& paramBool) override;
     std::future<std::list<StructBool>> funcBoolAsync(const std::list<StructBool>& paramBool, std::function<void(std::list<StructBool>)> callback = nullptr) override;
     std::list<StructInt> funcInt(const std::list<StructInt>& paramInt) override;
@@ -44,6 +46,8 @@ public:
     std::future<std::list<StructFloat>> funcFloatAsync(const std::list<StructFloat>& paramFloat, std::function<void(std::list<StructFloat>)> callback = nullptr) override;
     std::list<StructString> funcString(const std::list<StructString>& paramString) override;
     std::future<std::list<StructString>> funcStringAsync(const std::list<StructString>& paramString, std::function<void(std::list<StructString>)> callback = nullptr) override;
+    std::list<Enum0Enum> funcEnum(const std::list<Enum0Enum>& paramEnum) override;
+    std::future<std::list<Enum0Enum>> funcEnumAsync(const std::list<Enum0Enum>& paramEnum, std::function<void(std::list<Enum0Enum>)> callback = nullptr) override;
     IStructArrayInterfacePublisher& _getPublisher() const override;
 
     bool isReady() const;
@@ -67,6 +71,9 @@ private:
     /// @brief sets the value for the property PropString coming from the service
     /// @param args contains the param of the type std::list<StructString>
     void setPropStringLocal(const std::string& args);
+    /// @brief sets the value for the property PropEnum coming from the service
+    /// @param args contains the param of the type std::list<Enum0Enum>
+    void setPropEnumLocal(const std::string& args);
     /// @brief publishes the value for the signal SigBool coming from the service
     /// @param args contains the param(s) of the type(s) const std::list<StructBool>& paramBool
     void onSigBool(const std::string& args) const;
@@ -79,6 +86,9 @@ private:
     /// @brief publishes the value for the signal SigString coming from the service
     /// @param args contains the param(s) of the type(s) const std::list<StructString>& paramString
     void onSigString(const std::string& args) const;
+    /// @brief publishes the value for the signal SigEnum coming from the service
+    /// @param args contains the param(s) of the type(s) const std::list<Enum0Enum>& paramEnum
+    void onSigEnum(const std::string& args) const;
 
     bool m_isReady;
     /** Local storage for properties values. */

--- a/goldenmaster/modules/testbed1/generated/mqtt/structarrayinterfaceservice.cpp
+++ b/goldenmaster/modules/testbed1/generated/mqtt/structarrayinterfaceservice.cpp
@@ -29,10 +29,12 @@ std::map<std::string, ApiGear::MQTT::CallbackFunction> StructArrayInterfaceServi
         {std::string("testbed1/StructArrayInterface/set/propInt"), [this](const std::string& args, const std::string&, const std::string&){ this->onSetPropInt(args); } },
         {std::string("testbed1/StructArrayInterface/set/propFloat"), [this](const std::string& args, const std::string&, const std::string&){ this->onSetPropFloat(args); } },
         {std::string("testbed1/StructArrayInterface/set/propString"), [this](const std::string& args, const std::string&, const std::string&){ this->onSetPropString(args); } },
+        {std::string("testbed1/StructArrayInterface/set/propEnum"), [this](const std::string& args, const std::string&, const std::string&){ this->onSetPropEnum(args); } },
         {std::string("testbed1/StructArrayInterface/rpc/funcBool"), [this](const std::string& args, const std::string& responseTopic, const std::string& correlationData) { this->onInvokeFuncBool(args, responseTopic, correlationData); } },
         {std::string("testbed1/StructArrayInterface/rpc/funcInt"), [this](const std::string& args, const std::string& responseTopic, const std::string& correlationData) { this->onInvokeFuncInt(args, responseTopic, correlationData); } },
         {std::string("testbed1/StructArrayInterface/rpc/funcFloat"), [this](const std::string& args, const std::string& responseTopic, const std::string& correlationData) { this->onInvokeFuncFloat(args, responseTopic, correlationData); } },
         {std::string("testbed1/StructArrayInterface/rpc/funcString"), [this](const std::string& args, const std::string& responseTopic, const std::string& correlationData) { this->onInvokeFuncString(args, responseTopic, correlationData); } },
+        {std::string("testbed1/StructArrayInterface/rpc/funcEnum"), [this](const std::string& args, const std::string& responseTopic, const std::string& correlationData) { this->onInvokeFuncEnum(args, responseTopic, correlationData); } },
     };
 }
 
@@ -47,6 +49,7 @@ void StructArrayInterfaceService::onConnectionStatusChanged(bool connectionStatu
     onPropIntChanged(m_impl->getPropInt());
     onPropFloatChanged(m_impl->getPropFloat());
     onPropStringChanged(m_impl->getPropString());
+    onPropEnumChanged(m_impl->getPropEnum());
 }
 void StructArrayInterfaceService::onSetPropBool(const std::string& args) const
 {
@@ -92,6 +95,17 @@ void StructArrayInterfaceService::onSetPropString(const std::string& args) const
     auto propString = json_args.get<std::list<StructString>>();
     m_impl->setPropString(propString);
 }
+void StructArrayInterfaceService::onSetPropEnum(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    if (json_args.empty())
+    {
+        return;
+    }
+
+    auto propEnum = json_args.get<std::list<Enum0Enum>>();
+    m_impl->setPropEnum(propEnum);
+}
 void StructArrayInterfaceService::onInvokeFuncBool(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const
 {
     nlohmann::json json_args = nlohmann::json::parse(args);
@@ -118,6 +132,13 @@ void StructArrayInterfaceService::onInvokeFuncString(const std::string& args, co
     nlohmann::json json_args = nlohmann::json::parse(args);
     const std::list<StructString>& paramString = json_args.at(0).get<std::list<StructString>>();
     auto result = m_impl->funcString(paramString);
+    m_service->notifyInvokeResponse(responseTopic, nlohmann::json(result).dump(), correlationData);
+}
+void StructArrayInterfaceService::onInvokeFuncEnum(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    const std::list<Enum0Enum>& paramEnum = json_args.at(0).get<std::list<Enum0Enum>>();
+    auto result = m_impl->funcEnum(paramEnum);
     m_service->notifyInvokeResponse(responseTopic, nlohmann::json(result).dump(), correlationData);
 }
 void StructArrayInterfaceService::onSigBool(const std::list<StructBool>& paramBool)
@@ -152,6 +173,14 @@ void StructArrayInterfaceService::onSigString(const std::list<StructString>& par
         m_service->notifySignal(topic, nlohmann::json(args).dump());
     }
 }
+void StructArrayInterfaceService::onSigEnum(const std::list<Enum0Enum>& paramEnum)
+{
+    if(m_service != nullptr) {
+        const nlohmann::json& args = { paramEnum };
+        static const auto topic = std::string("testbed1/StructArrayInterface/sig/sigEnum");
+        m_service->notifySignal(topic, nlohmann::json(args).dump());
+    }
+}
 void StructArrayInterfaceService::onPropBoolChanged(const std::list<StructBool>& propBool)
 {
     if(m_service != nullptr) {
@@ -178,5 +207,12 @@ void StructArrayInterfaceService::onPropStringChanged(const std::list<StructStri
     if(m_service != nullptr) {
         static const auto topic = std::string("testbed1/StructArrayInterface/prop/propString");
         m_service->notifyPropertyChange(topic, nlohmann::json(propString).dump());
+    }
+}
+void StructArrayInterfaceService::onPropEnumChanged(const std::list<Enum0Enum>& propEnum)
+{
+    if(m_service != nullptr) {
+        static const auto topic = std::string("testbed1/StructArrayInterface/prop/propEnum");
+        m_service->notifyPropertyChange(topic, nlohmann::json(propEnum).dump());
     }
 }

--- a/goldenmaster/modules/testbed1/generated/mqtt/structarrayinterfaceservice.h
+++ b/goldenmaster/modules/testbed1/generated/mqtt/structarrayinterfaceservice.h
@@ -19,6 +19,7 @@ public:
     void onSigInt(const std::list<StructInt>& paramInt) override;
     void onSigFloat(const std::list<StructFloat>& paramFloat) override;
     void onSigString(const std::list<StructString>& paramString) override;
+    void onSigEnum(const std::list<Enum0Enum>& paramEnum) override;
 
 private:
     /// @brief factory to create the topic map which is used for bindings
@@ -30,6 +31,7 @@ private:
     void onInvokeFuncInt(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const;
     void onInvokeFuncFloat(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const;
     void onInvokeFuncString(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const;
+    void onInvokeFuncEnum(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const;
     void onPropBoolChanged(const std::list<StructBool>& propBool) override;
     /// @brief requests to set the value for the property PropBool coming from the client
     /// @param fields contains the param of the type std::list<StructBool>
@@ -46,6 +48,10 @@ private:
     /// @brief requests to set the value for the property PropString coming from the client
     /// @param fields contains the param of the type std::list<StructString>
     void onSetPropString(const std::string& args) const;
+    void onPropEnumChanged(const std::list<Enum0Enum>& propEnum) override;
+    /// @brief requests to set the value for the property PropEnum coming from the client
+    /// @param fields contains the param of the type std::list<Enum0Enum>
+    void onSetPropEnum(const std::string& args) const;
 
     std::shared_ptr<IStructArrayInterface> m_impl;
     std::shared_ptr<ApiGear::MQTT::Service> m_service;

--- a/goldenmaster/modules/testbed1/generated/mqtt/tests/CMakeLists.txt
+++ b/goldenmaster/modules/testbed1/generated/mqtt/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ set(TEST_TESTBED1_GENERATED_MQTT_SOURCES
     test_main.cpp
     test_structinterface.cpp
     test_structarrayinterface.cpp
+    test_structarray2interface.cpp
     )
 
 

--- a/goldenmaster/modules/testbed1/generated/mqtt/tests/test_structarray2interface.cpp
+++ b/goldenmaster/modules/testbed1/generated/mqtt/tests/test_structarray2interface.cpp
@@ -1,0 +1,424 @@
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include "testbed1/generated/core/test_struct_helper.h"
+#include "testbed1/implementation/structarray2interface.h"
+#include "testbed1/generated/mqtt/structarray2interfaceclient.h"
+#include "testbed1/generated/mqtt/structarray2interfaceservice.h"
+
+
+#include "apigear/mqtt/mqttclient.h"
+#include "apigear/mqtt/mqttservice.h"
+
+// Those tests do not use network connection.
+// They are set in a way the client writes data straight into read function of server and vice versa.
+
+namespace{
+
+    int timeout = 2000;//in ms
+}
+
+using namespace Test;
+using namespace Test::Testbed1;
+
+TEST_CASE("mqtt  testbed1 StructArray2Interface tests")
+{
+    auto mqttservice = std::make_shared<ApiGear::MQTT::Service>("StructArray2InterfacetestServer");
+    auto mqttclient = std::make_shared<ApiGear::MQTT::Client>("StructArray2InterfacetestClient");
+
+    auto clientStructArray2Interface = std::make_shared<Test::Testbed1::MQTT::StructArray2InterfaceClient>(mqttclient);
+    auto implStructArray2Interface= std::make_shared<Test::Testbed1::StructArray2Interface>();
+    auto serviceStructArray2Interface = std::make_shared<Test::Testbed1::MQTT::StructArray2InterfaceService>(implStructArray2Interface, mqttservice);
+
+    mqttservice->connectToHost("");
+    mqttclient->connectToHost("");
+
+    std::condition_variable m_wait;
+    std::mutex m_waitMutex;
+    std::unique_lock<std::mutex> lock(m_waitMutex, std::defer_lock);
+
+
+    std::atomic<bool> is_serviceConnected{ false };
+    auto service_connected_id = serviceStructArray2Interface->_subscribeForIsReady([&is_serviceConnected, &m_wait](auto connected)
+        {
+            if (connected)
+            {
+                is_serviceConnected = true;
+                m_wait.notify_all();
+            }
+        });
+    if (serviceStructArray2Interface->_is_ready() == true)
+    {
+        is_serviceConnected = true;
+        m_wait.notify_all();
+    }
+    lock.lock();
+    m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&is_serviceConnected]() { return is_serviceConnected == true; });
+    lock.unlock();
+    REQUIRE(is_serviceConnected);
+ 
+    std::atomic<bool> is_clientConnected{ false };
+    clientStructArray2Interface->_subscribeForIsReady([&is_clientConnected, &m_wait](auto connected)
+        {
+            if (connected)
+            {
+                is_clientConnected = true;
+                m_wait.notify_all();
+            }
+        });
+
+    lock.lock();
+    m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&is_clientConnected]() {return is_clientConnected  == true; });
+    lock.unlock();
+    REQUIRE(is_clientConnected);
+    SECTION("Test setting propBool")
+    {
+        std::atomic<bool> ispropBoolChanged = false;
+        clientStructArray2Interface->_getPublisher().subscribeToPropBoolChanged(
+        [&ispropBoolChanged, &m_wait ](auto value){
+            ispropBoolChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = Testbed1::StructBoolWithArray();
+        Testbed1::fillTestStructBoolWithArray(test_value);
+        clientStructArray2Interface->setPropBool(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropBoolChanged]() {return ispropBoolChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArray2Interface->getPropBool() == test_value);
+        REQUIRE(clientStructArray2Interface->getPropBool() == test_value);
+    }
+    SECTION("Test setting propInt")
+    {
+        std::atomic<bool> ispropIntChanged = false;
+        clientStructArray2Interface->_getPublisher().subscribeToPropIntChanged(
+        [&ispropIntChanged, &m_wait ](auto value){
+            ispropIntChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = Testbed1::StructIntWithArray();
+        Testbed1::fillTestStructIntWithArray(test_value);
+        clientStructArray2Interface->setPropInt(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropIntChanged]() {return ispropIntChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArray2Interface->getPropInt() == test_value);
+        REQUIRE(clientStructArray2Interface->getPropInt() == test_value);
+    }
+    SECTION("Test setting propFloat")
+    {
+        std::atomic<bool> ispropFloatChanged = false;
+        clientStructArray2Interface->_getPublisher().subscribeToPropFloatChanged(
+        [&ispropFloatChanged, &m_wait ](auto value){
+            ispropFloatChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = Testbed1::StructFloatWithArray();
+        Testbed1::fillTestStructFloatWithArray(test_value);
+        clientStructArray2Interface->setPropFloat(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropFloatChanged]() {return ispropFloatChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArray2Interface->getPropFloat() == test_value);
+        REQUIRE(clientStructArray2Interface->getPropFloat() == test_value);
+    }
+    SECTION("Test setting propString")
+    {
+        std::atomic<bool> ispropStringChanged = false;
+        clientStructArray2Interface->_getPublisher().subscribeToPropStringChanged(
+        [&ispropStringChanged, &m_wait ](auto value){
+            ispropStringChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = Testbed1::StructStringWithArray();
+        Testbed1::fillTestStructStringWithArray(test_value);
+        clientStructArray2Interface->setPropString(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropStringChanged]() {return ispropStringChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArray2Interface->getPropString() == test_value);
+        REQUIRE(clientStructArray2Interface->getPropString() == test_value);
+    }
+    SECTION("Test setting propEnum")
+    {
+        std::atomic<bool> ispropEnumChanged = false;
+        clientStructArray2Interface->_getPublisher().subscribeToPropEnumChanged(
+        [&ispropEnumChanged, &m_wait ](auto value){
+            ispropEnumChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = Testbed1::StructEnumWithArray();
+        Testbed1::fillTestStructEnumWithArray(test_value);
+        clientStructArray2Interface->setPropEnum(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropEnumChanged]() {return ispropEnumChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArray2Interface->getPropEnum() == test_value);
+        REQUIRE(clientStructArray2Interface->getPropEnum() == test_value);
+    }
+    SECTION("Test emit sigBool")
+    {
+        std::atomic<bool> issigBoolEmitted = false;
+        auto local_param_bool_struct = Testbed1::StructBoolWithArray();
+        Testbed1::fillTestStructBoolWithArray(local_param_bool_struct);
+
+        clientStructArray2Interface->_getPublisher().subscribeToSigBool(
+        [&m_wait, &issigBoolEmitted, &local_param_bool_struct](const Testbed1::StructBoolWithArray& paramBool)
+        {
+            REQUIRE(paramBool ==local_param_bool_struct);
+            issigBoolEmitted  = true;
+            m_wait.notify_all();
+        });
+
+         implStructArray2Interface->_getPublisher().publishSigBool(local_param_bool_struct);
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&issigBoolEmitted ]() {return issigBoolEmitted   == true; }));
+        lock.unlock();
+    }
+    SECTION("Test emit sigInt")
+    {
+        std::atomic<bool> issigIntEmitted = false;
+        auto local_param_int_struct = Testbed1::StructIntWithArray();
+        Testbed1::fillTestStructIntWithArray(local_param_int_struct);
+
+        clientStructArray2Interface->_getPublisher().subscribeToSigInt(
+        [&m_wait, &issigIntEmitted, &local_param_int_struct](const Testbed1::StructIntWithArray& paramInt)
+        {
+            REQUIRE(paramInt ==local_param_int_struct);
+            issigIntEmitted  = true;
+            m_wait.notify_all();
+        });
+
+         implStructArray2Interface->_getPublisher().publishSigInt(local_param_int_struct);
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&issigIntEmitted ]() {return issigIntEmitted   == true; }));
+        lock.unlock();
+    }
+    SECTION("Test emit sigFloat")
+    {
+        std::atomic<bool> issigFloatEmitted = false;
+        auto local_param_float_struct = Testbed1::StructFloatWithArray();
+        Testbed1::fillTestStructFloatWithArray(local_param_float_struct);
+
+        clientStructArray2Interface->_getPublisher().subscribeToSigFloat(
+        [&m_wait, &issigFloatEmitted, &local_param_float_struct](const Testbed1::StructFloatWithArray& paramFloat)
+        {
+            REQUIRE(paramFloat ==local_param_float_struct);
+            issigFloatEmitted  = true;
+            m_wait.notify_all();
+        });
+
+         implStructArray2Interface->_getPublisher().publishSigFloat(local_param_float_struct);
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&issigFloatEmitted ]() {return issigFloatEmitted   == true; }));
+        lock.unlock();
+    }
+    SECTION("Test emit sigString")
+    {
+        std::atomic<bool> issigStringEmitted = false;
+        auto local_param_string_struct = Testbed1::StructStringWithArray();
+        Testbed1::fillTestStructStringWithArray(local_param_string_struct);
+
+        clientStructArray2Interface->_getPublisher().subscribeToSigString(
+        [&m_wait, &issigStringEmitted, &local_param_string_struct](const Testbed1::StructStringWithArray& paramString)
+        {
+            REQUIRE(paramString ==local_param_string_struct);
+            issigStringEmitted  = true;
+            m_wait.notify_all();
+        });
+
+         implStructArray2Interface->_getPublisher().publishSigString(local_param_string_struct);
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&issigStringEmitted ]() {return issigStringEmitted   == true; }));
+        lock.unlock();
+    }
+    SECTION("Test method funcBool")
+    {
+        [[maybe_unused]] auto result =  clientStructArray2Interface->funcBool(Testbed1::StructBoolWithArray());
+        // CHECK EFFECTS OF YOUR METHOD AFER FUTURE IS DONE
+    }
+    SECTION("Test method funcBool async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcBoolAsync(Testbed1::StructBoolWithArray());
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::StructBool>()); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    SECTION("Test method funcBool async with callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcBoolAsync(Testbed1::StructBoolWithArray(),[&finished, &m_wait](std::list<StructBool> value){ (void) value; finished = true; m_wait.notify_all(); /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ });
+
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::StructBool>()); 
+    }
+    SECTION("Test method funcInt")
+    {
+        [[maybe_unused]] auto result =  clientStructArray2Interface->funcInt(Testbed1::StructIntWithArray());
+        // CHECK EFFECTS OF YOUR METHOD AFER FUTURE IS DONE
+    }
+    SECTION("Test method funcInt async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcIntAsync(Testbed1::StructIntWithArray());
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::StructInt>()); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    SECTION("Test method funcInt async with callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcIntAsync(Testbed1::StructIntWithArray(),[&finished, &m_wait](std::list<StructInt> value){ (void) value; finished = true; m_wait.notify_all(); /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ });
+
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::StructInt>()); 
+    }
+    SECTION("Test method funcFloat")
+    {
+        [[maybe_unused]] auto result =  clientStructArray2Interface->funcFloat(Testbed1::StructFloatWithArray());
+        // CHECK EFFECTS OF YOUR METHOD AFER FUTURE IS DONE
+    }
+    SECTION("Test method funcFloat async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcFloatAsync(Testbed1::StructFloatWithArray());
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::StructFloat>()); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    SECTION("Test method funcFloat async with callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcFloatAsync(Testbed1::StructFloatWithArray(),[&finished, &m_wait](std::list<StructFloat> value){ (void) value; finished = true; m_wait.notify_all(); /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ });
+
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::StructFloat>()); 
+    }
+    SECTION("Test method funcString")
+    {
+        [[maybe_unused]] auto result =  clientStructArray2Interface->funcString(Testbed1::StructStringWithArray());
+        // CHECK EFFECTS OF YOUR METHOD AFER FUTURE IS DONE
+    }
+    SECTION("Test method funcString async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcStringAsync(Testbed1::StructStringWithArray());
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::StructString>()); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    SECTION("Test method funcString async with callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcStringAsync(Testbed1::StructStringWithArray(),[&finished, &m_wait](std::list<StructString> value){ (void) value; finished = true; m_wait.notify_all(); /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ });
+
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::StructString>()); 
+    }
+    SECTION("Test method funcEnum")
+    {
+        [[maybe_unused]] auto result =  clientStructArray2Interface->funcEnum(Testbed1::StructEnumWithArray());
+        // CHECK EFFECTS OF YOUR METHOD AFER FUTURE IS DONE
+    }
+    SECTION("Test method funcEnum async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcEnumAsync(Testbed1::StructEnumWithArray());
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::Enum0Enum>()); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    SECTION("Test method funcEnum async with callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcEnumAsync(Testbed1::StructEnumWithArray(),[&finished, &m_wait](std::list<Enum0Enum> value){ (void) value; finished = true; m_wait.notify_all(); /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ });
+
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::Enum0Enum>()); 
+    }
+
+    std::atomic<bool> serviceDisconnected{ false };
+    mqttservice->subscribeToConnectionStatus([&serviceDisconnected, &m_wait](auto isConnected) {
+        if (!isConnected)
+        {
+            serviceDisconnected = true;
+            m_wait.notify_all();
+        }
+        
+        });
+
+    mqttservice->disconnect();
+
+    lock.lock();
+    m_wait.wait_for(lock, std::chrono::milliseconds(timeout),
+        [&serviceDisconnected]() { return serviceDisconnected == true; });
+    lock.unlock();
+    REQUIRE(serviceDisconnected);
+
+    std::atomic<bool> clientDisonnected{ false };
+    mqttclient->subscribeToConnectionStatus([&clientDisonnected, &m_wait](auto isConnected) {
+        if (!isConnected)
+        {
+            clientDisonnected = true;
+            m_wait.notify_all();
+        }
+        });
+
+    mqttclient->disconnect();
+
+    lock.lock();
+    m_wait.wait_for(lock, std::chrono::milliseconds(timeout),
+        [&clientDisonnected]() { return clientDisonnected == true; });
+    lock.unlock();
+    REQUIRE(clientDisonnected);
+
+    mqttservice.reset();
+    mqttclient.reset();
+    serviceStructArray2Interface.reset();
+    clientStructArray2Interface.reset();
+}

--- a/goldenmaster/modules/testbed1/generated/mqtt/tests/test_structarrayinterface.cpp
+++ b/goldenmaster/modules/testbed1/generated/mqtt/tests/test_structarrayinterface.cpp
@@ -151,6 +151,23 @@ TEST_CASE("mqtt  testbed1 StructArrayInterface tests")
         REQUIRE(implStructArrayInterface->getPropString() == test_value);
         REQUIRE(clientStructArrayInterface->getPropString() == test_value);
     }
+    SECTION("Test setting propEnum")
+    {
+        std::atomic<bool> ispropEnumChanged = false;
+        clientStructArrayInterface->_getPublisher().subscribeToPropEnumChanged(
+        [&ispropEnumChanged, &m_wait ](auto value){
+            ispropEnumChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = std::list<Testbed1::Enum0Enum>();  
+        test_value.push_back(Testbed1::Enum0Enum::value1);
+        clientStructArrayInterface->setPropEnum(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropEnumChanged]() {return ispropEnumChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArrayInterface->getPropEnum() == test_value);
+        REQUIRE(clientStructArrayInterface->getPropEnum() == test_value);
+    }
     SECTION("Test emit sigBool")
     {
         std::atomic<bool> issigBoolEmitted = false;
@@ -233,6 +250,25 @@ TEST_CASE("mqtt  testbed1 StructArrayInterface tests")
          implStructArrayInterface->_getPublisher().publishSigString(local_param_string_array);
         lock.lock();
         REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&issigStringEmitted ]() {return issigStringEmitted   == true; }));
+        lock.unlock();
+    }
+    SECTION("Test emit sigEnum")
+    {
+        std::atomic<bool> issigEnumEmitted = false;
+        auto local_param_enum_array = std::list<Testbed1::Enum0Enum>();
+        local_param_enum_array.push_back(Testbed1::Enum0Enum::value1);
+
+        clientStructArrayInterface->_getPublisher().subscribeToSigEnum(
+        [&m_wait, &issigEnumEmitted, &local_param_enum_array](const std::list<Testbed1::Enum0Enum>& paramEnum)
+        {
+            REQUIRE(paramEnum == local_param_enum_array);
+            issigEnumEmitted  = true;
+            m_wait.notify_all();
+        });
+
+         implStructArrayInterface->_getPublisher().publishSigEnum(local_param_enum_array);
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&issigEnumEmitted ]() {return issigEnumEmitted   == true; }));
         lock.unlock();
     }
     SECTION("Test method funcBool")
@@ -350,6 +386,35 @@ TEST_CASE("mqtt  testbed1 StructArrayInterface tests")
         lock.unlock();
         auto return_value = resultFuture.get();
         REQUIRE(return_value == std::list<Testbed1::StructString>()); 
+    }
+    SECTION("Test method funcEnum")
+    {
+        [[maybe_unused]] auto result =  clientStructArrayInterface->funcEnum(std::list<Testbed1::Enum0Enum>());
+        // CHECK EFFECTS OF YOUR METHOD AFER FUTURE IS DONE
+    }
+    SECTION("Test method funcEnum async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArrayInterface->funcEnumAsync(std::list<Testbed1::Enum0Enum>());
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::Enum0Enum>()); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    SECTION("Test method funcEnum async with callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArrayInterface->funcEnumAsync(std::list<Testbed1::Enum0Enum>(),[&finished, &m_wait](std::list<Enum0Enum> value){ (void) value; finished = true; m_wait.notify_all(); /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ });
+
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::Enum0Enum>()); 
     }
 
     std::atomic<bool> serviceDisconnected{ false };

--- a/goldenmaster/modules/testbed1/generated/nats/CMakeLists.txt
+++ b/goldenmaster/modules/testbed1/generated/nats/CMakeLists.txt
@@ -4,6 +4,8 @@ set (SOURCES_NATS
     structinterfaceclient.cpp
     structarrayinterfaceservice.cpp
     structarrayinterfaceclient.cpp
+    structarray2interfaceservice.cpp
+    structarray2interfaceclient.cpp
 )
 add_library(testbed1-nats SHARED ${SOURCES_NATS})
 add_library(testbed1::testbed1-nats ALIAS testbed1-nats)

--- a/goldenmaster/modules/testbed1/generated/nats/structarray2interfaceclient.cpp
+++ b/goldenmaster/modules/testbed1/generated/nats/structarray2interfaceclient.cpp
@@ -1,0 +1,517 @@
+#include "testbed1/generated/nats/structarray2interfaceclient.h"
+#include "testbed1/generated/core/structarray2interface.publisher.h"
+#include "testbed1/generated/core/testbed1.json.adapter.h"
+#include "apigear/utilities/logger.h"
+
+using namespace Test::Testbed1;
+using namespace Test::Testbed1::Nats;
+
+namespace{
+const uint32_t  expectedSingalsSubscriptions = 4;
+const uint32_t  expectedPropertiesSubscriptions = 5;
+const uint32_t  initSubscription = 1;
+const uint32_t  serviceAvailableSubscription = 1;
+constexpr uint32_t expectedSubscriptionsCount = serviceAvailableSubscription + initSubscription + expectedSingalsSubscriptions + expectedPropertiesSubscriptions;
+}
+
+std::shared_ptr<StructArray2InterfaceClient> StructArray2InterfaceClient::create(std::shared_ptr<ApiGear::Nats::Client> client)
+{
+    std::shared_ptr<StructArray2InterfaceClient> obj(new StructArray2InterfaceClient(client));
+    obj->init();
+    return obj;
+}
+
+std::shared_ptr<ApiGear::Nats::BaseAdapter> StructArray2InterfaceClient::getSharedFromDerrived()
+{
+    return shared_from_this();
+}
+
+StructArray2InterfaceClient::StructArray2InterfaceClient(std::shared_ptr<ApiGear::Nats::Client> client)
+    :BaseAdapter(client, expectedSubscriptionsCount)
+    , m_client(client)
+    , m_publisher(std::make_unique<StructArray2InterfacePublisher>())
+{}
+
+void StructArray2InterfaceClient::init()
+{
+    if (m_initialized.exchange(true)) {
+        AG_LOG_WARNING("init() called more than once on " "StructArray2InterfaceClient" ", ignoring");
+        return;
+    }
+    BaseAdapter::init([this](){onConnected();});
+}
+
+StructArray2InterfaceClient::~StructArray2InterfaceClient() = default;
+
+void StructArray2InterfaceClient::onConnected()
+{
+    auto clientId = m_client->getId();
+    m_requestInitCallId = _subscribeForIsReady([this, clientId](bool is_subscribed)
+    { 
+        if(!is_subscribed)
+        {
+            return;
+        }
+        const std::string initRequestTopic = "testbed1.StructArray2Interface.init";
+        m_client->publish(initRequestTopic, nlohmann::json(clientId).dump());
+        _unsubscribeFromIsReady(m_requestInitCallId);
+    });
+    subscribeTopic("testbed1.StructArray2Interface.service.available",[this](const auto& value){ handleAvailable(value); });
+    const std::string initTopic =  "testbed1.StructArray2Interface.init.resp." + std::to_string(clientId);
+    subscribeTopic(initTopic,[this](const auto& value){ handleInit(value); });
+    const std::string topic_propBool =  "testbed1.StructArray2Interface.prop.propBool";
+    subscribeTopic(topic_propBool, [this](const auto& value){ setPropBoolLocal(_to_PropBool(value)); });
+    const std::string topic_propInt =  "testbed1.StructArray2Interface.prop.propInt";
+    subscribeTopic(topic_propInt, [this](const auto& value){ setPropIntLocal(_to_PropInt(value)); });
+    const std::string topic_propFloat =  "testbed1.StructArray2Interface.prop.propFloat";
+    subscribeTopic(topic_propFloat, [this](const auto& value){ setPropFloatLocal(_to_PropFloat(value)); });
+    const std::string topic_propString =  "testbed1.StructArray2Interface.prop.propString";
+    subscribeTopic(topic_propString, [this](const auto& value){ setPropStringLocal(_to_PropString(value)); });
+    const std::string topic_propEnum =  "testbed1.StructArray2Interface.prop.propEnum";
+    subscribeTopic(topic_propEnum, [this](const auto& value){ setPropEnumLocal(_to_PropEnum(value)); });
+    const std::string topic_sigBool = "testbed1.StructArray2Interface.sig.sigBool";
+    subscribeTopic(topic_sigBool, [this](const auto& args){onSigBool(args);});
+    const std::string topic_sigInt = "testbed1.StructArray2Interface.sig.sigInt";
+    subscribeTopic(topic_sigInt, [this](const auto& args){onSigInt(args);});
+    const std::string topic_sigFloat = "testbed1.StructArray2Interface.sig.sigFloat";
+    subscribeTopic(topic_sigFloat, [this](const auto& args){onSigFloat(args);});
+    const std::string topic_sigString = "testbed1.StructArray2Interface.sig.sigString";
+    subscribeTopic(topic_sigString, [this](const auto& args){onSigString(args);});
+}
+void StructArray2InterfaceClient::handleAvailable(const std::string& /*empty payload*/)
+{
+    auto clientId = m_client->getId();
+    const std::string initRequestTopic = "testbed1.StructArray2Interface.init";
+    m_client->publish(initRequestTopic, nlohmann::json(clientId).dump());
+}
+
+void StructArray2InterfaceClient::setPropBool(const StructBoolWithArray& propBool)
+{
+    static const auto topic = std::string("testbed1.StructArray2Interface.set.propBool");
+    if(m_client == nullptr) {
+        return;
+    }
+    m_client->publish(topic, nlohmann::json(propBool).dump());
+}
+
+StructBoolWithArray StructArray2InterfaceClient::_to_PropBool(const std::string& args)
+{
+    nlohmann::json fields = nlohmann::json::parse(args);
+    if (fields.empty())
+    {
+        //AG_LOG_WARNING("error while setting the property propBool");
+        return StructBoolWithArray();
+    }
+   return fields.get<StructBoolWithArray>();
+}
+
+void StructArray2InterfaceClient::setPropBoolLocal(const StructBoolWithArray& propBool)
+{
+    if (m_data.m_propBool != propBool) {
+        m_data.m_propBool = propBool;
+        m_publisher->publishPropBoolChanged(propBool);
+    }
+}
+
+const StructBoolWithArray& StructArray2InterfaceClient::getPropBool() const
+{
+    return m_data.m_propBool;
+}
+
+void StructArray2InterfaceClient::setPropInt(const StructIntWithArray& propInt)
+{
+    static const auto topic = std::string("testbed1.StructArray2Interface.set.propInt");
+    if(m_client == nullptr) {
+        return;
+    }
+    m_client->publish(topic, nlohmann::json(propInt).dump());
+}
+
+StructIntWithArray StructArray2InterfaceClient::_to_PropInt(const std::string& args)
+{
+    nlohmann::json fields = nlohmann::json::parse(args);
+    if (fields.empty())
+    {
+        //AG_LOG_WARNING("error while setting the property propInt");
+        return StructIntWithArray();
+    }
+   return fields.get<StructIntWithArray>();
+}
+
+void StructArray2InterfaceClient::setPropIntLocal(const StructIntWithArray& propInt)
+{
+    if (m_data.m_propInt != propInt) {
+        m_data.m_propInt = propInt;
+        m_publisher->publishPropIntChanged(propInt);
+    }
+}
+
+const StructIntWithArray& StructArray2InterfaceClient::getPropInt() const
+{
+    return m_data.m_propInt;
+}
+
+void StructArray2InterfaceClient::setPropFloat(const StructFloatWithArray& propFloat)
+{
+    static const auto topic = std::string("testbed1.StructArray2Interface.set.propFloat");
+    if(m_client == nullptr) {
+        return;
+    }
+    m_client->publish(topic, nlohmann::json(propFloat).dump());
+}
+
+StructFloatWithArray StructArray2InterfaceClient::_to_PropFloat(const std::string& args)
+{
+    nlohmann::json fields = nlohmann::json::parse(args);
+    if (fields.empty())
+    {
+        //AG_LOG_WARNING("error while setting the property propFloat");
+        return StructFloatWithArray();
+    }
+   return fields.get<StructFloatWithArray>();
+}
+
+void StructArray2InterfaceClient::setPropFloatLocal(const StructFloatWithArray& propFloat)
+{
+    if (m_data.m_propFloat != propFloat) {
+        m_data.m_propFloat = propFloat;
+        m_publisher->publishPropFloatChanged(propFloat);
+    }
+}
+
+const StructFloatWithArray& StructArray2InterfaceClient::getPropFloat() const
+{
+    return m_data.m_propFloat;
+}
+
+void StructArray2InterfaceClient::setPropString(const StructStringWithArray& propString)
+{
+    static const auto topic = std::string("testbed1.StructArray2Interface.set.propString");
+    if(m_client == nullptr) {
+        return;
+    }
+    m_client->publish(topic, nlohmann::json(propString).dump());
+}
+
+StructStringWithArray StructArray2InterfaceClient::_to_PropString(const std::string& args)
+{
+    nlohmann::json fields = nlohmann::json::parse(args);
+    if (fields.empty())
+    {
+        //AG_LOG_WARNING("error while setting the property propString");
+        return StructStringWithArray();
+    }
+   return fields.get<StructStringWithArray>();
+}
+
+void StructArray2InterfaceClient::setPropStringLocal(const StructStringWithArray& propString)
+{
+    if (m_data.m_propString != propString) {
+        m_data.m_propString = propString;
+        m_publisher->publishPropStringChanged(propString);
+    }
+}
+
+const StructStringWithArray& StructArray2InterfaceClient::getPropString() const
+{
+    return m_data.m_propString;
+}
+
+void StructArray2InterfaceClient::setPropEnum(const StructEnumWithArray& propEnum)
+{
+    static const auto topic = std::string("testbed1.StructArray2Interface.set.propEnum");
+    if(m_client == nullptr) {
+        return;
+    }
+    m_client->publish(topic, nlohmann::json(propEnum).dump());
+}
+
+StructEnumWithArray StructArray2InterfaceClient::_to_PropEnum(const std::string& args)
+{
+    nlohmann::json fields = nlohmann::json::parse(args);
+    if (fields.empty())
+    {
+        //AG_LOG_WARNING("error while setting the property propEnum");
+        return StructEnumWithArray();
+    }
+   return fields.get<StructEnumWithArray>();
+}
+
+void StructArray2InterfaceClient::setPropEnumLocal(const StructEnumWithArray& propEnum)
+{
+    if (m_data.m_propEnum != propEnum) {
+        m_data.m_propEnum = propEnum;
+        m_publisher->publishPropEnumChanged(propEnum);
+    }
+}
+
+const StructEnumWithArray& StructArray2InterfaceClient::getPropEnum() const
+{
+    return m_data.m_propEnum;
+}
+
+void StructArray2InterfaceClient::handleInit(const std::string& value)
+{
+    nlohmann::json fields = nlohmann::json::parse(value);
+    if(fields.contains("propBool")) {
+        setPropBoolLocal(fields["propBool"].get<StructBoolWithArray>());
+    }
+    if(fields.contains("propInt")) {
+        setPropIntLocal(fields["propInt"].get<StructIntWithArray>());
+    }
+    if(fields.contains("propFloat")) {
+        setPropFloatLocal(fields["propFloat"].get<StructFloatWithArray>());
+    }
+    if(fields.contains("propString")) {
+        setPropStringLocal(fields["propString"].get<StructStringWithArray>());
+    }
+    if(fields.contains("propEnum")) {
+        setPropEnumLocal(fields["propEnum"].get<StructEnumWithArray>());
+    }
+}
+
+std::list<StructBool> StructArray2InterfaceClient::funcBool(const StructBoolWithArray& paramBool)
+{
+    if(m_client == nullptr) {
+        return std::list<StructBool>();
+    }
+    std::list<StructBool> value(funcBoolAsync(paramBool).get());
+    return value;
+}
+
+std::future<std::list<StructBool>> StructArray2InterfaceClient::funcBoolAsync(const StructBoolWithArray& paramBool, std::function<void(std::list<StructBool>)> user_callback)
+{
+    if(m_client == nullptr) {
+        throw std::runtime_error("Client is not initialized");
+    }
+    static const auto topic = std::string("testbed1.StructArray2Interface.rpc.funcBool");
+
+    return std::async(std::launch::async, [this, user_callback,paramBool]()
+    {
+        std::promise<std::list<StructBool>> resultPromise;
+        auto callback = [&resultPromise, user_callback](const auto& result)
+        {
+            if (result.empty())
+            {
+                resultPromise.set_value(std::list<StructBool>());
+                if (user_callback)
+                {
+                    user_callback(std::list<StructBool>());
+                }
+                return;
+            }
+            nlohmann::json field = nlohmann::json::parse(result);
+            const std::list<StructBool> value = field.get<std::list<StructBool>>();
+            resultPromise.set_value(value);
+            if (user_callback)
+            {
+                user_callback(value);
+            }
+        };
+
+        m_client->request(topic,  nlohmann::json::array({paramBool}).dump(), callback);
+        return resultPromise.get_future().get();
+    });
+}
+
+std::list<StructInt> StructArray2InterfaceClient::funcInt(const StructIntWithArray& paramInt)
+{
+    if(m_client == nullptr) {
+        return std::list<StructInt>();
+    }
+    std::list<StructInt> value(funcIntAsync(paramInt).get());
+    return value;
+}
+
+std::future<std::list<StructInt>> StructArray2InterfaceClient::funcIntAsync(const StructIntWithArray& paramInt, std::function<void(std::list<StructInt>)> user_callback)
+{
+    if(m_client == nullptr) {
+        throw std::runtime_error("Client is not initialized");
+    }
+    static const auto topic = std::string("testbed1.StructArray2Interface.rpc.funcInt");
+
+    return std::async(std::launch::async, [this, user_callback,paramInt]()
+    {
+        std::promise<std::list<StructInt>> resultPromise;
+        auto callback = [&resultPromise, user_callback](const auto& result)
+        {
+            if (result.empty())
+            {
+                resultPromise.set_value(std::list<StructInt>());
+                if (user_callback)
+                {
+                    user_callback(std::list<StructInt>());
+                }
+                return;
+            }
+            nlohmann::json field = nlohmann::json::parse(result);
+            const std::list<StructInt> value = field.get<std::list<StructInt>>();
+            resultPromise.set_value(value);
+            if (user_callback)
+            {
+                user_callback(value);
+            }
+        };
+
+        m_client->request(topic,  nlohmann::json::array({paramInt}).dump(), callback);
+        return resultPromise.get_future().get();
+    });
+}
+
+std::list<StructFloat> StructArray2InterfaceClient::funcFloat(const StructFloatWithArray& paramFloat)
+{
+    if(m_client == nullptr) {
+        return std::list<StructFloat>();
+    }
+    std::list<StructFloat> value(funcFloatAsync(paramFloat).get());
+    return value;
+}
+
+std::future<std::list<StructFloat>> StructArray2InterfaceClient::funcFloatAsync(const StructFloatWithArray& paramFloat, std::function<void(std::list<StructFloat>)> user_callback)
+{
+    if(m_client == nullptr) {
+        throw std::runtime_error("Client is not initialized");
+    }
+    static const auto topic = std::string("testbed1.StructArray2Interface.rpc.funcFloat");
+
+    return std::async(std::launch::async, [this, user_callback,paramFloat]()
+    {
+        std::promise<std::list<StructFloat>> resultPromise;
+        auto callback = [&resultPromise, user_callback](const auto& result)
+        {
+            if (result.empty())
+            {
+                resultPromise.set_value(std::list<StructFloat>());
+                if (user_callback)
+                {
+                    user_callback(std::list<StructFloat>());
+                }
+                return;
+            }
+            nlohmann::json field = nlohmann::json::parse(result);
+            const std::list<StructFloat> value = field.get<std::list<StructFloat>>();
+            resultPromise.set_value(value);
+            if (user_callback)
+            {
+                user_callback(value);
+            }
+        };
+
+        m_client->request(topic,  nlohmann::json::array({paramFloat}).dump(), callback);
+        return resultPromise.get_future().get();
+    });
+}
+
+std::list<StructString> StructArray2InterfaceClient::funcString(const StructStringWithArray& paramString)
+{
+    if(m_client == nullptr) {
+        return std::list<StructString>();
+    }
+    std::list<StructString> value(funcStringAsync(paramString).get());
+    return value;
+}
+
+std::future<std::list<StructString>> StructArray2InterfaceClient::funcStringAsync(const StructStringWithArray& paramString, std::function<void(std::list<StructString>)> user_callback)
+{
+    if(m_client == nullptr) {
+        throw std::runtime_error("Client is not initialized");
+    }
+    static const auto topic = std::string("testbed1.StructArray2Interface.rpc.funcString");
+
+    return std::async(std::launch::async, [this, user_callback,paramString]()
+    {
+        std::promise<std::list<StructString>> resultPromise;
+        auto callback = [&resultPromise, user_callback](const auto& result)
+        {
+            if (result.empty())
+            {
+                resultPromise.set_value(std::list<StructString>());
+                if (user_callback)
+                {
+                    user_callback(std::list<StructString>());
+                }
+                return;
+            }
+            nlohmann::json field = nlohmann::json::parse(result);
+            const std::list<StructString> value = field.get<std::list<StructString>>();
+            resultPromise.set_value(value);
+            if (user_callback)
+            {
+                user_callback(value);
+            }
+        };
+
+        m_client->request(topic,  nlohmann::json::array({paramString}).dump(), callback);
+        return resultPromise.get_future().get();
+    });
+}
+
+std::list<Enum0Enum> StructArray2InterfaceClient::funcEnum(const StructEnumWithArray& paramEnum)
+{
+    if(m_client == nullptr) {
+        return std::list<Enum0Enum>();
+    }
+    std::list<Enum0Enum> value(funcEnumAsync(paramEnum).get());
+    return value;
+}
+
+std::future<std::list<Enum0Enum>> StructArray2InterfaceClient::funcEnumAsync(const StructEnumWithArray& paramEnum, std::function<void(std::list<Enum0Enum>)> user_callback)
+{
+    if(m_client == nullptr) {
+        throw std::runtime_error("Client is not initialized");
+    }
+    static const auto topic = std::string("testbed1.StructArray2Interface.rpc.funcEnum");
+
+    return std::async(std::launch::async, [this, user_callback,paramEnum]()
+    {
+        std::promise<std::list<Enum0Enum>> resultPromise;
+        auto callback = [&resultPromise, user_callback](const auto& result)
+        {
+            if (result.empty())
+            {
+                resultPromise.set_value(std::list<Enum0Enum>());
+                if (user_callback)
+                {
+                    user_callback(std::list<Enum0Enum>());
+                }
+                return;
+            }
+            nlohmann::json field = nlohmann::json::parse(result);
+            const std::list<Enum0Enum> value = field.get<std::list<Enum0Enum>>();
+            resultPromise.set_value(value);
+            if (user_callback)
+            {
+                user_callback(value);
+            }
+        };
+
+        m_client->request(topic,  nlohmann::json::array({paramEnum}).dump(), callback);
+        return resultPromise.get_future().get();
+    });
+}
+void StructArray2InterfaceClient::onSigBool(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    m_publisher->publishSigBool(json_args[0].get<StructBoolWithArray>());
+}
+void StructArray2InterfaceClient::onSigInt(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    m_publisher->publishSigInt(json_args[0].get<StructIntWithArray>());
+}
+void StructArray2InterfaceClient::onSigFloat(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    m_publisher->publishSigFloat(json_args[0].get<StructFloatWithArray>());
+}
+void StructArray2InterfaceClient::onSigString(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    m_publisher->publishSigString(json_args[0].get<StructStringWithArray>());
+}
+
+IStructArray2InterfacePublisher& StructArray2InterfaceClient::_getPublisher() const
+{
+    return *m_publisher;
+}
+

--- a/goldenmaster/modules/testbed1/generated/nats/structarray2interfaceclient.h
+++ b/goldenmaster/modules/testbed1/generated/nats/structarray2interfaceclient.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include "testbed1/generated/api/common.h"
+#include "testbed1/generated/api/testbed1.h"
+#include "testbed1/generated/core/structarray2interface.data.h"
+#include "apigear/nats/natsclient.h"
+#include "apigear/nats/natstypes.h"
+#include "apigear/nats/baseadapter.h"
+
+#include <atomic>
+#include <future>
+#include <unordered_map>
+
+namespace Test {
+namespace Testbed1 {
+namespace Nats {
+/**
+ * @brief NATS adapter for StructArray2Interface.
+ *
+ * @note Threading: property-change and signal callbacks arrive on the NATS transport thread.
+ * Subscription management inside the publisher is thread safe, but the callbacks themselves
+ * execute without additional locking. Operation calls are not additionally synchronized —
+ * callers are responsible for thread safety of concurrent operation invocations.
+ * Property storage is not guarded by a mutex; wrap with StructArray2InterfaceThreadSafeDecorator
+ * for concurrent access from multiple threads.
+ */
+class TEST_TESTBED1_EXPORT StructArray2InterfaceClient : public IStructArray2Interface, public ApiGear::Nats::BaseAdapter,  public std::enable_shared_from_this<StructArray2InterfaceClient>
+{
+protected:
+    explicit StructArray2InterfaceClient(std::shared_ptr<ApiGear::Nats::Client> client);
+public:
+    static std::shared_ptr<StructArray2InterfaceClient> create(std::shared_ptr<ApiGear::Nats::Client> client);
+    virtual ~StructArray2InterfaceClient() override;
+    void init();
+    const StructBoolWithArray& getPropBool() const override;
+    void setPropBool(const StructBoolWithArray& propBool) override;
+    const StructIntWithArray& getPropInt() const override;
+    void setPropInt(const StructIntWithArray& propInt) override;
+    const StructFloatWithArray& getPropFloat() const override;
+    void setPropFloat(const StructFloatWithArray& propFloat) override;
+    const StructStringWithArray& getPropString() const override;
+    void setPropString(const StructStringWithArray& propString) override;
+    const StructEnumWithArray& getPropEnum() const override;
+    void setPropEnum(const StructEnumWithArray& propEnum) override;
+    std::list<StructBool> funcBool(const StructBoolWithArray& paramBool) override;
+    std::future<std::list<StructBool>> funcBoolAsync(const StructBoolWithArray& paramBool, std::function<void(std::list<StructBool>)> callback = nullptr) override;
+    std::list<StructInt> funcInt(const StructIntWithArray& paramInt) override;
+    std::future<std::list<StructInt>> funcIntAsync(const StructIntWithArray& paramInt, std::function<void(std::list<StructInt>)> callback = nullptr) override;
+    std::list<StructFloat> funcFloat(const StructFloatWithArray& paramFloat) override;
+    std::future<std::list<StructFloat>> funcFloatAsync(const StructFloatWithArray& paramFloat, std::function<void(std::list<StructFloat>)> callback = nullptr) override;
+    std::list<StructString> funcString(const StructStringWithArray& paramString) override;
+    std::future<std::list<StructString>> funcStringAsync(const StructStringWithArray& paramString, std::function<void(std::list<StructString>)> callback = nullptr) override;
+    std::list<Enum0Enum> funcEnum(const StructEnumWithArray& paramEnum) override;
+    std::future<std::list<Enum0Enum>> funcEnumAsync(const StructEnumWithArray& paramEnum, std::function<void(std::list<Enum0Enum>)> callback = nullptr) override;
+    IStructArray2InterfacePublisher& _getPublisher() const override;
+private:
+    std::shared_ptr<ApiGear::Nats::BaseAdapter> getSharedFromDerrived() override;
+    void handleAvailable(const std::string& payload);
+    void handleInit(const std::string& value);
+    /// @brief Converts incoming raw message formatted value to a value of property. 
+    /// @param args contains the param of the type StructBoolWithArray
+    StructBoolWithArray _to_PropBool(const std::string& args);
+    /// @brief sets the value for the property PropBool coming from the service
+    void setPropBoolLocal(const StructBoolWithArray& propBool);
+    /// @brief Converts incoming raw message formatted value to a value of property. 
+    /// @param args contains the param of the type StructIntWithArray
+    StructIntWithArray _to_PropInt(const std::string& args);
+    /// @brief sets the value for the property PropInt coming from the service
+    void setPropIntLocal(const StructIntWithArray& propInt);
+    /// @brief Converts incoming raw message formatted value to a value of property. 
+    /// @param args contains the param of the type StructFloatWithArray
+    StructFloatWithArray _to_PropFloat(const std::string& args);
+    /// @brief sets the value for the property PropFloat coming from the service
+    void setPropFloatLocal(const StructFloatWithArray& propFloat);
+    /// @brief Converts incoming raw message formatted value to a value of property. 
+    /// @param args contains the param of the type StructStringWithArray
+    StructStringWithArray _to_PropString(const std::string& args);
+    /// @brief sets the value for the property PropString coming from the service
+    void setPropStringLocal(const StructStringWithArray& propString);
+    /// @brief Converts incoming raw message formatted value to a value of property. 
+    /// @param args contains the param of the type StructEnumWithArray
+    StructEnumWithArray _to_PropEnum(const std::string& args);
+    /// @brief sets the value for the property PropEnum coming from the service
+    void setPropEnumLocal(const StructEnumWithArray& propEnum);
+    /// @brief publishes the value for the signal SigBool coming from the service
+    /// @param args contains the param(s) of the type(s) const StructBoolWithArray& paramBool
+    void onSigBool(const std::string& args) const;
+    /// @brief publishes the value for the signal SigInt coming from the service
+    /// @param args contains the param(s) of the type(s) const StructIntWithArray& paramInt
+    void onSigInt(const std::string& args) const;
+    /// @brief publishes the value for the signal SigFloat coming from the service
+    /// @param args contains the param(s) of the type(s) const StructFloatWithArray& paramFloat
+    void onSigFloat(const std::string& args) const;
+    /// @brief publishes the value for the signal SigString coming from the service
+    /// @param args contains the param(s) of the type(s) const StructStringWithArray& paramString
+    void onSigString(const std::string& args) const;
+    /** Local storage for properties values. */
+    StructArray2InterfaceData m_data;
+    uint64_t m_requestInitCallId = 0;
+    std::atomic<bool> m_initialized{false};
+    std::shared_ptr<ApiGear::Nats::Client> m_client;
+    /** The publisher for StructArray2Interface */
+    std::unique_ptr<IStructArray2InterfacePublisher> m_publisher;
+    void onConnected();
+
+};
+} // namespace Nats
+} // namespace Testbed1
+} // namespace Test

--- a/goldenmaster/modules/testbed1/generated/nats/structarray2interfaceservice.cpp
+++ b/goldenmaster/modules/testbed1/generated/nats/structarray2interfaceservice.cpp
@@ -1,0 +1,243 @@
+#include "testbed1/generated/nats/structarray2interfaceservice.h"
+#include "testbed1/generated/core/testbed1.json.adapter.h"
+#include "apigear/utilities/logger.h"
+#include <iostream>
+
+using namespace Test::Testbed1;
+using namespace Test::Testbed1::Nats;
+
+namespace{
+const uint32_t  expectedMethodSubscriptions = 5;
+const uint32_t  expectedPropertiesSubscriptions = 5;
+const uint32_t  initRespSubscription = 1;
+constexpr uint32_t expectedSubscriptionsCount = initRespSubscription + expectedMethodSubscriptions + expectedPropertiesSubscriptions;
+}
+
+StructArray2InterfaceService::StructArray2InterfaceService(std::shared_ptr<IStructArray2Interface> impl, std::shared_ptr<ApiGear::Nats::Service> service)
+    :BaseAdapter(service, expectedSubscriptionsCount)
+    , m_impl(impl)
+    , m_service(service)
+{
+    m_impl->_getPublisher().subscribeToAllChanges(*this);
+}
+
+void StructArray2InterfaceService::init()
+{
+    if (m_initialized.exchange(true)) {
+        AG_LOG_WARNING("init() called more than once on " "StructArray2InterfaceService" ", ignoring");
+        return;
+    }
+    BaseAdapter::init([this](){onConnected();});
+}
+
+std::shared_ptr<StructArray2InterfaceService> StructArray2InterfaceService::create(std::shared_ptr<IStructArray2Interface> impl, std::shared_ptr<ApiGear::Nats::Service> service)
+{
+    std::shared_ptr<StructArray2InterfaceService> obj(new StructArray2InterfaceService(impl, service));
+    obj->init();
+    return obj;
+}
+
+std::shared_ptr<ApiGear::Nats::BaseAdapter> StructArray2InterfaceService::getSharedFromDerrived()
+{
+    return shared_from_this();
+}
+
+
+StructArray2InterfaceService::~StructArray2InterfaceService()
+{
+    m_impl->_getPublisher().unsubscribeFromAllChanges(*this);
+}
+
+
+void StructArray2InterfaceService::onConnected()
+{
+    m_onReadySubscriptionId= _subscribeForIsReady([this](bool is_subscribed)
+    { 
+        if(!is_subscribed)
+        {
+            return;
+        }
+        const std::string topic = "testbed1.StructArray2Interface.service.available";
+        m_service->publish(topic, "");
+        _unsubscribeFromIsReady(m_onReadySubscriptionId);
+    });
+    subscribeTopic("testbed1.StructArray2Interface.set.propBool", [this](const auto& value){ onSetPropBool(value); });
+    subscribeTopic("testbed1.StructArray2Interface.set.propInt", [this](const auto& value){ onSetPropInt(value); });
+    subscribeTopic("testbed1.StructArray2Interface.set.propFloat", [this](const auto& value){ onSetPropFloat(value); });
+    subscribeTopic("testbed1.StructArray2Interface.set.propString", [this](const auto& value){ onSetPropString(value); });
+    subscribeTopic("testbed1.StructArray2Interface.set.propEnum", [this](const auto& value){ onSetPropEnum(value); });
+    subscribeRequest("testbed1.StructArray2Interface.rpc.funcBool", [this](const auto& args){  return onInvokeFuncBool(args); });
+    subscribeRequest("testbed1.StructArray2Interface.rpc.funcInt", [this](const auto& args){  return onInvokeFuncInt(args); });
+    subscribeRequest("testbed1.StructArray2Interface.rpc.funcFloat", [this](const auto& args){  return onInvokeFuncFloat(args); });
+    subscribeRequest("testbed1.StructArray2Interface.rpc.funcString", [this](const auto& args){  return onInvokeFuncString(args); });
+    subscribeRequest("testbed1.StructArray2Interface.rpc.funcEnum", [this](const auto& args){  return onInvokeFuncEnum(args); });
+
+    const std::string initRequestTopic = "testbed1.StructArray2Interface.init";
+    subscribeTopic(initRequestTopic, [this, initRequestTopic](const auto& value){
+        nlohmann::json json_id = nlohmann::json::parse(value);
+        if (json_id.empty())
+        {
+            return;
+        }
+        auto clientId = json_id.get<uint64_t>();
+        auto topic = initRequestTopic + ".resp." +  std::to_string(clientId);
+        auto properties = getState();
+        m_service->publish(topic, properties.dump());
+        }
+    );
+
+}
+
+nlohmann::json StructArray2InterfaceService::getState()
+{
+    return nlohmann::json::object({
+        { "propBool", m_impl->getPropBool() },
+        { "propInt", m_impl->getPropInt() },
+        { "propFloat", m_impl->getPropFloat() },
+        { "propString", m_impl->getPropString() },
+        { "propEnum", m_impl->getPropEnum() }
+    });
+}
+void StructArray2InterfaceService::onSetPropBool(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    if (json_args.empty())
+    {
+        return;
+    }
+
+    auto propBool = json_args.get<StructBoolWithArray>();
+    m_impl->setPropBool(propBool);
+}
+void StructArray2InterfaceService::onSetPropInt(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    if (json_args.empty())
+    {
+        return;
+    }
+
+    auto propInt = json_args.get<StructIntWithArray>();
+    m_impl->setPropInt(propInt);
+}
+void StructArray2InterfaceService::onSetPropFloat(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    if (json_args.empty())
+    {
+        return;
+    }
+
+    auto propFloat = json_args.get<StructFloatWithArray>();
+    m_impl->setPropFloat(propFloat);
+}
+void StructArray2InterfaceService::onSetPropString(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    if (json_args.empty())
+    {
+        return;
+    }
+
+    auto propString = json_args.get<StructStringWithArray>();
+    m_impl->setPropString(propString);
+}
+void StructArray2InterfaceService::onSetPropEnum(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    if (json_args.empty())
+    {
+        return;
+    }
+
+    auto propEnum = json_args.get<StructEnumWithArray>();
+    m_impl->setPropEnum(propEnum);
+}
+void StructArray2InterfaceService::onSigBool(const StructBoolWithArray& paramBool)
+{
+    (void) paramBool;
+    static const std::string topic = "testbed1.StructArray2Interface.sig.sigBool";
+    nlohmann::json args = { paramBool };
+    m_service->publish(topic, nlohmann::json(args).dump());
+}
+void StructArray2InterfaceService::onSigInt(const StructIntWithArray& paramInt)
+{
+    (void) paramInt;
+    static const std::string topic = "testbed1.StructArray2Interface.sig.sigInt";
+    nlohmann::json args = { paramInt };
+    m_service->publish(topic, nlohmann::json(args).dump());
+}
+void StructArray2InterfaceService::onSigFloat(const StructFloatWithArray& paramFloat)
+{
+    (void) paramFloat;
+    static const std::string topic = "testbed1.StructArray2Interface.sig.sigFloat";
+    nlohmann::json args = { paramFloat };
+    m_service->publish(topic, nlohmann::json(args).dump());
+}
+void StructArray2InterfaceService::onSigString(const StructStringWithArray& paramString)
+{
+    (void) paramString;
+    static const std::string topic = "testbed1.StructArray2Interface.sig.sigString";
+    nlohmann::json args = { paramString };
+    m_service->publish(topic, nlohmann::json(args).dump());
+}
+void StructArray2InterfaceService::onPropBoolChanged(const StructBoolWithArray& propBool)
+{
+    static const std::string topic = "testbed1.StructArray2Interface.prop.propBool";
+    m_service->publish(topic, nlohmann::json(propBool).dump());
+}
+void StructArray2InterfaceService::onPropIntChanged(const StructIntWithArray& propInt)
+{
+    static const std::string topic = "testbed1.StructArray2Interface.prop.propInt";
+    m_service->publish(topic, nlohmann::json(propInt).dump());
+}
+void StructArray2InterfaceService::onPropFloatChanged(const StructFloatWithArray& propFloat)
+{
+    static const std::string topic = "testbed1.StructArray2Interface.prop.propFloat";
+    m_service->publish(topic, nlohmann::json(propFloat).dump());
+}
+void StructArray2InterfaceService::onPropStringChanged(const StructStringWithArray& propString)
+{
+    static const std::string topic = "testbed1.StructArray2Interface.prop.propString";
+    m_service->publish(topic, nlohmann::json(propString).dump());
+}
+void StructArray2InterfaceService::onPropEnumChanged(const StructEnumWithArray& propEnum)
+{
+    static const std::string topic = "testbed1.StructArray2Interface.prop.propEnum";
+    m_service->publish(topic, nlohmann::json(propEnum).dump());
+}
+std::string StructArray2InterfaceService::onInvokeFuncBool(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    const StructBoolWithArray& paramBool = json_args.at(0).get<StructBoolWithArray>();
+    auto result = m_impl->funcBool(paramBool);
+    return nlohmann::json(result).dump();
+}
+std::string StructArray2InterfaceService::onInvokeFuncInt(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    const StructIntWithArray& paramInt = json_args.at(0).get<StructIntWithArray>();
+    auto result = m_impl->funcInt(paramInt);
+    return nlohmann::json(result).dump();
+}
+std::string StructArray2InterfaceService::onInvokeFuncFloat(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    const StructFloatWithArray& paramFloat = json_args.at(0).get<StructFloatWithArray>();
+    auto result = m_impl->funcFloat(paramFloat);
+    return nlohmann::json(result).dump();
+}
+std::string StructArray2InterfaceService::onInvokeFuncString(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    const StructStringWithArray& paramString = json_args.at(0).get<StructStringWithArray>();
+    auto result = m_impl->funcString(paramString);
+    return nlohmann::json(result).dump();
+}
+std::string StructArray2InterfaceService::onInvokeFuncEnum(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    const StructEnumWithArray& paramEnum = json_args.at(0).get<StructEnumWithArray>();
+    auto result = m_impl->funcEnum(paramEnum);
+    return nlohmann::json(result).dump();
+}

--- a/goldenmaster/modules/testbed1/generated/nats/structarray2interfaceservice.h
+++ b/goldenmaster/modules/testbed1/generated/nats/structarray2interfaceservice.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "testbed1/generated/api/testbed1.h"
+#include "testbed1/generated/api/common.h"
+#include "apigear/nats/natsservice.h"
+#include "apigear/nats/natstypes.h"
+#include "apigear/nats/baseadapter.h"
+
+#include <atomic>
+
+namespace Test {
+namespace Testbed1 {
+namespace Nats {
+class TEST_TESTBED1_EXPORT StructArray2InterfaceService : public IStructArray2InterfaceSubscriber, public ApiGear::Nats::BaseAdapter,  public std::enable_shared_from_this<StructArray2InterfaceService>
+{
+protected:
+    explicit StructArray2InterfaceService(std::shared_ptr<IStructArray2Interface> impl, std::shared_ptr<ApiGear::Nats::Service> service);
+public:
+    static std::shared_ptr<StructArray2InterfaceService> create(std::shared_ptr<IStructArray2Interface> impl, std::shared_ptr<ApiGear::Nats::Service> service);
+    virtual ~StructArray2InterfaceService() override;
+    void init();
+
+    // IStructArray2InterfaceSubscriber interface
+    void onSigBool(const StructBoolWithArray& paramBool) override;
+    void onSigInt(const StructIntWithArray& paramInt) override;
+    void onSigFloat(const StructFloatWithArray& paramFloat) override;
+    void onSigString(const StructStringWithArray& paramString) override;
+
+private:
+    std::shared_ptr<ApiGear::Nats::BaseAdapter> getSharedFromDerrived() override;
+    void onConnected();
+    nlohmann::json getState();
+    void onPropBoolChanged(const StructBoolWithArray& propBool) override;
+    /// @brief requests to set the value for the property PropBool coming from the client
+    /// @param fields contains the param of the type StructBoolWithArray
+    void onSetPropBool(const std::string& args) const;
+    void onPropIntChanged(const StructIntWithArray& propInt) override;
+    /// @brief requests to set the value for the property PropInt coming from the client
+    /// @param fields contains the param of the type StructIntWithArray
+    void onSetPropInt(const std::string& args) const;
+    void onPropFloatChanged(const StructFloatWithArray& propFloat) override;
+    /// @brief requests to set the value for the property PropFloat coming from the client
+    /// @param fields contains the param of the type StructFloatWithArray
+    void onSetPropFloat(const std::string& args) const;
+    void onPropStringChanged(const StructStringWithArray& propString) override;
+    /// @brief requests to set the value for the property PropString coming from the client
+    /// @param fields contains the param of the type StructStringWithArray
+    void onSetPropString(const std::string& args) const;
+    void onPropEnumChanged(const StructEnumWithArray& propEnum) override;
+    /// @brief requests to set the value for the property PropEnum coming from the client
+    /// @param fields contains the param of the type StructEnumWithArray
+    void onSetPropEnum(const std::string& args) const;
+    std::string onInvokeFuncBool(const std::string& args) const;
+    std::string onInvokeFuncInt(const std::string& args) const;
+    std::string onInvokeFuncFloat(const std::string& args) const;
+    std::string onInvokeFuncString(const std::string& args) const;
+    std::string onInvokeFuncEnum(const std::string& args) const;
+
+    std::shared_ptr<IStructArray2Interface> m_impl;
+    std::shared_ptr<ApiGear::Nats::Service> m_service;
+
+    uint64_t m_onReadySubscriptionId = 0;
+    std::atomic<bool> m_initialized{false};
+
+};
+} // namespace Nats
+} // namespace Testbed1
+} // namespace Test

--- a/goldenmaster/modules/testbed1/generated/nats/structarrayinterfaceclient.cpp
+++ b/goldenmaster/modules/testbed1/generated/nats/structarrayinterfaceclient.cpp
@@ -7,8 +7,8 @@ using namespace Test::Testbed1;
 using namespace Test::Testbed1::Nats;
 
 namespace{
-const uint32_t  expectedSingalsSubscriptions = 4;
-const uint32_t  expectedPropertiesSubscriptions = 4;
+const uint32_t  expectedSingalsSubscriptions = 5;
+const uint32_t  expectedPropertiesSubscriptions = 5;
 const uint32_t  initSubscription = 1;
 const uint32_t  serviceAvailableSubscription = 1;
 constexpr uint32_t expectedSubscriptionsCount = serviceAvailableSubscription + initSubscription + expectedSingalsSubscriptions + expectedPropertiesSubscriptions;
@@ -67,6 +67,8 @@ void StructArrayInterfaceClient::onConnected()
     subscribeTopic(topic_propFloat, [this](const auto& value){ setPropFloatLocal(_to_PropFloat(value)); });
     const std::string topic_propString =  "testbed1.StructArrayInterface.prop.propString";
     subscribeTopic(topic_propString, [this](const auto& value){ setPropStringLocal(_to_PropString(value)); });
+    const std::string topic_propEnum =  "testbed1.StructArrayInterface.prop.propEnum";
+    subscribeTopic(topic_propEnum, [this](const auto& value){ setPropEnumLocal(_to_PropEnum(value)); });
     const std::string topic_sigBool = "testbed1.StructArrayInterface.sig.sigBool";
     subscribeTopic(topic_sigBool, [this](const auto& args){onSigBool(args);});
     const std::string topic_sigInt = "testbed1.StructArrayInterface.sig.sigInt";
@@ -75,6 +77,8 @@ void StructArrayInterfaceClient::onConnected()
     subscribeTopic(topic_sigFloat, [this](const auto& args){onSigFloat(args);});
     const std::string topic_sigString = "testbed1.StructArrayInterface.sig.sigString";
     subscribeTopic(topic_sigString, [this](const auto& args){onSigString(args);});
+    const std::string topic_sigEnum = "testbed1.StructArrayInterface.sig.sigEnum";
+    subscribeTopic(topic_sigEnum, [this](const auto& args){onSigEnum(args);});
 }
 void StructArrayInterfaceClient::handleAvailable(const std::string& /*empty payload*/)
 {
@@ -215,6 +219,39 @@ const std::list<StructString>& StructArrayInterfaceClient::getPropString() const
     return m_data.m_propString;
 }
 
+void StructArrayInterfaceClient::setPropEnum(const std::list<Enum0Enum>& propEnum)
+{
+    static const auto topic = std::string("testbed1.StructArrayInterface.set.propEnum");
+    if(m_client == nullptr) {
+        return;
+    }
+    m_client->publish(topic, nlohmann::json(propEnum).dump());
+}
+
+std::list<Enum0Enum> StructArrayInterfaceClient::_to_PropEnum(const std::string& args)
+{
+    nlohmann::json fields = nlohmann::json::parse(args);
+    if (fields.empty())
+    {
+        //AG_LOG_WARNING("error while setting the property propEnum");
+        return std::list<Enum0Enum>();
+    }
+   return fields.get<std::list<Enum0Enum>>();
+}
+
+void StructArrayInterfaceClient::setPropEnumLocal(const std::list<Enum0Enum>& propEnum)
+{
+    if (m_data.m_propEnum != propEnum) {
+        m_data.m_propEnum = propEnum;
+        m_publisher->publishPropEnumChanged(propEnum);
+    }
+}
+
+const std::list<Enum0Enum>& StructArrayInterfaceClient::getPropEnum() const
+{
+    return m_data.m_propEnum;
+}
+
 void StructArrayInterfaceClient::handleInit(const std::string& value)
 {
     nlohmann::json fields = nlohmann::json::parse(value);
@@ -229,6 +266,9 @@ void StructArrayInterfaceClient::handleInit(const std::string& value)
     }
     if(fields.contains("propString")) {
         setPropStringLocal(fields["propString"].get<std::list<StructString>>());
+    }
+    if(fields.contains("propEnum")) {
+        setPropEnumLocal(fields["propEnum"].get<std::list<Enum0Enum>>());
     }
 }
 
@@ -407,6 +447,50 @@ std::future<std::list<StructString>> StructArrayInterfaceClient::funcStringAsync
         return resultPromise.get_future().get();
     });
 }
+
+std::list<Enum0Enum> StructArrayInterfaceClient::funcEnum(const std::list<Enum0Enum>& paramEnum)
+{
+    if(m_client == nullptr) {
+        return std::list<Enum0Enum>();
+    }
+    std::list<Enum0Enum> value(funcEnumAsync(paramEnum).get());
+    return value;
+}
+
+std::future<std::list<Enum0Enum>> StructArrayInterfaceClient::funcEnumAsync(const std::list<Enum0Enum>& paramEnum, std::function<void(std::list<Enum0Enum>)> user_callback)
+{
+    if(m_client == nullptr) {
+        throw std::runtime_error("Client is not initialized");
+    }
+    static const auto topic = std::string("testbed1.StructArrayInterface.rpc.funcEnum");
+
+    return std::async(std::launch::async, [this, user_callback,paramEnum]()
+    {
+        std::promise<std::list<Enum0Enum>> resultPromise;
+        auto callback = [&resultPromise, user_callback](const auto& result)
+        {
+            if (result.empty())
+            {
+                resultPromise.set_value(std::list<Enum0Enum>());
+                if (user_callback)
+                {
+                    user_callback(std::list<Enum0Enum>());
+                }
+                return;
+            }
+            nlohmann::json field = nlohmann::json::parse(result);
+            const std::list<Enum0Enum> value = field.get<std::list<Enum0Enum>>();
+            resultPromise.set_value(value);
+            if (user_callback)
+            {
+                user_callback(value);
+            }
+        };
+
+        m_client->request(topic,  nlohmann::json::array({paramEnum}).dump(), callback);
+        return resultPromise.get_future().get();
+    });
+}
 void StructArrayInterfaceClient::onSigBool(const std::string& args) const
 {
     nlohmann::json json_args = nlohmann::json::parse(args);
@@ -426,6 +510,11 @@ void StructArrayInterfaceClient::onSigString(const std::string& args) const
 {
     nlohmann::json json_args = nlohmann::json::parse(args);
     m_publisher->publishSigString(json_args[0].get<std::list<StructString>>());
+}
+void StructArrayInterfaceClient::onSigEnum(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    m_publisher->publishSigEnum(json_args[0].get<std::list<Enum0Enum>>());
 }
 
 IStructArrayInterfacePublisher& StructArrayInterfaceClient::_getPublisher() const

--- a/goldenmaster/modules/testbed1/generated/nats/structarrayinterfaceclient.h
+++ b/goldenmaster/modules/testbed1/generated/nats/structarrayinterfaceclient.h
@@ -40,6 +40,8 @@ public:
     void setPropFloat(const std::list<StructFloat>& propFloat) override;
     const std::list<StructString>& getPropString() const override;
     void setPropString(const std::list<StructString>& propString) override;
+    const std::list<Enum0Enum>& getPropEnum() const override;
+    void setPropEnum(const std::list<Enum0Enum>& propEnum) override;
     std::list<StructBool> funcBool(const std::list<StructBool>& paramBool) override;
     std::future<std::list<StructBool>> funcBoolAsync(const std::list<StructBool>& paramBool, std::function<void(std::list<StructBool>)> callback = nullptr) override;
     std::list<StructInt> funcInt(const std::list<StructInt>& paramInt) override;
@@ -48,6 +50,8 @@ public:
     std::future<std::list<StructFloat>> funcFloatAsync(const std::list<StructFloat>& paramFloat, std::function<void(std::list<StructFloat>)> callback = nullptr) override;
     std::list<StructString> funcString(const std::list<StructString>& paramString) override;
     std::future<std::list<StructString>> funcStringAsync(const std::list<StructString>& paramString, std::function<void(std::list<StructString>)> callback = nullptr) override;
+    std::list<Enum0Enum> funcEnum(const std::list<Enum0Enum>& paramEnum) override;
+    std::future<std::list<Enum0Enum>> funcEnumAsync(const std::list<Enum0Enum>& paramEnum, std::function<void(std::list<Enum0Enum>)> callback = nullptr) override;
     IStructArrayInterfacePublisher& _getPublisher() const override;
 private:
     std::shared_ptr<ApiGear::Nats::BaseAdapter> getSharedFromDerrived() override;
@@ -73,6 +77,11 @@ private:
     std::list<StructString> _to_PropString(const std::string& args);
     /// @brief sets the value for the property PropString coming from the service
     void setPropStringLocal(const std::list<StructString>& propString);
+    /// @brief Converts incoming raw message formatted value to a value of property. 
+    /// @param args contains the param of the type std::list<Enum0Enum>
+    std::list<Enum0Enum> _to_PropEnum(const std::string& args);
+    /// @brief sets the value for the property PropEnum coming from the service
+    void setPropEnumLocal(const std::list<Enum0Enum>& propEnum);
     /// @brief publishes the value for the signal SigBool coming from the service
     /// @param args contains the param(s) of the type(s) const std::list<StructBool>& paramBool
     void onSigBool(const std::string& args) const;
@@ -85,6 +94,9 @@ private:
     /// @brief publishes the value for the signal SigString coming from the service
     /// @param args contains the param(s) of the type(s) const std::list<StructString>& paramString
     void onSigString(const std::string& args) const;
+    /// @brief publishes the value for the signal SigEnum coming from the service
+    /// @param args contains the param(s) of the type(s) const std::list<Enum0Enum>& paramEnum
+    void onSigEnum(const std::string& args) const;
     /** Local storage for properties values. */
     StructArrayInterfaceData m_data;
     uint64_t m_requestInitCallId = 0;

--- a/goldenmaster/modules/testbed1/generated/nats/structarrayinterfaceservice.cpp
+++ b/goldenmaster/modules/testbed1/generated/nats/structarrayinterfaceservice.cpp
@@ -7,8 +7,8 @@ using namespace Test::Testbed1;
 using namespace Test::Testbed1::Nats;
 
 namespace{
-const uint32_t  expectedMethodSubscriptions = 4;
-const uint32_t  expectedPropertiesSubscriptions = 4;
+const uint32_t  expectedMethodSubscriptions = 5;
+const uint32_t  expectedPropertiesSubscriptions = 5;
 const uint32_t  initRespSubscription = 1;
 constexpr uint32_t expectedSubscriptionsCount = initRespSubscription + expectedMethodSubscriptions + expectedPropertiesSubscriptions;
 }
@@ -65,10 +65,12 @@ void StructArrayInterfaceService::onConnected()
     subscribeTopic("testbed1.StructArrayInterface.set.propInt", [this](const auto& value){ onSetPropInt(value); });
     subscribeTopic("testbed1.StructArrayInterface.set.propFloat", [this](const auto& value){ onSetPropFloat(value); });
     subscribeTopic("testbed1.StructArrayInterface.set.propString", [this](const auto& value){ onSetPropString(value); });
+    subscribeTopic("testbed1.StructArrayInterface.set.propEnum", [this](const auto& value){ onSetPropEnum(value); });
     subscribeRequest("testbed1.StructArrayInterface.rpc.funcBool", [this](const auto& args){  return onInvokeFuncBool(args); });
     subscribeRequest("testbed1.StructArrayInterface.rpc.funcInt", [this](const auto& args){  return onInvokeFuncInt(args); });
     subscribeRequest("testbed1.StructArrayInterface.rpc.funcFloat", [this](const auto& args){  return onInvokeFuncFloat(args); });
     subscribeRequest("testbed1.StructArrayInterface.rpc.funcString", [this](const auto& args){  return onInvokeFuncString(args); });
+    subscribeRequest("testbed1.StructArrayInterface.rpc.funcEnum", [this](const auto& args){  return onInvokeFuncEnum(args); });
 
     const std::string initRequestTopic = "testbed1.StructArrayInterface.init";
     subscribeTopic(initRequestTopic, [this, initRequestTopic](const auto& value){
@@ -92,7 +94,8 @@ nlohmann::json StructArrayInterfaceService::getState()
         { "propBool", m_impl->getPropBool() },
         { "propInt", m_impl->getPropInt() },
         { "propFloat", m_impl->getPropFloat() },
-        { "propString", m_impl->getPropString() }
+        { "propString", m_impl->getPropString() },
+        { "propEnum", m_impl->getPropEnum() }
     });
 }
 void StructArrayInterfaceService::onSetPropBool(const std::string& args) const
@@ -139,6 +142,17 @@ void StructArrayInterfaceService::onSetPropString(const std::string& args) const
     auto propString = json_args.get<std::list<StructString>>();
     m_impl->setPropString(propString);
 }
+void StructArrayInterfaceService::onSetPropEnum(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    if (json_args.empty())
+    {
+        return;
+    }
+
+    auto propEnum = json_args.get<std::list<Enum0Enum>>();
+    m_impl->setPropEnum(propEnum);
+}
 void StructArrayInterfaceService::onSigBool(const std::list<StructBool>& paramBool)
 {
     (void) paramBool;
@@ -167,6 +181,13 @@ void StructArrayInterfaceService::onSigString(const std::list<StructString>& par
     nlohmann::json args = { paramString };
     m_service->publish(topic, nlohmann::json(args).dump());
 }
+void StructArrayInterfaceService::onSigEnum(const std::list<Enum0Enum>& paramEnum)
+{
+    (void) paramEnum;
+    static const std::string topic = "testbed1.StructArrayInterface.sig.sigEnum";
+    nlohmann::json args = { paramEnum };
+    m_service->publish(topic, nlohmann::json(args).dump());
+}
 void StructArrayInterfaceService::onPropBoolChanged(const std::list<StructBool>& propBool)
 {
     static const std::string topic = "testbed1.StructArrayInterface.prop.propBool";
@@ -186,6 +207,11 @@ void StructArrayInterfaceService::onPropStringChanged(const std::list<StructStri
 {
     static const std::string topic = "testbed1.StructArrayInterface.prop.propString";
     m_service->publish(topic, nlohmann::json(propString).dump());
+}
+void StructArrayInterfaceService::onPropEnumChanged(const std::list<Enum0Enum>& propEnum)
+{
+    static const std::string topic = "testbed1.StructArrayInterface.prop.propEnum";
+    m_service->publish(topic, nlohmann::json(propEnum).dump());
 }
 std::string StructArrayInterfaceService::onInvokeFuncBool(const std::string& args) const
 {
@@ -213,5 +239,12 @@ std::string StructArrayInterfaceService::onInvokeFuncString(const std::string& a
     nlohmann::json json_args = nlohmann::json::parse(args);
     const std::list<StructString>& paramString = json_args.at(0).get<std::list<StructString>>();
     auto result = m_impl->funcString(paramString);
+    return nlohmann::json(result).dump();
+}
+std::string StructArrayInterfaceService::onInvokeFuncEnum(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    const std::list<Enum0Enum>& paramEnum = json_args.at(0).get<std::list<Enum0Enum>>();
+    auto result = m_impl->funcEnum(paramEnum);
     return nlohmann::json(result).dump();
 }

--- a/goldenmaster/modules/testbed1/generated/nats/structarrayinterfaceservice.h
+++ b/goldenmaster/modules/testbed1/generated/nats/structarrayinterfaceservice.h
@@ -25,6 +25,7 @@ public:
     void onSigInt(const std::list<StructInt>& paramInt) override;
     void onSigFloat(const std::list<StructFloat>& paramFloat) override;
     void onSigString(const std::list<StructString>& paramString) override;
+    void onSigEnum(const std::list<Enum0Enum>& paramEnum) override;
 
 private:
     std::shared_ptr<ApiGear::Nats::BaseAdapter> getSharedFromDerrived() override;
@@ -46,10 +47,15 @@ private:
     /// @brief requests to set the value for the property PropString coming from the client
     /// @param fields contains the param of the type std::list<StructString>
     void onSetPropString(const std::string& args) const;
+    void onPropEnumChanged(const std::list<Enum0Enum>& propEnum) override;
+    /// @brief requests to set the value for the property PropEnum coming from the client
+    /// @param fields contains the param of the type std::list<Enum0Enum>
+    void onSetPropEnum(const std::string& args) const;
     std::string onInvokeFuncBool(const std::string& args) const;
     std::string onInvokeFuncInt(const std::string& args) const;
     std::string onInvokeFuncFloat(const std::string& args) const;
     std::string onInvokeFuncString(const std::string& args) const;
+    std::string onInvokeFuncEnum(const std::string& args) const;
 
     std::shared_ptr<IStructArrayInterface> m_impl;
     std::shared_ptr<ApiGear::Nats::Service> m_service;

--- a/goldenmaster/modules/testbed1/generated/nats/tests/CMakeLists.txt
+++ b/goldenmaster/modules/testbed1/generated/nats/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ set(TEST_TESTBED1_GENERATED_NATS_SOURCES
     test_main.cpp
     test_structinterface.cpp
     test_structarrayinterface.cpp
+    test_structarray2interface.cpp
     )
 
 

--- a/goldenmaster/modules/testbed1/generated/nats/tests/test_structarray2interface.cpp
+++ b/goldenmaster/modules/testbed1/generated/nats/tests/test_structarray2interface.cpp
@@ -1,0 +1,389 @@
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include "testbed1/generated/core/test_struct_helper.h"
+#include "testbed1/implementation/structarray2interface.h"
+#include "testbed1/generated/nats/structarray2interfaceclient.h"
+#include "testbed1/generated/nats/structarray2interfaceservice.h"
+
+
+#include "apigear/nats/natsclient.h"
+#include "apigear/nats/natsservice.h"
+
+// Those tests require an external nats server, interface adapters for both client and service object side, are clients from Nats protocol pov.
+// Before running tests make sure that the server of your choice is running.
+
+namespace{
+
+    int timeout = 1000;//in ms
+}
+using namespace Test;
+using namespace Test::Testbed1;
+
+TEST_CASE("Nats  testbed1 StructArray2Interface tests")
+{
+    auto service = std::make_shared<ApiGear::Nats::Service>();
+
+    auto client = std::make_shared<ApiGear::Nats::Client>();
+    service->connect("nats://localhost:4222");
+    client->connect("nats://localhost:4222");
+
+    std::condition_variable m_wait;
+    std::mutex m_waitMutex;
+    std::unique_lock<std::mutex> lock(m_waitMutex, std::defer_lock);
+
+    auto implStructArray2Interface = std::make_shared<Test::Testbed1::StructArray2Interface>();
+    auto serviceStructArray2Interface = Nats::StructArray2InterfaceService::create(implStructArray2Interface, service);
+    lock.lock();
+    REQUIRE(m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [serviceStructArray2Interface]() {return  serviceStructArray2Interface->_is_ready();}));
+    lock.unlock();
+    service->flush();
+
+    auto clientStructArray2Interface = Nats::StructArray2InterfaceClient::create(client);
+    lock.lock();
+    REQUIRE(m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [clientStructArray2Interface]() {return clientStructArray2Interface->_is_ready(); }));
+    lock.unlock();
+    client->flush();
+    SECTION("Test setting propBool")
+    {
+        std::atomic<bool> ispropBoolChanged = false;
+        clientStructArray2Interface->_getPublisher().subscribeToPropBoolChanged(
+        [&ispropBoolChanged, &m_wait ](auto value){
+            ispropBoolChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = Testbed1::StructBoolWithArray();
+        Testbed1::fillTestStructBoolWithArray(test_value);
+        clientStructArray2Interface->setPropBool(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropBoolChanged]() {return ispropBoolChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArray2Interface->getPropBool() == test_value);
+        REQUIRE(clientStructArray2Interface->getPropBool() == test_value);
+    }
+    SECTION("Test setting propInt")
+    {
+        std::atomic<bool> ispropIntChanged = false;
+        clientStructArray2Interface->_getPublisher().subscribeToPropIntChanged(
+        [&ispropIntChanged, &m_wait ](auto value){
+            ispropIntChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = Testbed1::StructIntWithArray();
+        Testbed1::fillTestStructIntWithArray(test_value);
+        clientStructArray2Interface->setPropInt(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropIntChanged]() {return ispropIntChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArray2Interface->getPropInt() == test_value);
+        REQUIRE(clientStructArray2Interface->getPropInt() == test_value);
+    }
+    SECTION("Test setting propFloat")
+    {
+        std::atomic<bool> ispropFloatChanged = false;
+        clientStructArray2Interface->_getPublisher().subscribeToPropFloatChanged(
+        [&ispropFloatChanged, &m_wait ](auto value){
+            ispropFloatChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = Testbed1::StructFloatWithArray();
+        Testbed1::fillTestStructFloatWithArray(test_value);
+        clientStructArray2Interface->setPropFloat(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropFloatChanged]() {return ispropFloatChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArray2Interface->getPropFloat() == test_value);
+        REQUIRE(clientStructArray2Interface->getPropFloat() == test_value);
+    }
+    SECTION("Test setting propString")
+    {
+        std::atomic<bool> ispropStringChanged = false;
+        clientStructArray2Interface->_getPublisher().subscribeToPropStringChanged(
+        [&ispropStringChanged, &m_wait ](auto value){
+            ispropStringChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = Testbed1::StructStringWithArray();
+        Testbed1::fillTestStructStringWithArray(test_value);
+        clientStructArray2Interface->setPropString(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropStringChanged]() {return ispropStringChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArray2Interface->getPropString() == test_value);
+        REQUIRE(clientStructArray2Interface->getPropString() == test_value);
+    }
+    SECTION("Test setting propEnum")
+    {
+        std::atomic<bool> ispropEnumChanged = false;
+        clientStructArray2Interface->_getPublisher().subscribeToPropEnumChanged(
+        [&ispropEnumChanged, &m_wait ](auto value){
+            ispropEnumChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = Testbed1::StructEnumWithArray();
+        Testbed1::fillTestStructEnumWithArray(test_value);
+        clientStructArray2Interface->setPropEnum(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropEnumChanged]() {return ispropEnumChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArray2Interface->getPropEnum() == test_value);
+        REQUIRE(clientStructArray2Interface->getPropEnum() == test_value);
+    }
+    SECTION("Test emit sigBool")
+    {
+        std::atomic<bool> issigBoolEmitted = false;
+        auto local_param_bool_struct = Testbed1::StructBoolWithArray();
+        Testbed1::fillTestStructBoolWithArray(local_param_bool_struct);
+
+        clientStructArray2Interface->_getPublisher().subscribeToSigBool(
+        [&m_wait, &issigBoolEmitted, &local_param_bool_struct](const Testbed1::StructBoolWithArray& paramBool)
+        {
+            REQUIRE(paramBool ==local_param_bool_struct);
+            issigBoolEmitted  = true;
+            m_wait.notify_all();
+        });
+
+         implStructArray2Interface->_getPublisher().publishSigBool(local_param_bool_struct);
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&issigBoolEmitted ]() {return issigBoolEmitted   == true; }));
+        lock.unlock();
+    }
+    SECTION("Test emit sigInt")
+    {
+        std::atomic<bool> issigIntEmitted = false;
+        auto local_param_int_struct = Testbed1::StructIntWithArray();
+        Testbed1::fillTestStructIntWithArray(local_param_int_struct);
+
+        clientStructArray2Interface->_getPublisher().subscribeToSigInt(
+        [&m_wait, &issigIntEmitted, &local_param_int_struct](const Testbed1::StructIntWithArray& paramInt)
+        {
+            REQUIRE(paramInt ==local_param_int_struct);
+            issigIntEmitted  = true;
+            m_wait.notify_all();
+        });
+
+         implStructArray2Interface->_getPublisher().publishSigInt(local_param_int_struct);
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&issigIntEmitted ]() {return issigIntEmitted   == true; }));
+        lock.unlock();
+    }
+    SECTION("Test emit sigFloat")
+    {
+        std::atomic<bool> issigFloatEmitted = false;
+        auto local_param_float_struct = Testbed1::StructFloatWithArray();
+        Testbed1::fillTestStructFloatWithArray(local_param_float_struct);
+
+        clientStructArray2Interface->_getPublisher().subscribeToSigFloat(
+        [&m_wait, &issigFloatEmitted, &local_param_float_struct](const Testbed1::StructFloatWithArray& paramFloat)
+        {
+            REQUIRE(paramFloat ==local_param_float_struct);
+            issigFloatEmitted  = true;
+            m_wait.notify_all();
+        });
+
+         implStructArray2Interface->_getPublisher().publishSigFloat(local_param_float_struct);
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&issigFloatEmitted ]() {return issigFloatEmitted   == true; }));
+        lock.unlock();
+    }
+    SECTION("Test emit sigString")
+    {
+        std::atomic<bool> issigStringEmitted = false;
+        auto local_param_string_struct = Testbed1::StructStringWithArray();
+        Testbed1::fillTestStructStringWithArray(local_param_string_struct);
+
+        clientStructArray2Interface->_getPublisher().subscribeToSigString(
+        [&m_wait, &issigStringEmitted, &local_param_string_struct](const Testbed1::StructStringWithArray& paramString)
+        {
+            REQUIRE(paramString ==local_param_string_struct);
+            issigStringEmitted  = true;
+            m_wait.notify_all();
+        });
+
+         implStructArray2Interface->_getPublisher().publishSigString(local_param_string_struct);
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&issigStringEmitted ]() {return issigStringEmitted   == true; }));
+        lock.unlock();
+    }
+    SECTION("Test method funcBool")
+    {
+        [[maybe_unused]] auto result = clientStructArray2Interface->funcBool(Testbed1::StructBoolWithArray());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcBool async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcBoolAsync(Testbed1::StructBoolWithArray());
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::StructBool>()); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcBool async with callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcBoolAsync(Testbed1::StructBoolWithArray(),
+            [&finished, &m_wait](std::list<StructBool> value)
+            {
+                REQUIRE(value == std::list<Testbed1::StructBool>());
+                finished = true;
+                m_wait.notify_all();
+                /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */
+            });
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+
+        resultFuture.wait();
+    }
+    SECTION("Test method funcInt")
+    {
+        [[maybe_unused]] auto result = clientStructArray2Interface->funcInt(Testbed1::StructIntWithArray());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcInt async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcIntAsync(Testbed1::StructIntWithArray());
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::StructInt>()); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcInt async with callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcIntAsync(Testbed1::StructIntWithArray(),
+            [&finished, &m_wait](std::list<StructInt> value)
+            {
+                REQUIRE(value == std::list<Testbed1::StructInt>());
+                finished = true;
+                m_wait.notify_all();
+                /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */
+            });
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+
+        resultFuture.wait();
+    }
+    SECTION("Test method funcFloat")
+    {
+        [[maybe_unused]] auto result = clientStructArray2Interface->funcFloat(Testbed1::StructFloatWithArray());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcFloat async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcFloatAsync(Testbed1::StructFloatWithArray());
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::StructFloat>()); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcFloat async with callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcFloatAsync(Testbed1::StructFloatWithArray(),
+            [&finished, &m_wait](std::list<StructFloat> value)
+            {
+                REQUIRE(value == std::list<Testbed1::StructFloat>());
+                finished = true;
+                m_wait.notify_all();
+                /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */
+            });
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+
+        resultFuture.wait();
+    }
+    SECTION("Test method funcString")
+    {
+        [[maybe_unused]] auto result = clientStructArray2Interface->funcString(Testbed1::StructStringWithArray());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcString async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcStringAsync(Testbed1::StructStringWithArray());
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::StructString>()); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcString async with callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcStringAsync(Testbed1::StructStringWithArray(),
+            [&finished, &m_wait](std::list<StructString> value)
+            {
+                REQUIRE(value == std::list<Testbed1::StructString>());
+                finished = true;
+                m_wait.notify_all();
+                /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */
+            });
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+
+        resultFuture.wait();
+    }
+    SECTION("Test method funcEnum")
+    {
+        [[maybe_unused]] auto result = clientStructArray2Interface->funcEnum(Testbed1::StructEnumWithArray());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcEnum async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcEnumAsync(Testbed1::StructEnumWithArray());
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::Enum0Enum>()); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcEnum async with callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcEnumAsync(Testbed1::StructEnumWithArray(),
+            [&finished, &m_wait](std::list<Enum0Enum> value)
+            {
+                REQUIRE(value == std::list<Testbed1::Enum0Enum>());
+                finished = true;
+                m_wait.notify_all();
+                /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */
+            });
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+
+        resultFuture.wait();
+    }
+
+    serviceStructArray2Interface.reset();
+    clientStructArray2Interface.reset();
+    client->disconnect();
+    service->disconnect();
+    client.reset();
+    service.reset();
+}

--- a/goldenmaster/modules/testbed1/generated/nats/tests/test_structarrayinterface.cpp
+++ b/goldenmaster/modules/testbed1/generated/nats/tests/test_structarrayinterface.cpp
@@ -124,6 +124,23 @@ TEST_CASE("Nats  testbed1 StructArrayInterface tests")
         REQUIRE(implStructArrayInterface->getPropString() == test_value);
         REQUIRE(clientStructArrayInterface->getPropString() == test_value);
     }
+    SECTION("Test setting propEnum")
+    {
+        std::atomic<bool> ispropEnumChanged = false;
+        clientStructArrayInterface->_getPublisher().subscribeToPropEnumChanged(
+        [&ispropEnumChanged, &m_wait ](auto value){
+            ispropEnumChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = std::list<Testbed1::Enum0Enum>();  
+        test_value.push_back(Testbed1::Enum0Enum::value1);
+        clientStructArrayInterface->setPropEnum(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropEnumChanged]() {return ispropEnumChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArrayInterface->getPropEnum() == test_value);
+        REQUIRE(clientStructArrayInterface->getPropEnum() == test_value);
+    }
     SECTION("Test emit sigBool")
     {
         std::atomic<bool> issigBoolEmitted = false;
@@ -206,6 +223,25 @@ TEST_CASE("Nats  testbed1 StructArrayInterface tests")
          implStructArrayInterface->_getPublisher().publishSigString(local_param_string_array);
         lock.lock();
         REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&issigStringEmitted ]() {return issigStringEmitted   == true; }));
+        lock.unlock();
+    }
+    SECTION("Test emit sigEnum")
+    {
+        std::atomic<bool> issigEnumEmitted = false;
+        auto local_param_enum_array = std::list<Testbed1::Enum0Enum>();
+        local_param_enum_array.push_back(Testbed1::Enum0Enum::value1);
+
+        clientStructArrayInterface->_getPublisher().subscribeToSigEnum(
+        [&m_wait, &issigEnumEmitted, &local_param_enum_array](const std::list<Testbed1::Enum0Enum>& paramEnum)
+        {
+            REQUIRE(paramEnum == local_param_enum_array);
+            issigEnumEmitted  = true;
+            m_wait.notify_all();
+        });
+
+         implStructArrayInterface->_getPublisher().publishSigEnum(local_param_enum_array);
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&issigEnumEmitted ]() {return issigEnumEmitted   == true; }));
         lock.unlock();
     }
     SECTION("Test method funcBool")
@@ -334,6 +370,40 @@ TEST_CASE("Nats  testbed1 StructArrayInterface tests")
             [&finished, &m_wait](std::list<StructString> value)
             {
                 REQUIRE(value == std::list<Testbed1::StructString>());
+                finished = true;
+                m_wait.notify_all();
+                /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */
+            });
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+
+        resultFuture.wait();
+    }
+    SECTION("Test method funcEnum")
+    {
+        [[maybe_unused]] auto result = clientStructArrayInterface->funcEnum(std::list<Testbed1::Enum0Enum>());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcEnum async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArrayInterface->funcEnumAsync(std::list<Testbed1::Enum0Enum>());
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::Enum0Enum>()); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcEnum async with callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArrayInterface->funcEnumAsync(std::list<Testbed1::Enum0Enum>(),
+            [&finished, &m_wait](std::list<Enum0Enum> value)
+            {
+                REQUIRE(value == std::list<Testbed1::Enum0Enum>());
                 finished = true;
                 m_wait.notify_all();
                 /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */

--- a/goldenmaster/modules/testbed1/generated/olink/CMakeLists.txt
+++ b/goldenmaster/modules/testbed1/generated/olink/CMakeLists.txt
@@ -7,6 +7,8 @@ set (SOURCES_OLINK
     structinterfaceclient.cpp
     structarrayinterfaceservice.cpp
     structarrayinterfaceclient.cpp
+    structarray2interfaceservice.cpp
+    structarray2interfaceclient.cpp
 )
 add_library(testbed1-olink SHARED ${SOURCES_OLINK})
 add_library(testbed1::testbed1-olink ALIAS testbed1-olink)

--- a/goldenmaster/modules/testbed1/generated/olink/structarray2interfaceclient.cpp
+++ b/goldenmaster/modules/testbed1/generated/olink/structarray2interfaceclient.cpp
@@ -1,0 +1,381 @@
+
+
+#include "testbed1/generated/olink/structarray2interfaceclient.h"
+#include "testbed1/generated/core/structarray2interface.publisher.h"
+#include "testbed1/generated/core/testbed1.json.adapter.h"
+
+THIRD_PARTY_INCLUDES_START
+#include "olink/iclientnode.h"
+THIRD_PARTY_INCLUDES_END
+#include "apigear/utilities/logger.h"
+
+using namespace Test::Testbed1;
+using namespace Test::Testbed1::olink;
+
+namespace 
+{
+const std::string interfaceId = "testbed1.StructArray2Interface";
+}
+
+StructArray2InterfaceClient::StructArray2InterfaceClient()
+    : m_publisher(std::make_unique<StructArray2InterfacePublisher>())
+{}
+
+void StructArray2InterfaceClient::applyState(const nlohmann::json& fields) 
+{
+    if(fields.contains("propBool")) {
+        setPropBoolLocal(fields["propBool"].get<StructBoolWithArray>());
+    }
+    if(fields.contains("propInt")) {
+        setPropIntLocal(fields["propInt"].get<StructIntWithArray>());
+    }
+    if(fields.contains("propFloat")) {
+        setPropFloatLocal(fields["propFloat"].get<StructFloatWithArray>());
+    }
+    if(fields.contains("propString")) {
+        setPropStringLocal(fields["propString"].get<StructStringWithArray>());
+    }
+    if(fields.contains("propEnum")) {
+        setPropEnumLocal(fields["propEnum"].get<StructEnumWithArray>());
+    }
+}
+
+void StructArray2InterfaceClient::applyProperty(const std::string& propertyName, const nlohmann::json& value)
+{
+    if ( propertyName == "propBool") {
+        setPropBoolLocal(value.get<StructBoolWithArray>());
+    }
+    else if ( propertyName == "propInt") {
+        setPropIntLocal(value.get<StructIntWithArray>());
+    }
+    else if ( propertyName == "propFloat") {
+        setPropFloatLocal(value.get<StructFloatWithArray>());
+    }
+    else if ( propertyName == "propString") {
+        setPropStringLocal(value.get<StructStringWithArray>());
+    }
+    else if ( propertyName == "propEnum") {
+        setPropEnumLocal(value.get<StructEnumWithArray>());
+    }
+}
+
+void StructArray2InterfaceClient::setPropBool(const StructBoolWithArray& propBool)
+{
+    if(!m_node) {
+        AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return;
+    }
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
+    m_node->setRemoteProperty(propertyId, propBool);
+}
+
+void StructArray2InterfaceClient::setPropBoolLocal(const StructBoolWithArray& propBool)
+{
+    {
+        std::unique_lock<std::shared_timed_mutex> lock(m_propBoolMutex);
+        if (m_data.m_propBool == propBool) {
+            return;
+        }
+        m_data.m_propBool = propBool;
+    }
+
+    m_publisher->publishPropBoolChanged(propBool);
+}
+
+const StructBoolWithArray& StructArray2InterfaceClient::getPropBool() const
+{
+    std::shared_lock<std::shared_timed_mutex> lock(m_propBoolMutex);
+    return m_data.m_propBool;
+}
+
+void StructArray2InterfaceClient::setPropInt(const StructIntWithArray& propInt)
+{
+    if(!m_node) {
+        AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return;
+    }
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
+    m_node->setRemoteProperty(propertyId, propInt);
+}
+
+void StructArray2InterfaceClient::setPropIntLocal(const StructIntWithArray& propInt)
+{
+    {
+        std::unique_lock<std::shared_timed_mutex> lock(m_propIntMutex);
+        if (m_data.m_propInt == propInt) {
+            return;
+        }
+        m_data.m_propInt = propInt;
+    }
+
+    m_publisher->publishPropIntChanged(propInt);
+}
+
+const StructIntWithArray& StructArray2InterfaceClient::getPropInt() const
+{
+    std::shared_lock<std::shared_timed_mutex> lock(m_propIntMutex);
+    return m_data.m_propInt;
+}
+
+void StructArray2InterfaceClient::setPropFloat(const StructFloatWithArray& propFloat)
+{
+    if(!m_node) {
+        AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return;
+    }
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat");
+    m_node->setRemoteProperty(propertyId, propFloat);
+}
+
+void StructArray2InterfaceClient::setPropFloatLocal(const StructFloatWithArray& propFloat)
+{
+    {
+        std::unique_lock<std::shared_timed_mutex> lock(m_propFloatMutex);
+        if (m_data.m_propFloat == propFloat) {
+            return;
+        }
+        m_data.m_propFloat = propFloat;
+    }
+
+    m_publisher->publishPropFloatChanged(propFloat);
+}
+
+const StructFloatWithArray& StructArray2InterfaceClient::getPropFloat() const
+{
+    std::shared_lock<std::shared_timed_mutex> lock(m_propFloatMutex);
+    return m_data.m_propFloat;
+}
+
+void StructArray2InterfaceClient::setPropString(const StructStringWithArray& propString)
+{
+    if(!m_node) {
+        AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return;
+    }
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propString");
+    m_node->setRemoteProperty(propertyId, propString);
+}
+
+void StructArray2InterfaceClient::setPropStringLocal(const StructStringWithArray& propString)
+{
+    {
+        std::unique_lock<std::shared_timed_mutex> lock(m_propStringMutex);
+        if (m_data.m_propString == propString) {
+            return;
+        }
+        m_data.m_propString = propString;
+    }
+
+    m_publisher->publishPropStringChanged(propString);
+}
+
+const StructStringWithArray& StructArray2InterfaceClient::getPropString() const
+{
+    std::shared_lock<std::shared_timed_mutex> lock(m_propStringMutex);
+    return m_data.m_propString;
+}
+
+void StructArray2InterfaceClient::setPropEnum(const StructEnumWithArray& propEnum)
+{
+    if(!m_node) {
+        AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return;
+    }
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propEnum");
+    m_node->setRemoteProperty(propertyId, propEnum);
+}
+
+void StructArray2InterfaceClient::setPropEnumLocal(const StructEnumWithArray& propEnum)
+{
+    {
+        std::unique_lock<std::shared_timed_mutex> lock(m_propEnumMutex);
+        if (m_data.m_propEnum == propEnum) {
+            return;
+        }
+        m_data.m_propEnum = propEnum;
+    }
+
+    m_publisher->publishPropEnumChanged(propEnum);
+}
+
+const StructEnumWithArray& StructArray2InterfaceClient::getPropEnum() const
+{
+    std::shared_lock<std::shared_timed_mutex> lock(m_propEnumMutex);
+    return m_data.m_propEnum;
+}
+
+std::list<StructBool> StructArray2InterfaceClient::funcBool(const StructBoolWithArray& paramBool)
+{
+    return funcBoolAsync(paramBool).get();
+}
+
+std::future<std::list<StructBool>> StructArray2InterfaceClient::funcBoolAsync(const StructBoolWithArray& paramBool, std::function<void(std::list<StructBool>)> callback)
+{
+    if(!m_node) {
+        AG_LOG_WARNING("Attempt to invoke method but" + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return std::future<std::list<StructBool>>{};
+    }
+    std::shared_ptr<std::promise<std::list<StructBool>>> resultPromise = std::make_shared<std::promise<std::list<StructBool>>>();
+    static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcBool");
+    m_node->invokeRemote(operationId,
+        nlohmann::json::array({paramBool}), [resultPromise, callback](ApiGear::ObjectLink::InvokeReplyArg arg) {
+            const std::list<StructBool>& value = arg.value.get<std::list<StructBool>>();
+            resultPromise->set_value(value);
+            if (callback)
+            {
+                callback(value);
+            }
+        });
+    return resultPromise->get_future();
+}
+
+std::list<StructInt> StructArray2InterfaceClient::funcInt(const StructIntWithArray& paramInt)
+{
+    return funcIntAsync(paramInt).get();
+}
+
+std::future<std::list<StructInt>> StructArray2InterfaceClient::funcIntAsync(const StructIntWithArray& paramInt, std::function<void(std::list<StructInt>)> callback)
+{
+    if(!m_node) {
+        AG_LOG_WARNING("Attempt to invoke method but" + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return std::future<std::list<StructInt>>{};
+    }
+    std::shared_ptr<std::promise<std::list<StructInt>>> resultPromise = std::make_shared<std::promise<std::list<StructInt>>>();
+    static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcInt");
+    m_node->invokeRemote(operationId,
+        nlohmann::json::array({paramInt}), [resultPromise, callback](ApiGear::ObjectLink::InvokeReplyArg arg) {
+            const std::list<StructInt>& value = arg.value.get<std::list<StructInt>>();
+            resultPromise->set_value(value);
+            if (callback)
+            {
+                callback(value);
+            }
+        });
+    return resultPromise->get_future();
+}
+
+std::list<StructFloat> StructArray2InterfaceClient::funcFloat(const StructFloatWithArray& paramFloat)
+{
+    return funcFloatAsync(paramFloat).get();
+}
+
+std::future<std::list<StructFloat>> StructArray2InterfaceClient::funcFloatAsync(const StructFloatWithArray& paramFloat, std::function<void(std::list<StructFloat>)> callback)
+{
+    if(!m_node) {
+        AG_LOG_WARNING("Attempt to invoke method but" + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return std::future<std::list<StructFloat>>{};
+    }
+    std::shared_ptr<std::promise<std::list<StructFloat>>> resultPromise = std::make_shared<std::promise<std::list<StructFloat>>>();
+    static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcFloat");
+    m_node->invokeRemote(operationId,
+        nlohmann::json::array({paramFloat}), [resultPromise, callback](ApiGear::ObjectLink::InvokeReplyArg arg) {
+            const std::list<StructFloat>& value = arg.value.get<std::list<StructFloat>>();
+            resultPromise->set_value(value);
+            if (callback)
+            {
+                callback(value);
+            }
+        });
+    return resultPromise->get_future();
+}
+
+std::list<StructString> StructArray2InterfaceClient::funcString(const StructStringWithArray& paramString)
+{
+    return funcStringAsync(paramString).get();
+}
+
+std::future<std::list<StructString>> StructArray2InterfaceClient::funcStringAsync(const StructStringWithArray& paramString, std::function<void(std::list<StructString>)> callback)
+{
+    if(!m_node) {
+        AG_LOG_WARNING("Attempt to invoke method but" + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return std::future<std::list<StructString>>{};
+    }
+    std::shared_ptr<std::promise<std::list<StructString>>> resultPromise = std::make_shared<std::promise<std::list<StructString>>>();
+    static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcString");
+    m_node->invokeRemote(operationId,
+        nlohmann::json::array({paramString}), [resultPromise, callback](ApiGear::ObjectLink::InvokeReplyArg arg) {
+            const std::list<StructString>& value = arg.value.get<std::list<StructString>>();
+            resultPromise->set_value(value);
+            if (callback)
+            {
+                callback(value);
+            }
+        });
+    return resultPromise->get_future();
+}
+
+std::list<Enum0Enum> StructArray2InterfaceClient::funcEnum(const StructEnumWithArray& paramEnum)
+{
+    return funcEnumAsync(paramEnum).get();
+}
+
+std::future<std::list<Enum0Enum>> StructArray2InterfaceClient::funcEnumAsync(const StructEnumWithArray& paramEnum, std::function<void(std::list<Enum0Enum>)> callback)
+{
+    if(!m_node) {
+        AG_LOG_WARNING("Attempt to invoke method but" + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return std::future<std::list<Enum0Enum>>{};
+    }
+    std::shared_ptr<std::promise<std::list<Enum0Enum>>> resultPromise = std::make_shared<std::promise<std::list<Enum0Enum>>>();
+    static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcEnum");
+    m_node->invokeRemote(operationId,
+        nlohmann::json::array({paramEnum}), [resultPromise, callback](ApiGear::ObjectLink::InvokeReplyArg arg) {
+            const std::list<Enum0Enum>& value = arg.value.get<std::list<Enum0Enum>>();
+            resultPromise->set_value(value);
+            if (callback)
+            {
+                callback(value);
+            }
+        });
+    return resultPromise->get_future();
+}
+
+std::string StructArray2InterfaceClient::olinkObjectName()
+{
+    return interfaceId;
+}
+
+void StructArray2InterfaceClient::olinkOnSignal(const std::string& signalId, const nlohmann::json& args)
+{
+    const auto& signalName = ApiGear::ObjectLink::Name::getMemberName(signalId);
+    if(signalName == "sigBool") {
+        m_publisher->publishSigBool(args[0].get<StructBoolWithArray>());   
+        return;
+    }
+    if(signalName == "sigInt") {
+        m_publisher->publishSigInt(args[0].get<StructIntWithArray>());   
+        return;
+    }
+    if(signalName == "sigFloat") {
+        m_publisher->publishSigFloat(args[0].get<StructFloatWithArray>());   
+        return;
+    }
+    if(signalName == "sigString") {
+        m_publisher->publishSigString(args[0].get<StructStringWithArray>());   
+        return;
+    }
+}
+
+void StructArray2InterfaceClient::olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value)
+{
+    applyProperty(ApiGear::ObjectLink::Name::getMemberName(propertyId), value);
+}
+void StructArray2InterfaceClient::olinkOnInit(const std::string& /*name*/, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node)
+{
+    m_node = node;
+    applyState(props);
+}
+
+void StructArray2InterfaceClient::olinkOnRelease()
+{
+    m_node = nullptr;
+}
+
+bool StructArray2InterfaceClient::isReady() const
+{
+    return m_node != nullptr;
+}
+
+IStructArray2InterfacePublisher& StructArray2InterfaceClient::_getPublisher() const
+{
+    return *m_publisher;
+}

--- a/goldenmaster/modules/testbed1/generated/olink/structarray2interfaceclient.h
+++ b/goldenmaster/modules/testbed1/generated/olink/structarray2interfaceclient.h
@@ -1,0 +1,234 @@
+
+#pragma once
+
+#include "testbed1/generated/api/common.h"
+#include "testbed1/generated/api/testbed1.h"
+#include "testbed1/generated/core/structarray2interface.data.h"
+
+THIRD_PARTY_INCLUDES_START
+#include "olink/iobjectsink.h"
+THIRD_PARTY_INCLUDES_END
+
+#include <future>
+#include <shared_mutex>
+#include <memory>
+
+namespace ApiGear{
+namespace ObjectLink{
+class IClientNode;
+}
+}
+
+namespace Test {
+namespace Testbed1 {
+namespace olink {
+/**
+* Adapts the general OLink Client handler to a StructArray2Interface publisher in a way it provides access 
+* to remote StructArray2Interface services. 
+* Sends and receives data over the network with ObjectLink protocol, through the communication node. 
+* see https://objectlinkprotocol.net for ObjectLink details.
+* see https://github.com/apigear-io/objectlink-core-cpp.git for olink client node - abstraction over the network.
+* see Apigear::ObjectLink::OLinkConnection for Olink Client Handler implementation.
+*     It provides a network implementation and tools to connect StructArray2InterfaceClient to it.
+* Use on client side to request changes of the StructArray2Interface on the server side
+* and to subscribe for the StructArray2Interface changes.
+*
+* @note Threading: property-change and signal callbacks arrive on the OLink network thread.
+* Properties are individually guarded by shared_timed_mutex (concurrent reads allowed,
+* exclusive writes). Operation calls are not synchronized by this adapter.
+*/
+class TEST_TESTBED1_EXPORT StructArray2InterfaceClient : public IStructArray2Interface,
+    public ApiGear::ObjectLink::IObjectSink
+{
+public:
+
+    /** ctor */
+    explicit StructArray2InterfaceClient();
+    /** dtor */
+    virtual ~StructArray2InterfaceClient() = default;
+    /**
+    * Property getter
+    * @return Locally stored locally value for PropBool.
+    */
+    const StructBoolWithArray& getPropBool() const override;
+    /**
+    * Request setting a property on the StructArray2Interface service.
+    * @param The value to which set request is send for the PropBool.
+    */
+    void setPropBool(const StructBoolWithArray& propBool) override;
+    /**
+    * Property getter
+    * @return Locally stored locally value for PropInt.
+    */
+    const StructIntWithArray& getPropInt() const override;
+    /**
+    * Request setting a property on the StructArray2Interface service.
+    * @param The value to which set request is send for the PropInt.
+    */
+    void setPropInt(const StructIntWithArray& propInt) override;
+    /**
+    * Property getter
+    * @return Locally stored locally value for PropFloat.
+    */
+    const StructFloatWithArray& getPropFloat() const override;
+    /**
+    * Request setting a property on the StructArray2Interface service.
+    * @param The value to which set request is send for the PropFloat.
+    */
+    void setPropFloat(const StructFloatWithArray& propFloat) override;
+    /**
+    * Property getter
+    * @return Locally stored locally value for PropString.
+    */
+    const StructStringWithArray& getPropString() const override;
+    /**
+    * Request setting a property on the StructArray2Interface service.
+    * @param The value to which set request is send for the PropString.
+    */
+    void setPropString(const StructStringWithArray& propString) override;
+    /**
+    * Property getter
+    * @return Locally stored locally value for PropEnum.
+    */
+    const StructEnumWithArray& getPropEnum() const override;
+    /**
+    * Request setting a property on the StructArray2Interface service.
+    * @param The value to which set request is send for the PropEnum.
+    */
+    void setPropEnum(const StructEnumWithArray& propEnum) override;
+    /**
+    * Remote call of IStructArray2Interface::funcBool on the StructArray2Interface service.
+    * Uses funcBoolAsync
+    */
+    std::list<StructBool> funcBool(const StructBoolWithArray& paramBool) override;
+    /**
+    * Remote call of IStructArray2Interface::funcBool on the StructArray2Interface service.
+    */
+    std::future<std::list<StructBool>> funcBoolAsync(const StructBoolWithArray& paramBool, std::function<void(std::list<StructBool>)> callback = nullptr) override;
+    /**
+    * Remote call of IStructArray2Interface::funcInt on the StructArray2Interface service.
+    * Uses funcIntAsync
+    */
+    std::list<StructInt> funcInt(const StructIntWithArray& paramInt) override;
+    /**
+    * Remote call of IStructArray2Interface::funcInt on the StructArray2Interface service.
+    */
+    std::future<std::list<StructInt>> funcIntAsync(const StructIntWithArray& paramInt, std::function<void(std::list<StructInt>)> callback = nullptr) override;
+    /**
+    * Remote call of IStructArray2Interface::funcFloat on the StructArray2Interface service.
+    * Uses funcFloatAsync
+    */
+    std::list<StructFloat> funcFloat(const StructFloatWithArray& paramFloat) override;
+    /**
+    * Remote call of IStructArray2Interface::funcFloat on the StructArray2Interface service.
+    */
+    std::future<std::list<StructFloat>> funcFloatAsync(const StructFloatWithArray& paramFloat, std::function<void(std::list<StructFloat>)> callback = nullptr) override;
+    /**
+    * Remote call of IStructArray2Interface::funcString on the StructArray2Interface service.
+    * Uses funcStringAsync
+    */
+    std::list<StructString> funcString(const StructStringWithArray& paramString) override;
+    /**
+    * Remote call of IStructArray2Interface::funcString on the StructArray2Interface service.
+    */
+    std::future<std::list<StructString>> funcStringAsync(const StructStringWithArray& paramString, std::function<void(std::list<StructString>)> callback = nullptr) override;
+    /**
+    * Remote call of IStructArray2Interface::funcEnum on the StructArray2Interface service.
+    * Uses funcEnumAsync
+    */
+    std::list<Enum0Enum> funcEnum(const StructEnumWithArray& paramEnum) override;
+    /**
+    * Remote call of IStructArray2Interface::funcEnum on the StructArray2Interface service.
+    */
+    std::future<std::list<Enum0Enum>> funcEnumAsync(const StructEnumWithArray& paramEnum, std::function<void(std::list<Enum0Enum>)> callback = nullptr) override;
+
+    /** The publisher to subscribe to. */
+    IStructArray2InterfacePublisher& _getPublisher() const override;
+    
+    /**
+    * Informs if the StructArray2InterfaceClient is ready to send and receive messages.
+    * @return true if StructArray2Interface is operable, false otherwise.
+    */
+    bool isReady() const;
+
+    /**
+    * The name of the object for which this sink is created, object on server side has to have the same name.
+    * It serves as an identifier for the client registry, it has to be unique for the pair sink object - client node.
+    * Passed in the olink messages as an object identifier.
+    */
+    std::string olinkObjectName() override;
+    
+    /**
+    * Information about signal emission on a server side to all subscribers.
+    * @param signalId Unique identifier for the signal emitted from object.
+    * @param args The arguments for the signal.
+    */
+    void olinkOnSignal(const std::string& signalId, const nlohmann::json& args) override;
+    
+    /**
+    * Applies the information about the property changed on server side.
+    * @param propertyId Unique identifier of a changed property in object .
+    * @param value The value of the property.
+    */
+    void olinkOnPropertyChanged(const std::string& propertyId, const nlohmann::json& value) override;
+    
+    /** Informs this object sink that connection was is established.
+    * @param interfaceId The name of the object for which link was established.
+    * @param props Initial values obtained from the StructArray2Interface service
+    * @param the initialized link endpoint for this sink.
+    */
+    void olinkOnInit(const std::string& interfaceId, const nlohmann::json& props, ApiGear::ObjectLink::IClientNode *node) override;
+    /**
+    * Informs this object source that the link was disconnected and cannot be used anymore.
+    */
+    void olinkOnRelease() override;
+
+private:
+    /**
+    * Applies received data to local state and publishes changes to subscribers.
+    * @param the data received from StructArray2Interface service.
+    */
+    void applyState(const nlohmann::json& fields);
+    /**
+    * Applies received property value to local state and publishes changes to subscribers.
+    * @param propertyName the name of property to be changed.
+    * @param value The value for property.
+    */
+    void applyProperty(const std::string& propertyName, const nlohmann::json& value);
+    /**  Updates local value for PropBool and informs subscriber about the change*/
+    void setPropBoolLocal(const StructBoolWithArray& propBool);
+    /* Mutex for propBool property */
+    mutable std::shared_timed_mutex m_propBoolMutex;
+    /**  Updates local value for PropInt and informs subscriber about the change*/
+    void setPropIntLocal(const StructIntWithArray& propInt);
+    /* Mutex for propInt property */
+    mutable std::shared_timed_mutex m_propIntMutex;
+    /**  Updates local value for PropFloat and informs subscriber about the change*/
+    void setPropFloatLocal(const StructFloatWithArray& propFloat);
+    /* Mutex for propFloat property */
+    mutable std::shared_timed_mutex m_propFloatMutex;
+    /**  Updates local value for PropString and informs subscriber about the change*/
+    void setPropStringLocal(const StructStringWithArray& propString);
+    /* Mutex for propString property */
+    mutable std::shared_timed_mutex m_propStringMutex;
+    /**  Updates local value for PropEnum and informs subscriber about the change*/
+    void setPropEnumLocal(const StructEnumWithArray& propEnum);
+    /* Mutex for propEnum property */
+    mutable std::shared_timed_mutex m_propEnumMutex;
+
+    /** Local storage for properties values. */
+    StructArray2InterfaceData m_data;
+
+    /** 
+    * An abstraction layer over the connection with service for the StructArray2InterfaceClient.
+    * Handles incoming and outgoing messages.
+    * Is given when object is linked with the service.
+    */
+    ApiGear::ObjectLink::IClientNode* m_node = nullptr;
+
+    /** The publisher for StructArray2Interface */
+    std::unique_ptr<IStructArray2InterfacePublisher> m_publisher;
+};
+} // namespace olink
+} // namespace Testbed1
+} // namespace Test

--- a/goldenmaster/modules/testbed1/generated/olink/structarray2interfaceservice.cpp
+++ b/goldenmaster/modules/testbed1/generated/olink/structarray2interfaceservice.cpp
@@ -1,0 +1,217 @@
+
+
+#include "testbed1/generated/api/datastructs.api.h"
+#include "testbed1/generated/olink/structarray2interfaceservice.h"
+#include "testbed1/generated/core/testbed1.json.adapter.h"
+
+THIRD_PARTY_INCLUDES_START
+#include "olink/iremotenode.h"
+#include "olink/remoteregistry.h"
+THIRD_PARTY_INCLUDES_END
+#include "apigear/utilities/logger.h"
+
+#include <iostream>
+
+
+using namespace Test::Testbed1;
+using namespace Test::Testbed1::olink;
+
+namespace 
+{
+const std::string interfaceId = "testbed1.StructArray2Interface";
+}
+
+StructArray2InterfaceService::StructArray2InterfaceService(std::shared_ptr<IStructArray2Interface> StructArray2Interface, ApiGear::ObjectLink::RemoteRegistry& registry)
+    : m_StructArray2Interface(StructArray2Interface)
+    , m_registry(registry)
+{
+    m_StructArray2Interface->_getPublisher().subscribeToAllChanges(*this);
+}
+
+StructArray2InterfaceService::~StructArray2InterfaceService()
+{
+    m_StructArray2Interface->_getPublisher().unsubscribeFromAllChanges(*this);
+}
+
+std::string StructArray2InterfaceService::olinkObjectName() {
+    return interfaceId;
+}
+
+nlohmann::json StructArray2InterfaceService::olinkInvoke(const std::string& methodId, const nlohmann::json& fcnArgs) {
+    AG_LOG_DEBUG("StructArray2InterfaceService invoke " + methodId);
+    const auto& memberMethod = ApiGear::ObjectLink::Name::getMemberName(methodId);
+    if(memberMethod == "funcBool") {
+        const StructBoolWithArray& paramBool = fcnArgs.at(0);
+        std::list<StructBool> result = m_StructArray2Interface->funcBool(paramBool);
+        return result;
+    }
+    if(memberMethod == "funcInt") {
+        const StructIntWithArray& paramInt = fcnArgs.at(0);
+        std::list<StructInt> result = m_StructArray2Interface->funcInt(paramInt);
+        return result;
+    }
+    if(memberMethod == "funcFloat") {
+        const StructFloatWithArray& paramFloat = fcnArgs.at(0);
+        std::list<StructFloat> result = m_StructArray2Interface->funcFloat(paramFloat);
+        return result;
+    }
+    if(memberMethod == "funcString") {
+        const StructStringWithArray& paramString = fcnArgs.at(0);
+        std::list<StructString> result = m_StructArray2Interface->funcString(paramString);
+        return result;
+    }
+    if(memberMethod == "funcEnum") {
+        const StructEnumWithArray& paramEnum = fcnArgs.at(0);
+        std::list<Enum0Enum> result = m_StructArray2Interface->funcEnum(paramEnum);
+        return result;
+    }
+    return nlohmann::json();
+}
+
+void StructArray2InterfaceService::olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) {
+    AG_LOG_DEBUG("StructArray2InterfaceService set property " + propertyId);
+    const auto& memberProperty = ApiGear::ObjectLink::Name::getMemberName(propertyId);
+    if(memberProperty == "propBool") {
+        StructBoolWithArray propBool = value.get<StructBoolWithArray>();
+        m_StructArray2Interface->setPropBool(propBool);
+    }
+    if(memberProperty == "propInt") {
+        StructIntWithArray propInt = value.get<StructIntWithArray>();
+        m_StructArray2Interface->setPropInt(propInt);
+    }
+    if(memberProperty == "propFloat") {
+        StructFloatWithArray propFloat = value.get<StructFloatWithArray>();
+        m_StructArray2Interface->setPropFloat(propFloat);
+    }
+    if(memberProperty == "propString") {
+        StructStringWithArray propString = value.get<StructStringWithArray>();
+        m_StructArray2Interface->setPropString(propString);
+    }
+    if(memberProperty == "propEnum") {
+        StructEnumWithArray propEnum = value.get<StructEnumWithArray>();
+        m_StructArray2Interface->setPropEnum(propEnum);
+    } 
+}
+
+void StructArray2InterfaceService::olinkLinked(const std::string& objectId, ApiGear::ObjectLink::IRemoteNode* /*node*/) {
+    AG_LOG_DEBUG("StructArray2InterfaceService linked " + objectId);
+}
+
+void StructArray2InterfaceService::olinkUnlinked(const std::string& objectId){
+    AG_LOG_DEBUG("StructArray2InterfaceService unlinked " + objectId);
+}
+
+nlohmann::json StructArray2InterfaceService::olinkCollectProperties()
+{
+    return nlohmann::json::object({
+        { "propBool", m_StructArray2Interface->getPropBool() },
+        { "propInt", m_StructArray2Interface->getPropInt() },
+        { "propFloat", m_StructArray2Interface->getPropFloat() },
+        { "propString", m_StructArray2Interface->getPropString() },
+        { "propEnum", m_StructArray2Interface->getPropEnum() }
+    });
+}
+void StructArray2InterfaceService::onSigBool(const StructBoolWithArray& paramBool)
+{
+    const nlohmann::json args = { paramBool };
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigBool");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
+        auto lockedNode = node.lock();
+        if(lockedNode) {
+            lockedNode->notifySignal(signalId, args);
+        }
+    }
+}
+void StructArray2InterfaceService::onSigInt(const StructIntWithArray& paramInt)
+{
+    const nlohmann::json args = { paramInt };
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigInt");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
+        auto lockedNode = node.lock();
+        if(lockedNode) {
+            lockedNode->notifySignal(signalId, args);
+        }
+    }
+}
+void StructArray2InterfaceService::onSigFloat(const StructFloatWithArray& paramFloat)
+{
+    const nlohmann::json args = { paramFloat };
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigFloat");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
+        auto lockedNode = node.lock();
+        if(lockedNode) {
+            lockedNode->notifySignal(signalId, args);
+        }
+    }
+}
+void StructArray2InterfaceService::onSigString(const StructStringWithArray& paramString)
+{
+    const nlohmann::json args = { paramString };
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigString");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
+        auto lockedNode = node.lock();
+        if(lockedNode) {
+            lockedNode->notifySignal(signalId, args);
+        }
+    }
+}
+void StructArray2InterfaceService::onPropBoolChanged(const StructBoolWithArray& propBool)
+{
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
+        auto lockedNode = node.lock();
+        if(lockedNode) {
+            lockedNode->notifyPropertyChange(propertyId, propBool);
+        }
+    }
+}
+void StructArray2InterfaceService::onPropIntChanged(const StructIntWithArray& propInt)
+{
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propInt");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
+        auto lockedNode = node.lock();
+        if(lockedNode) {
+            lockedNode->notifyPropertyChange(propertyId, propInt);
+        }
+    }
+}
+void StructArray2InterfaceService::onPropFloatChanged(const StructFloatWithArray& propFloat)
+{
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propFloat");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
+        auto lockedNode = node.lock();
+        if(lockedNode) {
+            lockedNode->notifyPropertyChange(propertyId, propFloat);
+        }
+    }
+}
+void StructArray2InterfaceService::onPropStringChanged(const StructStringWithArray& propString)
+{
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propString");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
+        auto lockedNode = node.lock();
+        if(lockedNode) {
+            lockedNode->notifyPropertyChange(propertyId, propString);
+        }
+    }
+}
+void StructArray2InterfaceService::onPropEnumChanged(const StructEnumWithArray& propEnum)
+{
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propEnum");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
+        auto lockedNode = node.lock();
+        if(lockedNode) {
+            lockedNode->notifyPropertyChange(propertyId, propEnum);
+        }
+    }
+}
+

--- a/goldenmaster/modules/testbed1/generated/olink/structarray2interfaceservice.h
+++ b/goldenmaster/modules/testbed1/generated/olink/structarray2interfaceservice.h
@@ -1,0 +1,123 @@
+
+#pragma once
+
+#include "testbed1/generated/api/testbed1.h"
+#include "testbed1/generated/api/common.h"
+THIRD_PARTY_INCLUDES_START
+#include "olink/iobjectsource.h"
+THIRD_PARTY_INCLUDES_END
+
+
+namespace ApiGear {
+namespace ObjectLink {
+
+class RemoteRegistry;
+class IRemoteNode;
+
+}} //namespace ApiGear::ObjectLink
+
+namespace Test {
+namespace Testbed1 {
+namespace olink {
+/**
+* Server side for StructArray2Interface implements the StructArray2Interface service.
+* It is a source of data for StructArray2Interface clients.
+* Sends and receives data over the network with ObjectLink protocol. 
+* see https://objectlinkprotocol.net for Object Link Details
+*/
+class TEST_TESTBED1_EXPORT StructArray2InterfaceService : public ApiGear::ObjectLink::IObjectSource, public IStructArray2InterfaceSubscriber
+{
+public:
+    /**
+    * ctor
+    * @param StructArray2Interface The service source object, the actual StructArray2Interface object which is exposed for remote clients with olink.
+    * @param registry The global registry that keeps track of the object source services associated with network nodes.
+    */
+    explicit StructArray2InterfaceService(std::shared_ptr<IStructArray2Interface> StructArray2Interface, ApiGear::ObjectLink::RemoteRegistry& registry);
+    virtual ~StructArray2InterfaceService() override;
+
+    /**
+    * The name of the object for which this service is created, object on client side has to have the same name.
+    * It serves as an identifier for the source registry, it has to be unique for the pair source object - remote node.
+    * Passed in the olink messages as an object identifier.
+    */
+    std::string olinkObjectName() override;
+    /**
+    * Applies received method invocation with given arguments on the StructArray2Interface object.
+    * @param name Path of the method to invoke. Contains object name and the method name.
+    * @param args Arguments required to invoke a method in json format.
+    * @return the result of the invoked method (if applicable) that needs to be sent back to the clients.
+    */
+    nlohmann::json olinkInvoke(const std::string& methodId, const nlohmann::json& args) override;
+    /**
+    * Applies received change property request to StructArray2Interface object.
+    * @param name Path the property to change. Contains object name and the property name.
+    * @param args Value in json format requested to set for the property.
+    */
+    void olinkSetProperty(const std::string& propertyId, const nlohmann::json& value) override;
+    /**
+    * Informs this service source that the link was established.
+    * @param name The name of the object for which link was established.
+    * @param the initialized link endpoint.
+    */
+    void olinkLinked(const std::string& objectId, ApiGear::ObjectLink::IRemoteNode *node) override;
+    /**
+    * Informs this service source that the link was disconnected and cannot be used anymore.
+    */
+    void olinkUnlinked(const std::string& objectId) override;
+
+    /**
+    * Gets the current state of StructArray2Interface object.
+    * @return the set of properties with their current values for the StructArray2Interface object in json format.
+    */
+    nlohmann::json olinkCollectProperties() override;
+    /**
+    * Forwards emitted sigBool through network if the connection is established.
+    */
+    void onSigBool(const StructBoolWithArray& paramBool) override;
+    /**
+    * Forwards emitted sigInt through network if the connection is established.
+    */
+    void onSigInt(const StructIntWithArray& paramInt) override;
+    /**
+    * Forwards emitted sigFloat through network if the connection is established.
+    */
+    void onSigFloat(const StructFloatWithArray& paramFloat) override;
+    /**
+    * Forwards emitted sigString through network if the connection is established.
+    */
+    void onSigString(const StructStringWithArray& paramString) override;
+    /**
+    * Forwards propBool change through network if the connection is established.
+    */
+    void onPropBoolChanged(const StructBoolWithArray& propBool) override;
+    /**
+    * Forwards propInt change through network if the connection is established.
+    */
+    void onPropIntChanged(const StructIntWithArray& propInt) override;
+    /**
+    * Forwards propFloat change through network if the connection is established.
+    */
+    void onPropFloatChanged(const StructFloatWithArray& propFloat) override;
+    /**
+    * Forwards propString change through network if the connection is established.
+    */
+    void onPropStringChanged(const StructStringWithArray& propString) override;
+    /**
+    * Forwards propEnum change through network if the connection is established.
+    */
+    void onPropEnumChanged(const StructEnumWithArray& propEnum) override;
+
+private:
+    /**
+    * The StructArray2Interface used for object source.
+    */
+    std::shared_ptr<IStructArray2Interface> m_StructArray2Interface;
+    /**
+    * A global registry that keeps track of object sources associated with their network layer nodes.
+    */
+    ApiGear::ObjectLink::RemoteRegistry& m_registry;
+};
+} // namespace olink
+} // namespace Testbed1
+} // namespace Test

--- a/goldenmaster/modules/testbed1/generated/olink/structarrayinterfaceclient.cpp
+++ b/goldenmaster/modules/testbed1/generated/olink/structarrayinterfaceclient.cpp
@@ -35,6 +35,9 @@ void StructArrayInterfaceClient::applyState(const nlohmann::json& fields)
     if(fields.contains("propString")) {
         setPropStringLocal(fields["propString"].get<std::list<StructString>>());
     }
+    if(fields.contains("propEnum")) {
+        setPropEnumLocal(fields["propEnum"].get<std::list<Enum0Enum>>());
+    }
 }
 
 void StructArrayInterfaceClient::applyProperty(const std::string& propertyName, const nlohmann::json& value)
@@ -50,6 +53,9 @@ void StructArrayInterfaceClient::applyProperty(const std::string& propertyName, 
     }
     else if ( propertyName == "propString") {
         setPropStringLocal(value.get<std::list<StructString>>());
+    }
+    else if ( propertyName == "propEnum") {
+        setPropEnumLocal(value.get<std::list<Enum0Enum>>());
     }
 }
 
@@ -169,6 +175,35 @@ const std::list<StructString>& StructArrayInterfaceClient::getPropString() const
     return m_data.m_propString;
 }
 
+void StructArrayInterfaceClient::setPropEnum(const std::list<Enum0Enum>& propEnum)
+{
+    if(!m_node) {
+        AG_LOG_WARNING("Attempt to set property but " + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return;
+    }
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propEnum");
+    m_node->setRemoteProperty(propertyId, propEnum);
+}
+
+void StructArrayInterfaceClient::setPropEnumLocal(const std::list<Enum0Enum>& propEnum)
+{
+    {
+        std::unique_lock<std::shared_timed_mutex> lock(m_propEnumMutex);
+        if (m_data.m_propEnum == propEnum) {
+            return;
+        }
+        m_data.m_propEnum = propEnum;
+    }
+
+    m_publisher->publishPropEnumChanged(propEnum);
+}
+
+const std::list<Enum0Enum>& StructArrayInterfaceClient::getPropEnum() const
+{
+    std::shared_lock<std::shared_timed_mutex> lock(m_propEnumMutex);
+    return m_data.m_propEnum;
+}
+
 std::list<StructBool> StructArrayInterfaceClient::funcBool(const std::list<StructBool>& paramBool)
 {
     return funcBoolAsync(paramBool).get();
@@ -269,6 +304,31 @@ std::future<std::list<StructString>> StructArrayInterfaceClient::funcStringAsync
     return resultPromise->get_future();
 }
 
+std::list<Enum0Enum> StructArrayInterfaceClient::funcEnum(const std::list<Enum0Enum>& paramEnum)
+{
+    return funcEnumAsync(paramEnum).get();
+}
+
+std::future<std::list<Enum0Enum>> StructArrayInterfaceClient::funcEnumAsync(const std::list<Enum0Enum>& paramEnum, std::function<void(std::list<Enum0Enum>)> callback)
+{
+    if(!m_node) {
+        AG_LOG_WARNING("Attempt to invoke method but" + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return std::future<std::list<Enum0Enum>>{};
+    }
+    std::shared_ptr<std::promise<std::list<Enum0Enum>>> resultPromise = std::make_shared<std::promise<std::list<Enum0Enum>>>();
+    static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcEnum");
+    m_node->invokeRemote(operationId,
+        nlohmann::json::array({paramEnum}), [resultPromise, callback](ApiGear::ObjectLink::InvokeReplyArg arg) {
+            const std::list<Enum0Enum>& value = arg.value.get<std::list<Enum0Enum>>();
+            resultPromise->set_value(value);
+            if (callback)
+            {
+                callback(value);
+            }
+        });
+    return resultPromise->get_future();
+}
+
 std::string StructArrayInterfaceClient::olinkObjectName()
 {
     return interfaceId;
@@ -291,6 +351,10 @@ void StructArrayInterfaceClient::olinkOnSignal(const std::string& signalId, cons
     }
     if(signalName == "sigString") {
         m_publisher->publishSigString(args[0].get<std::list<StructString>>());   
+        return;
+    }
+    if(signalName == "sigEnum") {
+        m_publisher->publishSigEnum(args[0].get<std::list<Enum0Enum>>());   
         return;
     }
 }

--- a/goldenmaster/modules/testbed1/generated/olink/structarrayinterfaceclient.h
+++ b/goldenmaster/modules/testbed1/generated/olink/structarrayinterfaceclient.h
@@ -87,6 +87,16 @@ public:
     */
     void setPropString(const std::list<StructString>& propString) override;
     /**
+    * Property getter
+    * @return Locally stored locally value for PropEnum.
+    */
+    const std::list<Enum0Enum>& getPropEnum() const override;
+    /**
+    * Request setting a property on the StructArrayInterface service.
+    * @param The value to which set request is send for the PropEnum.
+    */
+    void setPropEnum(const std::list<Enum0Enum>& propEnum) override;
+    /**
     * Remote call of IStructArrayInterface::funcBool on the StructArrayInterface service.
     * Uses funcBoolAsync
     */
@@ -122,6 +132,15 @@ public:
     * Remote call of IStructArrayInterface::funcString on the StructArrayInterface service.
     */
     std::future<std::list<StructString>> funcStringAsync(const std::list<StructString>& paramString, std::function<void(std::list<StructString>)> callback = nullptr) override;
+    /**
+    * Remote call of IStructArrayInterface::funcEnum on the StructArrayInterface service.
+    * Uses funcEnumAsync
+    */
+    std::list<Enum0Enum> funcEnum(const std::list<Enum0Enum>& paramEnum) override;
+    /**
+    * Remote call of IStructArrayInterface::funcEnum on the StructArrayInterface service.
+    */
+    std::future<std::list<Enum0Enum>> funcEnumAsync(const std::list<Enum0Enum>& paramEnum, std::function<void(std::list<Enum0Enum>)> callback = nullptr) override;
 
     /** The publisher to subscribe to. */
     IStructArrayInterfacePublisher& _getPublisher() const override;
@@ -192,6 +211,10 @@ private:
     void setPropStringLocal(const std::list<StructString>& propString);
     /* Mutex for propString property */
     mutable std::shared_timed_mutex m_propStringMutex;
+    /**  Updates local value for PropEnum and informs subscriber about the change*/
+    void setPropEnumLocal(const std::list<Enum0Enum>& propEnum);
+    /* Mutex for propEnum property */
+    mutable std::shared_timed_mutex m_propEnumMutex;
 
     /** Local storage for properties values. */
     StructArrayInterfaceData m_data;

--- a/goldenmaster/modules/testbed1/generated/olink/structarrayinterfaceservice.cpp
+++ b/goldenmaster/modules/testbed1/generated/olink/structarrayinterfaceservice.cpp
@@ -60,6 +60,11 @@ nlohmann::json StructArrayInterfaceService::olinkInvoke(const std::string& metho
         std::list<StructString> result = m_StructArrayInterface->funcString(paramString);
         return result;
     }
+    if(memberMethod == "funcEnum") {
+        const std::list<Enum0Enum>& paramEnum = fcnArgs.at(0);
+        std::list<Enum0Enum> result = m_StructArrayInterface->funcEnum(paramEnum);
+        return result;
+    }
     return nlohmann::json();
 }
 
@@ -81,6 +86,10 @@ void StructArrayInterfaceService::olinkSetProperty(const std::string& propertyId
     if(memberProperty == "propString") {
         std::list<StructString> propString = value.get<std::list<StructString>>();
         m_StructArrayInterface->setPropString(propString);
+    }
+    if(memberProperty == "propEnum") {
+        std::list<Enum0Enum> propEnum = value.get<std::list<Enum0Enum>>();
+        m_StructArrayInterface->setPropEnum(propEnum);
     } 
 }
 
@@ -98,7 +107,8 @@ nlohmann::json StructArrayInterfaceService::olinkCollectProperties()
         { "propBool", m_StructArrayInterface->getPropBool() },
         { "propInt", m_StructArrayInterface->getPropInt() },
         { "propFloat", m_StructArrayInterface->getPropFloat() },
-        { "propString", m_StructArrayInterface->getPropString() }
+        { "propString", m_StructArrayInterface->getPropString() },
+        { "propEnum", m_StructArrayInterface->getPropEnum() }
     });
 }
 void StructArrayInterfaceService::onSigBool(const std::list<StructBool>& paramBool)
@@ -149,6 +159,18 @@ void StructArrayInterfaceService::onSigString(const std::list<StructString>& par
         }
     }
 }
+void StructArrayInterfaceService::onSigEnum(const std::list<Enum0Enum>& paramEnum)
+{
+    const nlohmann::json args = { paramEnum };
+    static const auto signalId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "sigEnum");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
+        auto lockedNode = node.lock();
+        if(lockedNode) {
+            lockedNode->notifySignal(signalId, args);
+        }
+    }
+}
 void StructArrayInterfaceService::onPropBoolChanged(const std::list<StructBool>& propBool)
 {
     static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propBool");
@@ -190,6 +212,17 @@ void StructArrayInterfaceService::onPropStringChanged(const std::list<StructStri
         auto lockedNode = node.lock();
         if(lockedNode) {
             lockedNode->notifyPropertyChange(propertyId, propString);
+        }
+    }
+}
+void StructArrayInterfaceService::onPropEnumChanged(const std::list<Enum0Enum>& propEnum)
+{
+    static const auto propertyId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "propEnum");
+    static const auto objectId = olinkObjectName();
+    for(auto node: m_registry.getNodes(objectId)) {
+        auto lockedNode = node.lock();
+        if(lockedNode) {
+            lockedNode->notifyPropertyChange(propertyId, propEnum);
         }
     }
 }

--- a/goldenmaster/modules/testbed1/generated/olink/structarrayinterfaceservice.h
+++ b/goldenmaster/modules/testbed1/generated/olink/structarrayinterfaceservice.h
@@ -88,6 +88,10 @@ public:
     */
     void onSigString(const std::list<StructString>& paramString) override;
     /**
+    * Forwards emitted sigEnum through network if the connection is established.
+    */
+    void onSigEnum(const std::list<Enum0Enum>& paramEnum) override;
+    /**
     * Forwards propBool change through network if the connection is established.
     */
     void onPropBoolChanged(const std::list<StructBool>& propBool) override;
@@ -103,6 +107,10 @@ public:
     * Forwards propString change through network if the connection is established.
     */
     void onPropStringChanged(const std::list<StructString>& propString) override;
+    /**
+    * Forwards propEnum change through network if the connection is established.
+    */
+    void onPropEnumChanged(const std::list<Enum0Enum>& propEnum) override;
 
 private:
     /**

--- a/goldenmaster/modules/testbed1/generated/olink/tests/CMakeLists.txt
+++ b/goldenmaster/modules/testbed1/generated/olink/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ set(TEST_TESTBED1_GENERATED_OLINK_SOURCES
     test_main.cpp
     test_structinterface.cpp
     test_structarrayinterface.cpp
+    test_structarray2interface.cpp
     )
 
 

--- a/goldenmaster/modules/testbed1/generated/olink/tests/test_structarray2interface.cpp
+++ b/goldenmaster/modules/testbed1/generated/olink/tests/test_structarray2interface.cpp
@@ -1,0 +1,371 @@
+#pragma warning (disable: 4251)
+#pragma warning (disable: 4099)
+
+#include <catch2/catch.hpp>
+#include <condition_variable>
+
+
+#include "testbed1/generated/core/test_struct_helper.h"
+#include "testbed1/implementation/structarray2interface.h"
+#include "testbed1/generated/olink/structarray2interfaceclient.h"
+#include "testbed1/generated/olink/structarray2interfaceservice.h"
+
+
+THIRD_PARTY_INCLUDES_START
+#include "olink/clientregistry.h"
+#include "olink/clientnode.h"
+#include "olink/remotenode.h"
+#include "olink/remoteregistry.h"
+THIRD_PARTY_INCLUDES_END
+
+// Those tests do not use network connection.
+// They are set in a way the client writes data straight into read function of server and vice versa.
+
+namespace{
+
+    int timeout = 1000;//in ms
+}
+
+using namespace Test;
+using namespace Test::Testbed1;
+
+TEST_CASE("olink  testbed1 StructArray2Interface tests")
+{
+
+
+    ApiGear::ObjectLink::ClientRegistry client_registry;
+    auto clientNode = ApiGear::ObjectLink::ClientNode::create(client_registry);
+    auto clientStructArray2Interface = std::make_shared<Test::Testbed1::olink::StructArray2InterfaceClient>();
+
+    ApiGear::ObjectLink::RemoteRegistry remote_registry;
+    auto remoteNode = ApiGear::ObjectLink::RemoteNode::createRemoteNode(remote_registry);
+    auto implStructArray2Interface = std::make_shared<Test::Testbed1::StructArray2Interface>();
+    auto serviceStructArray2Interface = std::make_shared<Test::Testbed1::olink::StructArray2InterfaceService>(implStructArray2Interface, remote_registry);
+    remote_registry.addSource(serviceStructArray2Interface);
+
+    remoteNode->onWrite([clientNode](std::string msg){clientNode->handleMessage(msg);});
+    clientNode->onWrite([remoteNode](std::string msg){remoteNode->handleMessage(msg);});
+
+    clientNode->registry().addSink(clientStructArray2Interface);
+    clientNode->linkRemote(clientStructArray2Interface->olinkObjectName());
+
+    std::condition_variable m_wait;
+    std::mutex m_waitMutex;
+    std::unique_lock<std::mutex> lock(m_waitMutex, std::defer_lock);
+    SECTION("Test setting propBool")
+    {
+        std::atomic<bool> ispropBoolChanged = false;
+        clientStructArray2Interface->_getPublisher().subscribeToPropBoolChanged(
+        [&ispropBoolChanged, &m_wait ](auto value){
+            ispropBoolChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = Testbed1::StructBoolWithArray();
+        Testbed1::fillTestStructBoolWithArray(test_value);
+        clientStructArray2Interface->setPropBool(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropBoolChanged]() {return ispropBoolChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArray2Interface->getPropBool() == test_value);
+        REQUIRE(clientStructArray2Interface->getPropBool() == test_value);
+    }
+    SECTION("Test setting propInt")
+    {
+        std::atomic<bool> ispropIntChanged = false;
+        clientStructArray2Interface->_getPublisher().subscribeToPropIntChanged(
+        [&ispropIntChanged, &m_wait ](auto value){
+            ispropIntChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = Testbed1::StructIntWithArray();
+        Testbed1::fillTestStructIntWithArray(test_value);
+        clientStructArray2Interface->setPropInt(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropIntChanged]() {return ispropIntChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArray2Interface->getPropInt() == test_value);
+        REQUIRE(clientStructArray2Interface->getPropInt() == test_value);
+    }
+    SECTION("Test setting propFloat")
+    {
+        std::atomic<bool> ispropFloatChanged = false;
+        clientStructArray2Interface->_getPublisher().subscribeToPropFloatChanged(
+        [&ispropFloatChanged, &m_wait ](auto value){
+            ispropFloatChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = Testbed1::StructFloatWithArray();
+        Testbed1::fillTestStructFloatWithArray(test_value);
+        clientStructArray2Interface->setPropFloat(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropFloatChanged]() {return ispropFloatChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArray2Interface->getPropFloat() == test_value);
+        REQUIRE(clientStructArray2Interface->getPropFloat() == test_value);
+    }
+    SECTION("Test setting propString")
+    {
+        std::atomic<bool> ispropStringChanged = false;
+        clientStructArray2Interface->_getPublisher().subscribeToPropStringChanged(
+        [&ispropStringChanged, &m_wait ](auto value){
+            ispropStringChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = Testbed1::StructStringWithArray();
+        Testbed1::fillTestStructStringWithArray(test_value);
+        clientStructArray2Interface->setPropString(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropStringChanged]() {return ispropStringChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArray2Interface->getPropString() == test_value);
+        REQUIRE(clientStructArray2Interface->getPropString() == test_value);
+    }
+    SECTION("Test setting propEnum")
+    {
+        std::atomic<bool> ispropEnumChanged = false;
+        clientStructArray2Interface->_getPublisher().subscribeToPropEnumChanged(
+        [&ispropEnumChanged, &m_wait ](auto value){
+            ispropEnumChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = Testbed1::StructEnumWithArray();
+        Testbed1::fillTestStructEnumWithArray(test_value);
+        clientStructArray2Interface->setPropEnum(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropEnumChanged]() {return ispropEnumChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArray2Interface->getPropEnum() == test_value);
+        REQUIRE(clientStructArray2Interface->getPropEnum() == test_value);
+    }
+    SECTION("Test emit sigBool")
+    {
+        std::atomic<bool> issigBoolEmitted = false;
+        auto local_param_bool_struct = Testbed1::StructBoolWithArray();
+        Testbed1::fillTestStructBoolWithArray(local_param_bool_struct);
+
+        clientStructArray2Interface->_getPublisher().subscribeToSigBool(
+        [&m_wait, &issigBoolEmitted, &local_param_bool_struct](const Testbed1::StructBoolWithArray& paramBool)
+        {
+            REQUIRE(paramBool ==local_param_bool_struct);
+            issigBoolEmitted  = true;
+            m_wait.notify_all();
+        });
+
+         implStructArray2Interface->_getPublisher().publishSigBool(local_param_bool_struct);
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&issigBoolEmitted ]() {return issigBoolEmitted   == true; }));
+        lock.unlock();
+    }
+    SECTION("Test emit sigInt")
+    {
+        std::atomic<bool> issigIntEmitted = false;
+        auto local_param_int_struct = Testbed1::StructIntWithArray();
+        Testbed1::fillTestStructIntWithArray(local_param_int_struct);
+
+        clientStructArray2Interface->_getPublisher().subscribeToSigInt(
+        [&m_wait, &issigIntEmitted, &local_param_int_struct](const Testbed1::StructIntWithArray& paramInt)
+        {
+            REQUIRE(paramInt ==local_param_int_struct);
+            issigIntEmitted  = true;
+            m_wait.notify_all();
+        });
+
+         implStructArray2Interface->_getPublisher().publishSigInt(local_param_int_struct);
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&issigIntEmitted ]() {return issigIntEmitted   == true; }));
+        lock.unlock();
+    }
+    SECTION("Test emit sigFloat")
+    {
+        std::atomic<bool> issigFloatEmitted = false;
+        auto local_param_float_struct = Testbed1::StructFloatWithArray();
+        Testbed1::fillTestStructFloatWithArray(local_param_float_struct);
+
+        clientStructArray2Interface->_getPublisher().subscribeToSigFloat(
+        [&m_wait, &issigFloatEmitted, &local_param_float_struct](const Testbed1::StructFloatWithArray& paramFloat)
+        {
+            REQUIRE(paramFloat ==local_param_float_struct);
+            issigFloatEmitted  = true;
+            m_wait.notify_all();
+        });
+
+         implStructArray2Interface->_getPublisher().publishSigFloat(local_param_float_struct);
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&issigFloatEmitted ]() {return issigFloatEmitted   == true; }));
+        lock.unlock();
+    }
+    SECTION("Test emit sigString")
+    {
+        std::atomic<bool> issigStringEmitted = false;
+        auto local_param_string_struct = Testbed1::StructStringWithArray();
+        Testbed1::fillTestStructStringWithArray(local_param_string_struct);
+
+        clientStructArray2Interface->_getPublisher().subscribeToSigString(
+        [&m_wait, &issigStringEmitted, &local_param_string_struct](const Testbed1::StructStringWithArray& paramString)
+        {
+            REQUIRE(paramString ==local_param_string_struct);
+            issigStringEmitted  = true;
+            m_wait.notify_all();
+        });
+
+         implStructArray2Interface->_getPublisher().publishSigString(local_param_string_struct);
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&issigStringEmitted ]() {return issigStringEmitted   == true; }));
+        lock.unlock();
+    }
+    SECTION("Test method funcBool")
+    {
+        [[maybe_unused]] auto result = clientStructArray2Interface->funcBool(Testbed1::StructBoolWithArray());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcBool async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcBoolAsync(Testbed1::StructBoolWithArray());
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::StructBool>()); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    SECTION("Test method funcBool async with a callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcBoolAsync(Testbed1::StructBoolWithArray(),[&finished, &m_wait](std::list<StructBool> value){ (void) value;finished = true; m_wait.notify_all(); /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ });
+         
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::StructBool>()); 
+        
+    }
+    SECTION("Test method funcInt")
+    {
+        [[maybe_unused]] auto result = clientStructArray2Interface->funcInt(Testbed1::StructIntWithArray());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcInt async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcIntAsync(Testbed1::StructIntWithArray());
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::StructInt>()); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    SECTION("Test method funcInt async with a callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcIntAsync(Testbed1::StructIntWithArray(),[&finished, &m_wait](std::list<StructInt> value){ (void) value;finished = true; m_wait.notify_all(); /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ });
+         
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::StructInt>()); 
+        
+    }
+    SECTION("Test method funcFloat")
+    {
+        [[maybe_unused]] auto result = clientStructArray2Interface->funcFloat(Testbed1::StructFloatWithArray());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcFloat async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcFloatAsync(Testbed1::StructFloatWithArray());
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::StructFloat>()); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    SECTION("Test method funcFloat async with a callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcFloatAsync(Testbed1::StructFloatWithArray(),[&finished, &m_wait](std::list<StructFloat> value){ (void) value;finished = true; m_wait.notify_all(); /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ });
+         
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::StructFloat>()); 
+        
+    }
+    SECTION("Test method funcString")
+    {
+        [[maybe_unused]] auto result = clientStructArray2Interface->funcString(Testbed1::StructStringWithArray());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcString async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcStringAsync(Testbed1::StructStringWithArray());
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::StructString>()); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    SECTION("Test method funcString async with a callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcStringAsync(Testbed1::StructStringWithArray(),[&finished, &m_wait](std::list<StructString> value){ (void) value;finished = true; m_wait.notify_all(); /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ });
+         
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::StructString>()); 
+        
+    }
+    SECTION("Test method funcEnum")
+    {
+        [[maybe_unused]] auto result = clientStructArray2Interface->funcEnum(Testbed1::StructEnumWithArray());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcEnum async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcEnumAsync(Testbed1::StructEnumWithArray());
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::Enum0Enum>()); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    SECTION("Test method funcEnum async with a callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArray2Interface->funcEnumAsync(Testbed1::StructEnumWithArray(),[&finished, &m_wait](std::list<Enum0Enum> value){ (void) value;finished = true; m_wait.notify_all(); /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ });
+         
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::Enum0Enum>()); 
+        
+    }
+    clientNode->unlinkRemote(clientStructArray2Interface->olinkObjectName());
+    remote_registry.removeSource(serviceStructArray2Interface->olinkObjectName());
+    client_registry.removeSink(clientStructArray2Interface->olinkObjectName());
+    serviceStructArray2Interface.reset();
+    clientStructArray2Interface.reset();
+}

--- a/goldenmaster/modules/testbed1/generated/olink/tests/test_structarrayinterface.cpp
+++ b/goldenmaster/modules/testbed1/generated/olink/tests/test_structarrayinterface.cpp
@@ -128,6 +128,23 @@ TEST_CASE("olink  testbed1 StructArrayInterface tests")
         REQUIRE(implStructArrayInterface->getPropString() == test_value);
         REQUIRE(clientStructArrayInterface->getPropString() == test_value);
     }
+    SECTION("Test setting propEnum")
+    {
+        std::atomic<bool> ispropEnumChanged = false;
+        clientStructArrayInterface->_getPublisher().subscribeToPropEnumChanged(
+        [&ispropEnumChanged, &m_wait ](auto value){
+            ispropEnumChanged  = true;
+            m_wait.notify_all();
+        });
+        auto test_value = std::list<Testbed1::Enum0Enum>();  
+        test_value.push_back(Testbed1::Enum0Enum::value1);
+        clientStructArrayInterface->setPropEnum(test_value);;
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&ispropEnumChanged]() {return ispropEnumChanged  == true; }));
+        lock.unlock();
+        REQUIRE(implStructArrayInterface->getPropEnum() == test_value);
+        REQUIRE(clientStructArrayInterface->getPropEnum() == test_value);
+    }
     SECTION("Test emit sigBool")
     {
         std::atomic<bool> issigBoolEmitted = false;
@@ -210,6 +227,25 @@ TEST_CASE("olink  testbed1 StructArrayInterface tests")
          implStructArrayInterface->_getPublisher().publishSigString(local_param_string_array);
         lock.lock();
         REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&issigStringEmitted ]() {return issigStringEmitted   == true; }));
+        lock.unlock();
+    }
+    SECTION("Test emit sigEnum")
+    {
+        std::atomic<bool> issigEnumEmitted = false;
+        auto local_param_enum_array = std::list<Testbed1::Enum0Enum>();
+        local_param_enum_array.push_back(Testbed1::Enum0Enum::value1);
+
+        clientStructArrayInterface->_getPublisher().subscribeToSigEnum(
+        [&m_wait, &issigEnumEmitted, &local_param_enum_array](const std::list<Testbed1::Enum0Enum>& paramEnum)
+        {
+            REQUIRE(paramEnum == local_param_enum_array);
+            issigEnumEmitted  = true;
+            m_wait.notify_all();
+        });
+
+         implStructArrayInterface->_getPublisher().publishSigEnum(local_param_enum_array);
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&issigEnumEmitted ]() {return issigEnumEmitted   == true; }));
         lock.unlock();
     }
     SECTION("Test method funcBool")
@@ -330,6 +366,36 @@ TEST_CASE("olink  testbed1 StructArrayInterface tests")
         lock.unlock();
         auto return_value = resultFuture.get();
         REQUIRE(return_value == std::list<Testbed1::StructString>()); 
+        
+    }
+    SECTION("Test method funcEnum")
+    {
+        [[maybe_unused]] auto result = clientStructArrayInterface->funcEnum(std::list<Testbed1::Enum0Enum>());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcEnum async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArrayInterface->funcEnumAsync(std::list<Testbed1::Enum0Enum>());
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::Enum0Enum>()); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    SECTION("Test method funcEnum async with a callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientStructArrayInterface->funcEnumAsync(std::list<Testbed1::Enum0Enum>(),[&finished, &m_wait](std::list<Enum0Enum> value){ (void) value;finished = true; m_wait.notify_all(); /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ });
+         
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == std::list<Testbed1::Enum0Enum>()); 
         
     }
     clientNode->unlinkRemote(clientStructArrayInterface->olinkObjectName());

--- a/goldenmaster/modules/testbed1/implementation/CMakeLists.txt
+++ b/goldenmaster/modules/testbed1/implementation/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(Threads REQUIRED)
 set (SOURCES_CORE_IMPL
     structinterface.cpp
     structarrayinterface.cpp
+    structarray2interface.cpp
 )
 add_library(testbed1-implementation SHARED ${SOURCES_CORE_IMPL})
 add_library(testbed1::testbed1-implementation ALIAS testbed1-implementation)
@@ -35,6 +36,7 @@ set (SOURCES_TEST
     ${CMAKE_CURRENT_SOURCE_DIR}/../generated/core/testbed1.test.cpp
     structinterface.test.cpp
     structarrayinterface.test.cpp
+    structarray2interface.test.cpp
 )
 add_executable(test_testbed1
     ${SOURCES_TEST}

--- a/goldenmaster/modules/testbed1/implementation/structarray2interface.cpp
+++ b/goldenmaster/modules/testbed1/implementation/structarray2interface.cpp
@@ -1,0 +1,185 @@
+
+
+#include "testbed1/implementation/structarray2interface.h"
+#include "testbed1/generated/core/structarray2interface.publisher.h"
+#include "testbed1/generated/core/structarray2interface.data.h"
+
+using namespace Test::Testbed1;
+
+StructArray2Interface::StructArray2Interface()
+    : m_publisher(std::make_unique<StructArray2InterfacePublisher>())
+{
+}
+StructArray2Interface::~StructArray2Interface()
+{
+}
+
+void StructArray2Interface::setPropBool(const StructBoolWithArray& propBool)
+{
+    if (m_data.m_propBool != propBool) {
+        m_data.m_propBool = propBool;
+        m_publisher->publishPropBoolChanged(propBool);
+    }
+}
+
+const StructBoolWithArray& StructArray2Interface::getPropBool() const
+{
+    return m_data.m_propBool;
+}
+
+void StructArray2Interface::setPropInt(const StructIntWithArray& propInt)
+{
+    if (m_data.m_propInt != propInt) {
+        m_data.m_propInt = propInt;
+        m_publisher->publishPropIntChanged(propInt);
+    }
+}
+
+const StructIntWithArray& StructArray2Interface::getPropInt() const
+{
+    return m_data.m_propInt;
+}
+
+void StructArray2Interface::setPropFloat(const StructFloatWithArray& propFloat)
+{
+    if (m_data.m_propFloat != propFloat) {
+        m_data.m_propFloat = propFloat;
+        m_publisher->publishPropFloatChanged(propFloat);
+    }
+}
+
+const StructFloatWithArray& StructArray2Interface::getPropFloat() const
+{
+    return m_data.m_propFloat;
+}
+
+void StructArray2Interface::setPropString(const StructStringWithArray& propString)
+{
+    if (m_data.m_propString != propString) {
+        m_data.m_propString = propString;
+        m_publisher->publishPropStringChanged(propString);
+    }
+}
+
+const StructStringWithArray& StructArray2Interface::getPropString() const
+{
+    return m_data.m_propString;
+}
+
+void StructArray2Interface::setPropEnum(const StructEnumWithArray& propEnum)
+{
+    if (m_data.m_propEnum != propEnum) {
+        m_data.m_propEnum = propEnum;
+        m_publisher->publishPropEnumChanged(propEnum);
+    }
+}
+
+const StructEnumWithArray& StructArray2Interface::getPropEnum() const
+{
+    return m_data.m_propEnum;
+}
+
+std::list<StructBool> StructArray2Interface::funcBool(const StructBoolWithArray& paramBool)
+{
+    (void) paramBool; // suppress the 'Unreferenced Formal Parameter' warning.
+    // do business logic here
+    return std::list<StructBool>();
+}
+
+std::future<std::list<StructBool>> StructArray2Interface::funcBoolAsync(const StructBoolWithArray& paramBool, std::function<void(std::list<StructBool>)> callback)
+{
+    return std::async(std::launch::async, [this, callback,
+                    paramBool]()
+        {auto result = funcBool(paramBool);
+            if (callback)
+            {
+                callback(result);
+            }return result;
+        }
+    );
+}
+
+std::list<StructInt> StructArray2Interface::funcInt(const StructIntWithArray& paramInt)
+{
+    (void) paramInt; // suppress the 'Unreferenced Formal Parameter' warning.
+    // do business logic here
+    return std::list<StructInt>();
+}
+
+std::future<std::list<StructInt>> StructArray2Interface::funcIntAsync(const StructIntWithArray& paramInt, std::function<void(std::list<StructInt>)> callback)
+{
+    return std::async(std::launch::async, [this, callback,
+                    paramInt]()
+        {auto result = funcInt(paramInt);
+            if (callback)
+            {
+                callback(result);
+            }return result;
+        }
+    );
+}
+
+std::list<StructFloat> StructArray2Interface::funcFloat(const StructFloatWithArray& paramFloat)
+{
+    (void) paramFloat; // suppress the 'Unreferenced Formal Parameter' warning.
+    // do business logic here
+    return std::list<StructFloat>();
+}
+
+std::future<std::list<StructFloat>> StructArray2Interface::funcFloatAsync(const StructFloatWithArray& paramFloat, std::function<void(std::list<StructFloat>)> callback)
+{
+    return std::async(std::launch::async, [this, callback,
+                    paramFloat]()
+        {auto result = funcFloat(paramFloat);
+            if (callback)
+            {
+                callback(result);
+            }return result;
+        }
+    );
+}
+
+std::list<StructString> StructArray2Interface::funcString(const StructStringWithArray& paramString)
+{
+    (void) paramString; // suppress the 'Unreferenced Formal Parameter' warning.
+    // do business logic here
+    return std::list<StructString>();
+}
+
+std::future<std::list<StructString>> StructArray2Interface::funcStringAsync(const StructStringWithArray& paramString, std::function<void(std::list<StructString>)> callback)
+{
+    return std::async(std::launch::async, [this, callback,
+                    paramString]()
+        {auto result = funcString(paramString);
+            if (callback)
+            {
+                callback(result);
+            }return result;
+        }
+    );
+}
+
+std::list<Enum0Enum> StructArray2Interface::funcEnum(const StructEnumWithArray& paramEnum)
+{
+    (void) paramEnum; // suppress the 'Unreferenced Formal Parameter' warning.
+    // do business logic here
+    return std::list<Enum0Enum>();
+}
+
+std::future<std::list<Enum0Enum>> StructArray2Interface::funcEnumAsync(const StructEnumWithArray& paramEnum, std::function<void(std::list<Enum0Enum>)> callback)
+{
+    return std::async(std::launch::async, [this, callback,
+                    paramEnum]()
+        {auto result = funcEnum(paramEnum);
+            if (callback)
+            {
+                callback(result);
+            }return result;
+        }
+    );
+}
+
+IStructArray2InterfacePublisher& StructArray2Interface::_getPublisher() const
+{
+    return *m_publisher;
+}

--- a/goldenmaster/modules/testbed1/implementation/structarray2interface.h
+++ b/goldenmaster/modules/testbed1/implementation/structarray2interface.h
@@ -1,0 +1,62 @@
+
+#pragma once
+#include "testbed1/generated/api/testbed1.h"
+#include "testbed1/generated/api/common.h"
+#include "testbed1/generated/core/structarray2interface.data.h"
+#include <memory>
+
+namespace Test {
+namespace Testbed1 {
+
+/**
+* The StructArray2Interface implementation.
+*/
+class TEST_TESTBED1_EXPORT StructArray2Interface : public IStructArray2Interface
+{
+public:
+    explicit StructArray2Interface();
+    ~StructArray2Interface();
+public:
+    void setPropBool(const StructBoolWithArray& propBool) override;
+    const StructBoolWithArray& getPropBool() const override;
+    
+    void setPropInt(const StructIntWithArray& propInt) override;
+    const StructIntWithArray& getPropInt() const override;
+    
+    void setPropFloat(const StructFloatWithArray& propFloat) override;
+    const StructFloatWithArray& getPropFloat() const override;
+    
+    void setPropString(const StructStringWithArray& propString) override;
+    const StructStringWithArray& getPropString() const override;
+    
+    void setPropEnum(const StructEnumWithArray& propEnum) override;
+    const StructEnumWithArray& getPropEnum() const override;
+    
+    std::list<StructBool> funcBool(const StructBoolWithArray& paramBool) override;
+    std::future<std::list<StructBool>> funcBoolAsync(const StructBoolWithArray& paramBool, std::function<void(std::list<StructBool>)> callback = nullptr) override;
+        
+    std::list<StructInt> funcInt(const StructIntWithArray& paramInt) override;
+    std::future<std::list<StructInt>> funcIntAsync(const StructIntWithArray& paramInt, std::function<void(std::list<StructInt>)> callback = nullptr) override;
+        
+    std::list<StructFloat> funcFloat(const StructFloatWithArray& paramFloat) override;
+    std::future<std::list<StructFloat>> funcFloatAsync(const StructFloatWithArray& paramFloat, std::function<void(std::list<StructFloat>)> callback = nullptr) override;
+        
+    std::list<StructString> funcString(const StructStringWithArray& paramString) override;
+    std::future<std::list<StructString>> funcStringAsync(const StructStringWithArray& paramString, std::function<void(std::list<StructString>)> callback = nullptr) override;
+        
+    std::list<Enum0Enum> funcEnum(const StructEnumWithArray& paramEnum) override;
+    std::future<std::list<Enum0Enum>> funcEnumAsync(const StructEnumWithArray& paramEnum, std::function<void(std::list<Enum0Enum>)> callback = nullptr) override;
+        
+    /**
+    * Access to a publisher, use it to subscribe for StructArray2Interface changes and signal emission.
+    * @return The publisher for StructArray2Interface.
+    */
+    IStructArray2InterfacePublisher& _getPublisher() const override;
+private:
+    /** The publisher for the StructArray2Interface. */
+    std::unique_ptr<IStructArray2InterfacePublisher> m_publisher;
+    /** The helper structure to store all the properties for StructArray2Interface. */
+    StructArray2InterfaceData m_data;
+};
+} // namespace Testbed1
+} // namespace Test

--- a/goldenmaster/modules/testbed1/implementation/structarray2interface.test.cpp
+++ b/goldenmaster/modules/testbed1/implementation/structarray2interface.test.cpp
@@ -1,0 +1,130 @@
+#include <memory>
+#include "catch2/catch.hpp"
+#include "testbed1/implementation/structarray2interface.h"
+#include "apigear/utilities/fuzzy_compare.h"
+
+using namespace Test::Testbed1;
+TEST_CASE("Testing StructArray2Interface", "[StructArray2Interface]"){
+    std::unique_ptr<IStructArray2Interface> testStructArray2Interface = std::make_unique<StructArray2Interface>();
+    // setup your test
+    SECTION("Test operation funcBool") {
+        // Do implement test here
+        testStructArray2Interface->funcBool(StructBoolWithArray());
+    }
+
+    SECTION("Test operation async funcBool") {
+        // Do implement test here
+
+        auto future = testStructArray2Interface->funcBoolAsync(StructBoolWithArray());
+    }
+
+    SECTION("Test operation async funcBool with a callback") {
+        // Do implement test here
+
+        auto future = testStructArray2Interface->funcBoolAsync(StructBoolWithArray(),[](std::list<StructBool> value){ (void)value; /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ }
+            );
+    }
+    SECTION("Test operation funcInt") {
+        // Do implement test here
+        testStructArray2Interface->funcInt(StructIntWithArray());
+    }
+
+    SECTION("Test operation async funcInt") {
+        // Do implement test here
+
+        auto future = testStructArray2Interface->funcIntAsync(StructIntWithArray());
+    }
+
+    SECTION("Test operation async funcInt with a callback") {
+        // Do implement test here
+
+        auto future = testStructArray2Interface->funcIntAsync(StructIntWithArray(),[](std::list<StructInt> value){ (void)value; /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ }
+            );
+    }
+    SECTION("Test operation funcFloat") {
+        // Do implement test here
+        testStructArray2Interface->funcFloat(StructFloatWithArray());
+    }
+
+    SECTION("Test operation async funcFloat") {
+        // Do implement test here
+
+        auto future = testStructArray2Interface->funcFloatAsync(StructFloatWithArray());
+    }
+
+    SECTION("Test operation async funcFloat with a callback") {
+        // Do implement test here
+
+        auto future = testStructArray2Interface->funcFloatAsync(StructFloatWithArray(),[](std::list<StructFloat> value){ (void)value; /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ }
+            );
+    }
+    SECTION("Test operation funcString") {
+        // Do implement test here
+        testStructArray2Interface->funcString(StructStringWithArray());
+    }
+
+    SECTION("Test operation async funcString") {
+        // Do implement test here
+
+        auto future = testStructArray2Interface->funcStringAsync(StructStringWithArray());
+    }
+
+    SECTION("Test operation async funcString with a callback") {
+        // Do implement test here
+
+        auto future = testStructArray2Interface->funcStringAsync(StructStringWithArray(),[](std::list<StructString> value){ (void)value; /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ }
+            );
+    }
+    SECTION("Test operation funcEnum") {
+        // Do implement test here
+        testStructArray2Interface->funcEnum(StructEnumWithArray());
+    }
+
+    SECTION("Test operation async funcEnum") {
+        // Do implement test here
+
+        auto future = testStructArray2Interface->funcEnumAsync(StructEnumWithArray());
+    }
+
+    SECTION("Test operation async funcEnum with a callback") {
+        // Do implement test here
+
+        auto future = testStructArray2Interface->funcEnumAsync(StructEnumWithArray(),[](std::list<Enum0Enum> value){ (void)value; /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ }
+            );
+    }
+    SECTION("Test property propBool") {
+        // Do implement test here
+        testStructArray2Interface->setPropBool(StructBoolWithArray());
+        auto actual = testStructArray2Interface->getPropBool();
+        auto expected =  StructBoolWithArray();
+        REQUIRE(actual == expected);
+    }
+    SECTION("Test property propInt") {
+        // Do implement test here
+        testStructArray2Interface->setPropInt(StructIntWithArray());
+        auto actual = testStructArray2Interface->getPropInt();
+        auto expected =  StructIntWithArray();
+        REQUIRE(actual == expected);
+    }
+    SECTION("Test property propFloat") {
+        // Do implement test here
+        testStructArray2Interface->setPropFloat(StructFloatWithArray());
+        auto actual = testStructArray2Interface->getPropFloat();
+        auto expected =  StructFloatWithArray();
+        REQUIRE(actual == expected);
+    }
+    SECTION("Test property propString") {
+        // Do implement test here
+        testStructArray2Interface->setPropString(StructStringWithArray());
+        auto actual = testStructArray2Interface->getPropString();
+        auto expected =  StructStringWithArray();
+        REQUIRE(actual == expected);
+    }
+    SECTION("Test property propEnum") {
+        // Do implement test here
+        testStructArray2Interface->setPropEnum(StructEnumWithArray());
+        auto actual = testStructArray2Interface->getPropEnum();
+        auto expected =  StructEnumWithArray();
+        REQUIRE(actual == expected);
+    }
+}

--- a/goldenmaster/modules/testbed1/implementation/structarrayinterface.cpp
+++ b/goldenmaster/modules/testbed1/implementation/structarrayinterface.cpp
@@ -66,6 +66,19 @@ const std::list<StructString>& StructArrayInterface::getPropString() const
     return m_data.m_propString;
 }
 
+void StructArrayInterface::setPropEnum(const std::list<Enum0Enum>& propEnum)
+{
+    if (m_data.m_propEnum != propEnum) {
+        m_data.m_propEnum = propEnum;
+        m_publisher->publishPropEnumChanged(propEnum);
+    }
+}
+
+const std::list<Enum0Enum>& StructArrayInterface::getPropEnum() const
+{
+    return m_data.m_propEnum;
+}
+
 std::list<StructBool> StructArrayInterface::funcBool(const std::list<StructBool>& paramBool)
 {
     (void) paramBool; // suppress the 'Unreferenced Formal Parameter' warning.
@@ -138,6 +151,26 @@ std::future<std::list<StructString>> StructArrayInterface::funcStringAsync(const
     return std::async(std::launch::async, [this, callback,
                     paramString]()
         {auto result = funcString(paramString);
+            if (callback)
+            {
+                callback(result);
+            }return result;
+        }
+    );
+}
+
+std::list<Enum0Enum> StructArrayInterface::funcEnum(const std::list<Enum0Enum>& paramEnum)
+{
+    (void) paramEnum; // suppress the 'Unreferenced Formal Parameter' warning.
+    // do business logic here
+    return std::list<Enum0Enum>();
+}
+
+std::future<std::list<Enum0Enum>> StructArrayInterface::funcEnumAsync(const std::list<Enum0Enum>& paramEnum, std::function<void(std::list<Enum0Enum>)> callback)
+{
+    return std::async(std::launch::async, [this, callback,
+                    paramEnum]()
+        {auto result = funcEnum(paramEnum);
             if (callback)
             {
                 callback(result);

--- a/goldenmaster/modules/testbed1/implementation/structarrayinterface.h
+++ b/goldenmaster/modules/testbed1/implementation/structarrayinterface.h
@@ -29,6 +29,9 @@ public:
     void setPropString(const std::list<StructString>& propString) override;
     const std::list<StructString>& getPropString() const override;
     
+    void setPropEnum(const std::list<Enum0Enum>& propEnum) override;
+    const std::list<Enum0Enum>& getPropEnum() const override;
+    
     std::list<StructBool> funcBool(const std::list<StructBool>& paramBool) override;
     std::future<std::list<StructBool>> funcBoolAsync(const std::list<StructBool>& paramBool, std::function<void(std::list<StructBool>)> callback = nullptr) override;
         
@@ -40,6 +43,9 @@ public:
         
     std::list<StructString> funcString(const std::list<StructString>& paramString) override;
     std::future<std::list<StructString>> funcStringAsync(const std::list<StructString>& paramString, std::function<void(std::list<StructString>)> callback = nullptr) override;
+        
+    std::list<Enum0Enum> funcEnum(const std::list<Enum0Enum>& paramEnum) override;
+    std::future<std::list<Enum0Enum>> funcEnumAsync(const std::list<Enum0Enum>& paramEnum, std::function<void(std::list<Enum0Enum>)> callback = nullptr) override;
         
     /**
     * Access to a publisher, use it to subscribe for StructArrayInterface changes and signal emission.

--- a/goldenmaster/modules/testbed1/implementation/structarrayinterface.test.cpp
+++ b/goldenmaster/modules/testbed1/implementation/structarrayinterface.test.cpp
@@ -75,6 +75,23 @@ TEST_CASE("Testing StructArrayInterface", "[StructArrayInterface]"){
         auto future = testStructArrayInterface->funcStringAsync(std::list<StructString>(),[](std::list<StructString> value){ (void)value; /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ }
             );
     }
+    SECTION("Test operation funcEnum") {
+        // Do implement test here
+        testStructArrayInterface->funcEnum(std::list<Enum0Enum>());
+    }
+
+    SECTION("Test operation async funcEnum") {
+        // Do implement test here
+
+        auto future = testStructArrayInterface->funcEnumAsync(std::list<Enum0Enum>());
+    }
+
+    SECTION("Test operation async funcEnum with a callback") {
+        // Do implement test here
+
+        auto future = testStructArrayInterface->funcEnumAsync(std::list<Enum0Enum>(),[](std::list<Enum0Enum> value){ (void)value; /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ }
+            );
+    }
     SECTION("Test property propBool") {
         // Do implement test here
         testStructArrayInterface->setPropBool(std::list<StructBool>());
@@ -101,6 +118,13 @@ TEST_CASE("Testing StructArrayInterface", "[StructArrayInterface]"){
         testStructArrayInterface->setPropString(std::list<StructString>());
         auto actual = testStructArrayInterface->getPropString();
         auto expected =  std::list<StructString>();
+        REQUIRE(actual == expected);
+    }
+    SECTION("Test property propEnum") {
+        // Do implement test here
+        testStructArrayInterface->setPropEnum(std::list<Enum0Enum>());
+        auto actual = testStructArrayInterface->getPropEnum();
+        auto expected =  std::list<Enum0Enum>();
         REQUIRE(actual == expected);
     }
 }

--- a/goldenmaster/modules/testbed2/generated/api/nestedstruct1interface.api.h
+++ b/goldenmaster/modules/testbed2/generated/api/nestedstruct1interface.api.h
@@ -28,6 +28,22 @@ public:
     virtual ~INestedStruct1Interface() = default;
 
 
+    virtual void funcNoReturnValue(const NestedStruct1& param1) = 0;
+    /**
+    * Asynchronous version of funcNoReturnValue(const NestedStruct1& param1)
+    * @return Promise of type void which is set once the function has completed
+    */
+    virtual std::future<void> funcNoReturnValueAsync(const NestedStruct1& param1, std::function<void(void)> callback = nullptr) = 0;
+
+
+    virtual NestedStruct1 funcNoParams() = 0;
+    /**
+    * Asynchronous version of funcNoParams()
+    * @return Promise of type NestedStruct1 which is set once the function has completed
+    */
+    virtual std::future<NestedStruct1> funcNoParamsAsync( std::function<void(NestedStruct1)> callback = nullptr) = 0;
+
+
     virtual NestedStruct1 func1(const NestedStruct1& param1) = 0;
     /**
     * Asynchronous version of func1(const NestedStruct1& param1)

--- a/goldenmaster/modules/testbed2/generated/core/nestedstruct1interface.threadsafedecorator.cpp
+++ b/goldenmaster/modules/testbed2/generated/core/nestedstruct1interface.threadsafedecorator.cpp
@@ -7,6 +7,24 @@ NestedStruct1InterfaceThreadSafeDecorator::NestedStruct1InterfaceThreadSafeDecor
     : m_impl(impl)
 {
 }
+void NestedStruct1InterfaceThreadSafeDecorator::funcNoReturnValue(const NestedStruct1& param1)
+{
+    return m_impl->funcNoReturnValue(param1);
+}
+
+std::future<void> NestedStruct1InterfaceThreadSafeDecorator::funcNoReturnValueAsync(const NestedStruct1& param1, std::function<void(void)> callback)
+{
+    return m_impl->funcNoReturnValueAsync(param1, callback);
+}
+NestedStruct1 NestedStruct1InterfaceThreadSafeDecorator::funcNoParams()
+{
+    return m_impl->funcNoParams();
+}
+
+std::future<NestedStruct1> NestedStruct1InterfaceThreadSafeDecorator::funcNoParamsAsync( std::function<void(NestedStruct1)> callback)
+{
+    return m_impl->funcNoParamsAsync( callback);
+}
 NestedStruct1 NestedStruct1InterfaceThreadSafeDecorator::func1(const NestedStruct1& param1)
 {
     return m_impl->func1(param1);

--- a/goldenmaster/modules/testbed2/generated/core/nestedstruct1interface.threadsafedecorator.h
+++ b/goldenmaster/modules/testbed2/generated/core/nestedstruct1interface.threadsafedecorator.h
@@ -43,6 +43,28 @@ public:
     * Forwards call to NestedStruct1Interface implementation.
     * @warning This forward call is not made thread safe by this class.
     */
+    void funcNoReturnValue(const NestedStruct1& param1) override;
+    /** 
+    * Forwards call to NestedStruct1Interface implementation.
+    * @warning This forward call is not made thread safe by this class.
+    */
+    std::future<void> funcNoReturnValueAsync(const NestedStruct1& param1, std::function<void(void)> callback = nullptr) override;
+
+    /** 
+    * Forwards call to NestedStruct1Interface implementation.
+    * @warning This forward call is not made thread safe by this class.
+    */
+    NestedStruct1 funcNoParams() override;
+    /** 
+    * Forwards call to NestedStruct1Interface implementation.
+    * @warning This forward call is not made thread safe by this class.
+    */
+    std::future<NestedStruct1> funcNoParamsAsync( std::function<void(NestedStruct1)> callback = nullptr) override;
+
+    /** 
+    * Forwards call to NestedStruct1Interface implementation.
+    * @warning This forward call is not made thread safe by this class.
+    */
     NestedStruct1 func1(const NestedStruct1& param1) override;
     /** 
     * Forwards call to NestedStruct1Interface implementation.

--- a/goldenmaster/modules/testbed2/generated/monitor/nestedstruct1interface.tracedecorator.cpp
+++ b/goldenmaster/modules/testbed2/generated/monitor/nestedstruct1interface.tracedecorator.cpp
@@ -19,6 +19,26 @@ std::unique_ptr<NestedStruct1InterfaceTraceDecorator> NestedStruct1InterfaceTrac
 {
     return std::unique_ptr<NestedStruct1InterfaceTraceDecorator>(new NestedStruct1InterfaceTraceDecorator(impl, tracer));
 }
+void NestedStruct1InterfaceTraceDecorator::funcNoReturnValue(const NestedStruct1& param1)
+{
+    m_tracer->trace_funcNoReturnValue(param1);
+    return m_impl.funcNoReturnValue(param1);
+}
+std::future<void> NestedStruct1InterfaceTraceDecorator::funcNoReturnValueAsync(const NestedStruct1& param1, std::function<void(void)> callback)
+{
+    m_tracer->trace_funcNoReturnValue(param1);
+    return m_impl.funcNoReturnValueAsync(param1, callback);
+}
+NestedStruct1 NestedStruct1InterfaceTraceDecorator::funcNoParams()
+{
+    m_tracer->trace_funcNoParams();
+    return m_impl.funcNoParams();
+}
+std::future<NestedStruct1> NestedStruct1InterfaceTraceDecorator::funcNoParamsAsync( std::function<void(NestedStruct1)> callback)
+{
+    m_tracer->trace_funcNoParams();
+    return m_impl.funcNoParamsAsync( callback);
+}
 NestedStruct1 NestedStruct1InterfaceTraceDecorator::func1(const NestedStruct1& param1)
 {
     m_tracer->trace_func1(param1);

--- a/goldenmaster/modules/testbed2/generated/monitor/nestedstruct1interface.tracedecorator.h
+++ b/goldenmaster/modules/testbed2/generated/monitor/nestedstruct1interface.tracedecorator.h
@@ -34,6 +34,16 @@ public:
     */
     virtual ~NestedStruct1InterfaceTraceDecorator();
 
+    /** Traces funcNoReturnValue and forwards call to NestedStruct1Interface implementation. */
+    void funcNoReturnValue(const NestedStruct1& param1) override;
+    /** Traces funcNoReturnValue and forwards call to NestedStruct1Interface implementation. */
+    std::future<void> funcNoReturnValueAsync(const NestedStruct1& param1, std::function<void(void)> callback = nullptr) override;
+    
+    /** Traces funcNoParams and forwards call to NestedStruct1Interface implementation. */
+    NestedStruct1 funcNoParams() override;
+    /** Traces funcNoParams and forwards call to NestedStruct1Interface implementation. */
+    std::future<NestedStruct1> funcNoParamsAsync( std::function<void(NestedStruct1)> callback = nullptr) override;
+    
     /** Traces func1 and forwards call to NestedStruct1Interface implementation. */
     NestedStruct1 func1(const NestedStruct1& param1) override;
     /** Traces func1 and forwards call to NestedStruct1Interface implementation. */

--- a/goldenmaster/modules/testbed2/generated/monitor/nestedstruct1interface.tracer.cpp
+++ b/goldenmaster/modules/testbed2/generated/monitor/nestedstruct1interface.tracer.cpp
@@ -16,6 +16,19 @@ void NestedStruct1InterfaceTracer::capture_state(INestedStruct1Interface* obj)
     m_tracer.state("testbed2.NestedStruct1Interface#_state", fields_);
 }
 
+void NestedStruct1InterfaceTracer::trace_funcNoReturnValue(const NestedStruct1& param1)
+{
+    nlohmann::json fields_;
+    fields_["param1"] = param1;
+    m_tracer.call("testbed2.NestedStruct1Interface#funcNoReturnValue", fields_);
+}
+
+void NestedStruct1InterfaceTracer::trace_funcNoParams()
+{
+    nlohmann::json fields_;
+    m_tracer.call("testbed2.NestedStruct1Interface#funcNoParams", fields_);
+}
+
 void NestedStruct1InterfaceTracer::trace_func1(const NestedStruct1& param1)
 {
     nlohmann::json fields_;

--- a/goldenmaster/modules/testbed2/generated/monitor/nestedstruct1interface.tracer.h
+++ b/goldenmaster/modules/testbed2/generated/monitor/nestedstruct1interface.tracer.h
@@ -27,6 +27,16 @@ public:
   */
   void capture_state(INestedStruct1Interface* obj);
   /**
+  * Prepares information about the funcNoReturnValue call in a nlohmann::json format and puts to a tracer.
+  * @param The NestedStruct1Interface object to trace.
+  */
+  void trace_funcNoReturnValue(const NestedStruct1& param1);
+  /**
+  * Prepares information about the funcNoParams call in a nlohmann::json format and puts to a tracer.
+  * @param The NestedStruct1Interface object to trace.
+  */
+  void trace_funcNoParams();
+  /**
   * Prepares information about the func1 call in a nlohmann::json format and puts to a tracer.
   * @param The NestedStruct1Interface object to trace.
   */

--- a/goldenmaster/modules/testbed2/generated/mqtt/nestedstruct1interfaceclient.cpp
+++ b/goldenmaster/modules/testbed2/generated/mqtt/nestedstruct1interfaceclient.cpp
@@ -31,6 +31,8 @@ std::map<std::string, ApiGear::MQTT::CallbackFunction> NestedStruct1InterfaceCli
     return {
         { std::string("testbed2/NestedStruct1Interface/prop/prop1"), [this](const std::string& args, const std::string&, const std::string&){ this->setProp1Local(args); } },
         { std::string("testbed2/NestedStruct1Interface/sig/sig1"), [this](const std::string& args, const std::string&, const std::string&){ this->onSig1(args); } },
+        { std::string("testbed2/NestedStruct1Interface/rpc/funcNoReturnValue/"+clientId+"/result"), [this](const std::string& args, const std::string&, const std::string& correlationData){ this->onInvokeReply(args, correlationData); } },
+        { std::string("testbed2/NestedStruct1Interface/rpc/funcNoParams/"+clientId+"/result"), [this](const std::string& args, const std::string&, const std::string& correlationData){ this->onInvokeReply(args, correlationData); } },
         { std::string("testbed2/NestedStruct1Interface/rpc/func1/"+clientId+"/result"), [this](const std::string& args, const std::string&, const std::string& correlationData){ this->onInvokeReply(args, correlationData); } },
     };
 };
@@ -62,6 +64,71 @@ void NestedStruct1InterfaceClient::setProp1Local(const std::string& args)
 const NestedStruct1& NestedStruct1InterfaceClient::getProp1() const
 {
     return m_data.m_prop1;
+}
+
+void NestedStruct1InterfaceClient::funcNoReturnValue(const NestedStruct1& param1)
+{
+    if(m_client == nullptr) {
+        return;
+    }
+    funcNoReturnValueAsync(param1);
+}
+
+std::future<void> NestedStruct1InterfaceClient::funcNoReturnValueAsync(const NestedStruct1& param1, std::function<void(void)> callback)
+{
+    if(m_client == nullptr) {
+        throw std::runtime_error("Client is not initialized");
+    }
+    return std::async(std::launch::async, [this, callback,
+                    param1]()
+        {
+            std::promise<void> resultPromise;
+            static const auto topic = std::string("testbed2/NestedStruct1Interface/rpc/funcNoReturnValue");
+            static const auto responseTopic = std::string(topic + "/" + m_client->getClientId() + "/result");
+            auto responseId = 0; //Not used, the service won't respond, no handler is added for response.
+            m_client->invokeRemote(topic, responseTopic, nlohmann::json::array({param1}).dump(), responseId);
+            resultPromise.set_value();
+            if (callback)
+            {
+                callback();
+            }
+            return resultPromise.get_future().get();
+        }
+    );
+}
+
+NestedStruct1 NestedStruct1InterfaceClient::funcNoParams()
+{
+    if(m_client == nullptr) {
+        return NestedStruct1();
+    }
+    NestedStruct1 value(funcNoParamsAsync().get());
+    return value;
+}
+
+std::future<NestedStruct1> NestedStruct1InterfaceClient::funcNoParamsAsync( std::function<void(NestedStruct1)> callback)
+{
+    if(m_client == nullptr) {
+        throw std::runtime_error("Client is not initialized");
+    }
+    return std::async(std::launch::async, [this, callback]()
+        {
+            std::promise<NestedStruct1> resultPromise;
+            static const auto topic = std::string("testbed2/NestedStruct1Interface/rpc/funcNoParams");
+            static const auto responseTopic = std::string(topic + "/" + m_client->getClientId() + "/result");
+            ApiGear::MQTT::InvokeReplyFunc responseHandler = [&resultPromise, callback](ApiGear::MQTT::InvokeReplyArg arg) {
+                const NestedStruct1& value = arg.value.get<NestedStruct1>();
+                resultPromise.set_value(value);
+                if (callback)
+                {
+                    callback(value);
+                }
+            };
+            auto responseId = registerResponseHandler(responseHandler);
+            m_client->invokeRemote(topic, responseTopic, nlohmann::json::array({}).dump(), responseId);
+            return resultPromise.get_future().get();
+        }
+    );
 }
 
 NestedStruct1 NestedStruct1InterfaceClient::func1(const NestedStruct1& param1)

--- a/goldenmaster/modules/testbed2/generated/mqtt/nestedstruct1interfaceclient.h
+++ b/goldenmaster/modules/testbed2/generated/mqtt/nestedstruct1interfaceclient.h
@@ -30,6 +30,10 @@ public:
     virtual ~NestedStruct1InterfaceClient() override;
     const NestedStruct1& getProp1() const override;
     void setProp1(const NestedStruct1& prop1) override;
+    void funcNoReturnValue(const NestedStruct1& param1) override;
+    std::future<void> funcNoReturnValueAsync(const NestedStruct1& param1, std::function<void(void)> callback = nullptr) override;
+    NestedStruct1 funcNoParams() override;
+    std::future<NestedStruct1> funcNoParamsAsync( std::function<void(NestedStruct1)> callback = nullptr) override;
     NestedStruct1 func1(const NestedStruct1& param1) override;
     std::future<NestedStruct1> func1Async(const NestedStruct1& param1, std::function<void(NestedStruct1)> callback = nullptr) override;
     INestedStruct1InterfacePublisher& _getPublisher() const override;

--- a/goldenmaster/modules/testbed2/generated/mqtt/nestedstruct1interfaceservice.cpp
+++ b/goldenmaster/modules/testbed2/generated/mqtt/nestedstruct1interfaceservice.cpp
@@ -26,6 +26,8 @@ std::map<std::string, ApiGear::MQTT::CallbackFunction> NestedStruct1InterfaceSer
 {
     return {
         {std::string("testbed2/NestedStruct1Interface/set/prop1"), [this](const std::string& args, const std::string&, const std::string&){ this->onSetProp1(args); } },
+        {std::string("testbed2/NestedStruct1Interface/rpc/funcNoReturnValue"), [this](const std::string& args, const std::string& responseTopic, const std::string& correlationData) { this->onInvokeFuncNoReturnValue(args, responseTopic, correlationData); } },
+        {std::string("testbed2/NestedStruct1Interface/rpc/funcNoParams"), [this](const std::string& args, const std::string& responseTopic, const std::string& correlationData) { this->onInvokeFuncNoParams(args, responseTopic, correlationData); } },
         {std::string("testbed2/NestedStruct1Interface/rpc/func1"), [this](const std::string& args, const std::string& responseTopic, const std::string& correlationData) { this->onInvokeFunc1(args, responseTopic, correlationData); } },
     };
 }
@@ -49,6 +51,20 @@ void NestedStruct1InterfaceService::onSetProp1(const std::string& args) const
 
     auto prop1 = json_args.get<NestedStruct1>();
     m_impl->setProp1(prop1);
+}
+void NestedStruct1InterfaceService::onInvokeFuncNoReturnValue(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    (void) responseTopic;
+    (void) correlationData;
+    const NestedStruct1& param1 = json_args.at(0).get<NestedStruct1>();
+    m_impl->funcNoReturnValue(param1);
+}
+void NestedStruct1InterfaceService::onInvokeFuncNoParams(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    auto result = m_impl->funcNoParams();
+    m_service->notifyInvokeResponse(responseTopic, nlohmann::json(result).dump(), correlationData);
 }
 void NestedStruct1InterfaceService::onInvokeFunc1(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const
 {

--- a/goldenmaster/modules/testbed2/generated/mqtt/nestedstruct1interfaceservice.h
+++ b/goldenmaster/modules/testbed2/generated/mqtt/nestedstruct1interfaceservice.h
@@ -23,6 +23,8 @@ private:
     std::map<std::string, ApiGear::MQTT::CallbackFunction> createTopicMap();
 
     void onConnectionStatusChanged(bool connectionStatus);
+    void onInvokeFuncNoReturnValue(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const;
+    void onInvokeFuncNoParams(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const;
     void onInvokeFunc1(const std::string& args, const std::string& responseTopic, const std::string& correlationData) const;
     void onProp1Changed(const NestedStruct1& prop1) override;
     /// @brief requests to set the value for the property Prop1 coming from the client

--- a/goldenmaster/modules/testbed2/generated/mqtt/tests/test_nestedstruct1interface.cpp
+++ b/goldenmaster/modules/testbed2/generated/mqtt/tests/test_nestedstruct1interface.cpp
@@ -111,6 +111,50 @@ TEST_CASE("mqtt  testbed2 NestedStruct1Interface tests")
         REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&issig1Emitted ]() {return issig1Emitted   == true; }));
         lock.unlock();
     }
+    SECTION("Test method funcNoReturnValue")
+    {
+         clientNestedStruct1Interface->funcNoReturnValue(Testbed2::NestedStruct1());
+        // CHECK EFFECTS OF YOUR METHOD AFER FUTURE IS DONE
+    }
+    SECTION("Test method funcNoReturnValue async")
+    {
+        auto resultFuture = clientNestedStruct1Interface->funcNoReturnValueAsync(Testbed2::NestedStruct1());
+        // The void function only sends request. It does not wait for the actual function on server side to be finished.
+    }
+
+    SECTION("Test method funcNoReturnValue async with callback")
+    {
+        auto resultFuture = clientNestedStruct1Interface->funcNoReturnValueAsync(Testbed2::NestedStruct1(),[](){/* you can add a callback, but it will be called right after sending the request. It does not wait for the actual function on server side to be finished. */ });
+    }
+    SECTION("Test method funcNoParams")
+    {
+        [[maybe_unused]] auto result =  clientNestedStruct1Interface->funcNoParams();
+        // CHECK EFFECTS OF YOUR METHOD AFER FUTURE IS DONE
+    }
+    SECTION("Test method funcNoParams async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientNestedStruct1Interface->funcNoParamsAsync();
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == Testbed2::NestedStruct1()); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    SECTION("Test method funcNoParams async with callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientNestedStruct1Interface->funcNoParamsAsync([&finished, &m_wait](NestedStruct1 value){ (void) value; finished = true; m_wait.notify_all(); /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ });
+
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == Testbed2::NestedStruct1()); 
+    }
     SECTION("Test method func1")
     {
         [[maybe_unused]] auto result =  clientNestedStruct1Interface->func1(Testbed2::NestedStruct1());

--- a/goldenmaster/modules/testbed2/generated/nats/nestedstruct1interfaceclient.cpp
+++ b/goldenmaster/modules/testbed2/generated/nats/nestedstruct1interfaceclient.cpp
@@ -112,6 +112,83 @@ void NestedStruct1InterfaceClient::handleInit(const std::string& value)
     }
 }
 
+void NestedStruct1InterfaceClient::funcNoReturnValue(const NestedStruct1& param1)
+{
+    if(m_client == nullptr) {
+        return;
+    }
+    funcNoReturnValueAsync(param1);
+}
+
+std::future<void> NestedStruct1InterfaceClient::funcNoReturnValueAsync(const NestedStruct1& param1, std::function<void(void)> user_callback)
+{
+    if(m_client == nullptr) {
+        throw std::runtime_error("Client is not initialized");
+    }
+    static const auto topic = std::string("testbed2.NestedStruct1Interface.rpc.funcNoReturnValue");
+
+    return std::async(std::launch::async, [this, user_callback,param1]()
+    {
+        std::promise<void> resultPromise;
+        auto callback = [&resultPromise, user_callback](const auto& result)
+        {
+            (void) result;
+            resultPromise.set_value();
+            if (user_callback)
+            {
+                user_callback();
+            }
+        };
+
+        m_client->request(topic,  nlohmann::json::array({param1}).dump(), callback);
+        return resultPromise.get_future().get();
+    });
+}
+
+NestedStruct1 NestedStruct1InterfaceClient::funcNoParams()
+{
+    if(m_client == nullptr) {
+        return NestedStruct1();
+    }
+    NestedStruct1 value(funcNoParamsAsync().get());
+    return value;
+}
+
+std::future<NestedStruct1> NestedStruct1InterfaceClient::funcNoParamsAsync( std::function<void(NestedStruct1)> user_callback)
+{
+    if(m_client == nullptr) {
+        throw std::runtime_error("Client is not initialized");
+    }
+    static const auto topic = std::string("testbed2.NestedStruct1Interface.rpc.funcNoParams");
+
+    return std::async(std::launch::async, [this, user_callback]()
+    {
+        std::promise<NestedStruct1> resultPromise;
+        auto callback = [&resultPromise, user_callback](const auto& result)
+        {
+            if (result.empty())
+            {
+                resultPromise.set_value(NestedStruct1());
+                if (user_callback)
+                {
+                    user_callback(NestedStruct1());
+                }
+                return;
+            }
+            nlohmann::json field = nlohmann::json::parse(result);
+            const NestedStruct1 value = field.get<NestedStruct1>();
+            resultPromise.set_value(value);
+            if (user_callback)
+            {
+                user_callback(value);
+            }
+        };
+
+        m_client->request(topic,  nlohmann::json::array({}).dump(), callback);
+        return resultPromise.get_future().get();
+    });
+}
+
 NestedStruct1 NestedStruct1InterfaceClient::func1(const NestedStruct1& param1)
 {
     if(m_client == nullptr) {

--- a/goldenmaster/modules/testbed2/generated/nats/nestedstruct1interfaceclient.h
+++ b/goldenmaster/modules/testbed2/generated/nats/nestedstruct1interfaceclient.h
@@ -34,6 +34,10 @@ public:
     void init();
     const NestedStruct1& getProp1() const override;
     void setProp1(const NestedStruct1& prop1) override;
+    void funcNoReturnValue(const NestedStruct1& param1) override;
+    std::future<void> funcNoReturnValueAsync(const NestedStruct1& param1, std::function<void(void)> callback = nullptr) override;
+    NestedStruct1 funcNoParams() override;
+    std::future<NestedStruct1> funcNoParamsAsync( std::function<void(NestedStruct1)> callback = nullptr) override;
     NestedStruct1 func1(const NestedStruct1& param1) override;
     std::future<NestedStruct1> func1Async(const NestedStruct1& param1, std::function<void(NestedStruct1)> callback = nullptr) override;
     INestedStruct1InterfacePublisher& _getPublisher() const override;

--- a/goldenmaster/modules/testbed2/generated/nats/nestedstruct1interfaceservice.cpp
+++ b/goldenmaster/modules/testbed2/generated/nats/nestedstruct1interfaceservice.cpp
@@ -7,7 +7,7 @@ using namespace Test::Testbed2;
 using namespace Test::Testbed2::Nats;
 
 namespace{
-const uint32_t  expectedMethodSubscriptions = 1;
+const uint32_t  expectedMethodSubscriptions = 3;
 const uint32_t  expectedPropertiesSubscriptions = 1;
 const uint32_t  initRespSubscription = 1;
 constexpr uint32_t expectedSubscriptionsCount = initRespSubscription + expectedMethodSubscriptions + expectedPropertiesSubscriptions;
@@ -62,6 +62,8 @@ void NestedStruct1InterfaceService::onConnected()
         _unsubscribeFromIsReady(m_onReadySubscriptionId);
     });
     subscribeTopic("testbed2.NestedStruct1Interface.set.prop1", [this](const auto& value){ onSetProp1(value); });
+    subscribeRequest("testbed2.NestedStruct1Interface.rpc.funcNoReturnValue", [this](const auto& args){  return onInvokeFuncNoReturnValue(args); });
+    subscribeRequest("testbed2.NestedStruct1Interface.rpc.funcNoParams", [this](const auto& args){  return onInvokeFuncNoParams(args); });
     subscribeRequest("testbed2.NestedStruct1Interface.rpc.func1", [this](const auto& args){  return onInvokeFunc1(args); });
 
     const std::string initRequestTopic = "testbed2.NestedStruct1Interface.init";
@@ -108,6 +110,19 @@ void NestedStruct1InterfaceService::onProp1Changed(const NestedStruct1& prop1)
 {
     static const std::string topic = "testbed2.NestedStruct1Interface.prop.prop1";
     m_service->publish(topic, nlohmann::json(prop1).dump());
+}
+std::string NestedStruct1InterfaceService::onInvokeFuncNoReturnValue(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    const NestedStruct1& param1 = json_args.at(0).get<NestedStruct1>();
+    m_impl->funcNoReturnValue(param1);
+    return "0";
+}
+std::string NestedStruct1InterfaceService::onInvokeFuncNoParams(const std::string& args) const
+{
+    nlohmann::json json_args = nlohmann::json::parse(args);
+    auto result = m_impl->funcNoParams();
+    return nlohmann::json(result).dump();
 }
 std::string NestedStruct1InterfaceService::onInvokeFunc1(const std::string& args) const
 {

--- a/goldenmaster/modules/testbed2/generated/nats/nestedstruct1interfaceservice.h
+++ b/goldenmaster/modules/testbed2/generated/nats/nestedstruct1interfaceservice.h
@@ -31,6 +31,8 @@ private:
     /// @brief requests to set the value for the property Prop1 coming from the client
     /// @param fields contains the param of the type NestedStruct1
     void onSetProp1(const std::string& args) const;
+    std::string onInvokeFuncNoReturnValue(const std::string& args) const;
+    std::string onInvokeFuncNoParams(const std::string& args) const;
     std::string onInvokeFunc1(const std::string& args) const;
 
     std::shared_ptr<INestedStruct1Interface> m_impl;

--- a/goldenmaster/modules/testbed2/generated/nats/tests/test_nestedstruct1interface.cpp
+++ b/goldenmaster/modules/testbed2/generated/nats/tests/test_nestedstruct1interface.cpp
@@ -84,6 +84,72 @@ TEST_CASE("Nats  testbed2 NestedStruct1Interface tests")
         REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&issig1Emitted ]() {return issig1Emitted   == true; }));
         lock.unlock();
     }
+    SECTION("Test method funcNoReturnValue")
+    {
+        clientNestedStruct1Interface->funcNoReturnValue(Testbed2::NestedStruct1());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcNoReturnValue async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientNestedStruct1Interface->funcNoReturnValueAsync(Testbed2::NestedStruct1());
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        resultFuture.wait();
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcNoReturnValue async with callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientNestedStruct1Interface->funcNoReturnValueAsync(Testbed2::NestedStruct1(),
+            [&finished, &m_wait]()
+            { 
+                finished = true;
+                m_wait.notify_all();
+                /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */
+            });
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+
+        resultFuture.wait();
+    }
+    SECTION("Test method funcNoParams")
+    {
+        [[maybe_unused]] auto result = clientNestedStruct1Interface->funcNoParams();
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcNoParams async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientNestedStruct1Interface->funcNoParamsAsync();
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == Testbed2::NestedStruct1()); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcNoParams async with callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientNestedStruct1Interface->funcNoParamsAsync(
+            [&finished, &m_wait](NestedStruct1 value)
+            {
+                REQUIRE(value == Testbed2::NestedStruct1());
+                finished = true;
+                m_wait.notify_all();
+                /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */
+            });
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+
+        resultFuture.wait();
+    }
     SECTION("Test method func1")
     {
         [[maybe_unused]] auto result = clientNestedStruct1Interface->func1(Testbed2::NestedStruct1());

--- a/goldenmaster/modules/testbed2/generated/olink/nestedstruct1interfaceclient.cpp
+++ b/goldenmaster/modules/testbed2/generated/olink/nestedstruct1interfaceclient.cpp
@@ -64,6 +64,56 @@ const NestedStruct1& NestedStruct1InterfaceClient::getProp1() const
     return m_data.m_prop1;
 }
 
+void NestedStruct1InterfaceClient::funcNoReturnValue(const NestedStruct1& param1)
+{
+    return funcNoReturnValueAsync(param1).get();
+}
+
+std::future<void> NestedStruct1InterfaceClient::funcNoReturnValueAsync(const NestedStruct1& param1, std::function<void(void)> callback)
+{
+    if(!m_node) {
+        AG_LOG_WARNING("Attempt to invoke method but" + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return std::future<void>{};
+    }
+    std::shared_ptr<std::promise<void>> resultPromise = std::make_shared<std::promise<void>>();
+    static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcNoReturnValue");
+    m_node->invokeRemote(operationId,
+        nlohmann::json::array({param1}), [resultPromise, callback](ApiGear::ObjectLink::InvokeReplyArg arg) {
+            (void) arg;
+            resultPromise->set_value();
+            if (callback)
+            {
+                callback();
+            }
+        });
+    return resultPromise->get_future();
+}
+
+NestedStruct1 NestedStruct1InterfaceClient::funcNoParams()
+{
+    return funcNoParamsAsync().get();
+}
+
+std::future<NestedStruct1> NestedStruct1InterfaceClient::funcNoParamsAsync( std::function<void(NestedStruct1)> callback)
+{
+    if(!m_node) {
+        AG_LOG_WARNING("Attempt to invoke method but" + olinkObjectName() +" is not linked to source . Make sure your object is linked. Check your connection to service");
+        return std::future<NestedStruct1>{};
+    }
+    std::shared_ptr<std::promise<NestedStruct1>> resultPromise = std::make_shared<std::promise<NestedStruct1>>();
+    static const auto operationId = ApiGear::ObjectLink::Name::createMemberId(olinkObjectName(), "funcNoParams");
+    m_node->invokeRemote(operationId,
+        nlohmann::json::array({}), [resultPromise, callback](ApiGear::ObjectLink::InvokeReplyArg arg) {
+            const NestedStruct1& value = arg.value.get<NestedStruct1>();
+            resultPromise->set_value(value);
+            if (callback)
+            {
+                callback(value);
+            }
+        });
+    return resultPromise->get_future();
+}
+
 NestedStruct1 NestedStruct1InterfaceClient::func1(const NestedStruct1& param1)
 {
     return func1Async(param1).get();

--- a/goldenmaster/modules/testbed2/generated/olink/nestedstruct1interfaceclient.h
+++ b/goldenmaster/modules/testbed2/generated/olink/nestedstruct1interfaceclient.h
@@ -57,6 +57,24 @@ public:
     */
     void setProp1(const NestedStruct1& prop1) override;
     /**
+    * Remote call of INestedStruct1Interface::funcNoReturnValue on the NestedStruct1Interface service.
+    * Uses funcNoReturnValueAsync
+    */
+    void funcNoReturnValue(const NestedStruct1& param1) override;
+    /**
+    * Remote call of INestedStruct1Interface::funcNoReturnValue on the NestedStruct1Interface service.
+    */
+    std::future<void> funcNoReturnValueAsync(const NestedStruct1& param1, std::function<void(void)> callback = nullptr) override;
+    /**
+    * Remote call of INestedStruct1Interface::funcNoParams on the NestedStruct1Interface service.
+    * Uses funcNoParamsAsync
+    */
+    NestedStruct1 funcNoParams() override;
+    /**
+    * Remote call of INestedStruct1Interface::funcNoParams on the NestedStruct1Interface service.
+    */
+    std::future<NestedStruct1> funcNoParamsAsync( std::function<void(NestedStruct1)> callback = nullptr) override;
+    /**
     * Remote call of INestedStruct1Interface::func1 on the NestedStruct1Interface service.
     * Uses func1Async
     */

--- a/goldenmaster/modules/testbed2/generated/olink/nestedstruct1interfaceservice.cpp
+++ b/goldenmaster/modules/testbed2/generated/olink/nestedstruct1interfaceservice.cpp
@@ -40,6 +40,15 @@ std::string NestedStruct1InterfaceService::olinkObjectName() {
 nlohmann::json NestedStruct1InterfaceService::olinkInvoke(const std::string& methodId, const nlohmann::json& fcnArgs) {
     AG_LOG_DEBUG("NestedStruct1InterfaceService invoke " + methodId);
     const auto& memberMethod = ApiGear::ObjectLink::Name::getMemberName(methodId);
+    if(memberMethod == "funcNoReturnValue") {
+        const NestedStruct1& param1 = fcnArgs.at(0);
+        m_NestedStruct1Interface->funcNoReturnValue(param1);
+        return nlohmann::json{};
+    }
+    if(memberMethod == "funcNoParams") {
+        NestedStruct1 result = m_NestedStruct1Interface->funcNoParams();
+        return result;
+    }
     if(memberMethod == "func1") {
         const NestedStruct1& param1 = fcnArgs.at(0);
         NestedStruct1 result = m_NestedStruct1Interface->func1(param1);

--- a/goldenmaster/modules/testbed2/generated/olink/tests/test_nestedstruct1interface.cpp
+++ b/goldenmaster/modules/testbed2/generated/olink/tests/test_nestedstruct1interface.cpp
@@ -88,6 +88,64 @@ TEST_CASE("olink  testbed2 NestedStruct1Interface tests")
         REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&issig1Emitted ]() {return issig1Emitted   == true; }));
         lock.unlock();
     }
+    SECTION("Test method funcNoReturnValue")
+    {
+        clientNestedStruct1Interface->funcNoReturnValue(Testbed2::NestedStruct1());
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcNoReturnValue async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientNestedStruct1Interface->funcNoReturnValueAsync(Testbed2::NestedStruct1());
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        resultFuture.wait();
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    SECTION("Test method funcNoReturnValue async with a callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientNestedStruct1Interface->funcNoReturnValueAsync(Testbed2::NestedStruct1(),[&finished, &m_wait](){finished = true; m_wait.notify_all(); /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ });
+         
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        resultFuture.wait();
+        
+    }
+    SECTION("Test method funcNoParams")
+    {
+        [[maybe_unused]] auto result = clientNestedStruct1Interface->funcNoParams();
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+    SECTION("Test method funcNoParams async")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientNestedStruct1Interface->funcNoParamsAsync();
+        auto f = std::async(std::launch::async, [&finished, &resultFuture, &m_wait]() {resultFuture.wait(); finished = true; m_wait.notify_all();});
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == Testbed2::NestedStruct1()); 
+        // CHECK EFFECTS OF YOUR METHOD HERE
+    }
+
+    SECTION("Test method funcNoParams async with a callback")
+    {
+        std::atomic<bool> finished = false;
+        auto resultFuture = clientNestedStruct1Interface->funcNoParamsAsync([&finished, &m_wait](NestedStruct1 value){ (void) value;finished = true; m_wait.notify_all(); /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ });
+         
+        lock.lock();
+        REQUIRE( m_wait.wait_for(lock, std::chrono::milliseconds(timeout), [&finished](){ return finished == true; }));
+        lock.unlock();
+        auto return_value = resultFuture.get();
+        REQUIRE(return_value == Testbed2::NestedStruct1()); 
+        
+    }
     SECTION("Test method func1")
     {
         [[maybe_unused]] auto result = clientNestedStruct1Interface->func1(Testbed2::NestedStruct1());

--- a/goldenmaster/modules/testbed2/implementation/nestedstruct1interface.cpp
+++ b/goldenmaster/modules/testbed2/implementation/nestedstruct1interface.cpp
@@ -27,6 +27,43 @@ const NestedStruct1& NestedStruct1Interface::getProp1() const
     return m_data.m_prop1;
 }
 
+void NestedStruct1Interface::funcNoReturnValue(const NestedStruct1& param1)
+{
+    (void) param1; // suppress the 'Unreferenced Formal Parameter' warning.
+    // do business logic here
+}
+
+std::future<void> NestedStruct1Interface::funcNoReturnValueAsync(const NestedStruct1& param1, std::function<void(void)> callback)
+{
+    return std::async(std::launch::async, [this, callback,
+                    param1]()
+        {funcNoReturnValue(param1);
+            if (callback)
+            {
+                callback();
+            }
+        }
+    );
+}
+
+NestedStruct1 NestedStruct1Interface::funcNoParams()
+{
+    // do business logic here
+    return NestedStruct1();
+}
+
+std::future<NestedStruct1> NestedStruct1Interface::funcNoParamsAsync( std::function<void(NestedStruct1)> callback)
+{
+    return std::async(std::launch::async, [this, callback]()
+        {auto result = funcNoParams();
+            if (callback)
+            {
+                callback(result);
+            }return result;
+        }
+    );
+}
+
 NestedStruct1 NestedStruct1Interface::func1(const NestedStruct1& param1)
 {
     (void) param1; // suppress the 'Unreferenced Formal Parameter' warning.

--- a/goldenmaster/modules/testbed2/implementation/nestedstruct1interface.h
+++ b/goldenmaster/modules/testbed2/implementation/nestedstruct1interface.h
@@ -20,6 +20,12 @@ public:
     void setProp1(const NestedStruct1& prop1) override;
     const NestedStruct1& getProp1() const override;
     
+    void funcNoReturnValue(const NestedStruct1& param1) override;
+    std::future<void> funcNoReturnValueAsync(const NestedStruct1& param1, std::function<void(void)> callback = nullptr) override;
+        
+    NestedStruct1 funcNoParams() override;
+    std::future<NestedStruct1> funcNoParamsAsync( std::function<void(NestedStruct1)> callback = nullptr) override;
+        
     NestedStruct1 func1(const NestedStruct1& param1) override;
     std::future<NestedStruct1> func1Async(const NestedStruct1& param1, std::function<void(NestedStruct1)> callback = nullptr) override;
         

--- a/goldenmaster/modules/testbed2/implementation/nestedstruct1interface.test.cpp
+++ b/goldenmaster/modules/testbed2/implementation/nestedstruct1interface.test.cpp
@@ -7,6 +7,40 @@ using namespace Test::Testbed2;
 TEST_CASE("Testing NestedStruct1Interface", "[NestedStruct1Interface]"){
     std::unique_ptr<INestedStruct1Interface> testNestedStruct1Interface = std::make_unique<NestedStruct1Interface>();
     // setup your test
+    SECTION("Test operation funcNoReturnValue") {
+        // Do implement test here
+        testNestedStruct1Interface->funcNoReturnValue(NestedStruct1());
+    }
+
+    SECTION("Test operation async funcNoReturnValue") {
+        // Do implement test here
+
+        auto future = testNestedStruct1Interface->funcNoReturnValueAsync(NestedStruct1());
+    }
+
+    SECTION("Test operation async funcNoReturnValue with a callback") {
+        // Do implement test here
+
+        auto future = testNestedStruct1Interface->funcNoReturnValueAsync(NestedStruct1(),[]( ){ /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ }
+            );
+    }
+    SECTION("Test operation funcNoParams") {
+        // Do implement test here
+        testNestedStruct1Interface->funcNoParams();
+    }
+
+    SECTION("Test operation async funcNoParams") {
+        // Do implement test here
+
+        auto future = testNestedStruct1Interface->funcNoParamsAsync();
+    }
+
+    SECTION("Test operation async funcNoParams with a callback") {
+        // Do implement test here
+
+        auto future = testNestedStruct1Interface->funcNoParamsAsync([](NestedStruct1 value){ (void)value; /* YOU CAN CHECK EFFECTS OF YOUR METHOD HERE */ }
+            );
+    }
     SECTION("Test operation func1") {
         // Do implement test here
         testNestedStruct1Interface->func1(NestedStruct1());

--- a/goldenmaster/scripts/test_cmake.sh
+++ b/goldenmaster/scripts/test_cmake.sh
@@ -50,6 +50,8 @@ buildCMakeModule "modules/extern_types" $source_root
 if [ $buildresult -ne 0 ]; then exit 1; fi;
 buildCMakeModule "modules/counter" $source_root
 if [ $buildresult -ne 0 ]; then exit 1; fi;
+buildCMakeModule "modules/tb_struct_array" $source_root
+if [ $buildresult -ne 0 ]; then exit 1; fi;
 # examples app
 buildCMakeBinary "examples/app" $source_root
 if [ $buildresult -ne 0 ]; then exit 1; fi;

--- a/goldenmaster/scripts/test_conan.bat
+++ b/goldenmaster/scripts/test_conan.bat
@@ -41,6 +41,9 @@ if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
 @REM Building and testing counter module
 call :build_and_test_module "counter" "../../modules/counter/conan"
 if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
+@REM Building and testing tb_struct_array module
+call :build_and_test_module "tb_struct_array" "../../modules/tb_struct_array/conan"
+if %ERRORLEVEL% GEQ 1 exit /b %ERRORLEVEL%
 
 @REM Leave build folder
 cd ..

--- a/goldenmaster/scripts/test_conan.sh
+++ b/goldenmaster/scripts/test_conan.sh
@@ -62,6 +62,8 @@ build_module "custom_types"
 build_module "extern_types"
 # Building and testing Counter module
 build_module "counter"
+# Building and testing TbStructArray module
+build_module "tb_struct_array"
 build_example "examples/app"
 build_example "examples/appthreadsafe"
 build_example "examples/olinkserver"

--- a/templates/module/generated/core/test_struct_helper.cpp.tpl
+++ b/templates/module/generated/core/test_struct_helper.cpp.tpl
@@ -15,7 +15,7 @@ void {{ Camel .Module.Name }}::fillTest{{Camel .Name }}({{Camel .Module.Name }}:
 	{{- if .IsArray }}
 	auto local_{{snake .Name}}_array = {{ cppDefault $namespacePrefix . }};
 	{{- if not ( or (eq .KindType "extern") ( or .IsPrimitive  (eq .KindType "enum") ) )}}
-	auto element{{snake .Name}} = {{ cppDefault $namespacePrefix . }};
+	auto element{{snake .Name}} = {{ cppTestValue $namespacePrefix . }};
 	fillTest{{Camel .Type }}(element{{snake .Name}});
 	{{- else}}
 	auto element{{snake .Name}} = {{cppTestValue $namespacePrefix . }};


### PR DESCRIPTION
## Summary
- Fixes template bug where `cppDefault` was used instead of `cppTestValue` for struct-array element variables in `test_struct_helper.cpp.tpl`
- `cppDefault` on an array field returns `std::list<T>()`, but the element variable needs just `T()` — `cppTestValue` already handles this correctly
- Adds `tb.struct.array` test module (via apigear-io/test-apis#16) covering previously untested struct field combinations: array-of-structs, array-of-enums, array-of-primitives, and a mixed struct

## Test plan
- [x] Reverted fix, generated code, compiled — 4 type errors confirmed (red)
- [x] Applied fix, generated code, compiled — clean (green)
- [x] `go run main.go diff` — no regressions against goldenmaster