### PR TITLE
fix(examples): overhaul with shared utilities

### DIFF
--- a/goldenmaster/examples/app/CMakeLists.txt
+++ b/goldenmaster/examples/app/CMakeLists.txt
@@ -19,6 +19,7 @@ if(NOT MSVC)
   target_compile_options(app PRIVATE -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wnon-virtual-dtor -Woverloaded-virtual -Wcast-align -Werror -fvisibility=hidden)
 else()
   target_compile_options(app PRIVATE /W4 /WX /wd4251)
+  target_compile_definitions(app PRIVATE -D_CRT_SECURE_NO_WARNINGS)
 endif()
 
 find_package(testbed2 REQUIRED COMPONENTS testbed2-core testbed2-implementation testbed2-monitor)

--- a/goldenmaster/examples/app/main.cpp
+++ b/goldenmaster/examples/app/main.cpp
@@ -52,6 +52,7 @@
 #include "tb_struct_array/implementation/structarrayfieldinterface.h"
 #include "tb_struct_array/generated/monitor/structarrayfieldinterface.tracedecorator.h"
 #include "apigear/tracer/tracer.h"
+#include <iostream>
 
 using namespace Test;
 
@@ -111,5 +112,21 @@ int main(){
     std::unique_ptr<TbStructArray::IStructArrayFieldInterface> testTbStructArrayStructArrayFieldInterface = std::make_unique<TbStructArray::StructArrayFieldInterface>();
     std::unique_ptr<TbStructArray::IStructArrayFieldInterface> testTbStructArrayStructArrayFieldInterfaceTraceDecorator = TbStructArray::StructArrayFieldInterfaceTraceDecorator::connect(*testTbStructArrayStructArrayFieldInterface, tracer);
 
+    // Demonstrate basic property access
+    
+    {
+        [[maybe_unused]] auto value = testTestbed2ManyParamInterface->getProp1();
+        std::cout << "Testbed2::ManyParamInterface::Prop1 default value retrieved" << std::endl;
+        testTestbed2ManyParamInterface->setProp1(0);
+        std::cout << "Testbed2::ManyParamInterface::Prop1 value set" << std::endl;
+    }
+    
+    {
+        [[maybe_unused]] auto result = testTestbed2ManyParamInterface->func1(0);
+        std::cout << "Testbed2::ManyParamInterface::func1 called" << std::endl;
+    }
+    
+
+    std::cout << "App example finished." << std::endl;
     return 0;
 }

--- a/goldenmaster/examples/appthreadsafe/CMakeLists.txt
+++ b/goldenmaster/examples/appthreadsafe/CMakeLists.txt
@@ -19,6 +19,7 @@ if(NOT MSVC)
   target_compile_options(appthreadsafe PRIVATE -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wnon-virtual-dtor -Woverloaded-virtual -Wcast-align -Werror -fvisibility=hidden)
 else()
   target_compile_options(appthreadsafe PRIVATE /W4 /WX /wd4251)
+  target_compile_definitions(appthreadsafe PRIVATE -D_CRT_SECURE_NO_WARNINGS)
 endif()
 
 find_package(testbed2 REQUIRED COMPONENTS testbed2-core testbed2-implementation)

--- a/goldenmaster/examples/appthreadsafe/main.cpp
+++ b/goldenmaster/examples/appthreadsafe/main.cpp
@@ -51,6 +51,8 @@
 #include "counter/generated/core/counter.threadsafedecorator.h"
 #include "tb_struct_array/implementation/structarrayfieldinterface.h"
 #include "tb_struct_array/generated/core/structarrayfieldinterface.threadsafedecorator.h"
+#include <iostream>
+
 
 void testTestbed2ManyParamInterface()
 {
@@ -61,16 +63,24 @@ void testTestbed2ManyParamInterface()
     // Thread safe access
     auto l_prop1 = 0;
     l_prop1 = testManyParamInterface->getProp1();
+    std::cout << "  ManyParamInterface::Prop1 retrieved" << std::endl;
     testManyParamInterface->setProp1(l_prop1);
+    std::cout << "  ManyParamInterface::Prop1 set" << std::endl;
     auto l_prop2 = 0;
     l_prop2 = testManyParamInterface->getProp2();
+    std::cout << "  ManyParamInterface::Prop2 retrieved" << std::endl;
     testManyParamInterface->setProp2(l_prop2);
+    std::cout << "  ManyParamInterface::Prop2 set" << std::endl;
     auto l_prop3 = 0;
     l_prop3 = testManyParamInterface->getProp3();
+    std::cout << "  ManyParamInterface::Prop3 retrieved" << std::endl;
     testManyParamInterface->setProp3(l_prop3);
+    std::cout << "  ManyParamInterface::Prop3 set" << std::endl;
     auto l_prop4 = 0;
     l_prop4 = testManyParamInterface->getProp4();
+    std::cout << "  ManyParamInterface::Prop4 retrieved" << std::endl;
     testManyParamInterface->setProp4(l_prop4);
+    std::cout << "  ManyParamInterface::Prop4 set" << std::endl;
 }
 
 void testTestbed2NestedStruct1Interface()
@@ -82,7 +92,9 @@ void testTestbed2NestedStruct1Interface()
     // Thread safe access
     auto l_prop1 = NestedStruct1();
     l_prop1 = testNestedStruct1Interface->getProp1();
+    std::cout << "  NestedStruct1Interface::Prop1 retrieved" << std::endl;
     testNestedStruct1Interface->setProp1(l_prop1);
+    std::cout << "  NestedStruct1Interface::Prop1 set" << std::endl;
 }
 
 void testTestbed2NestedStruct2Interface()
@@ -94,10 +106,14 @@ void testTestbed2NestedStruct2Interface()
     // Thread safe access
     auto l_prop1 = NestedStruct1();
     l_prop1 = testNestedStruct2Interface->getProp1();
+    std::cout << "  NestedStruct2Interface::Prop1 retrieved" << std::endl;
     testNestedStruct2Interface->setProp1(l_prop1);
+    std::cout << "  NestedStruct2Interface::Prop1 set" << std::endl;
     auto l_prop2 = NestedStruct2();
     l_prop2 = testNestedStruct2Interface->getProp2();
+    std::cout << "  NestedStruct2Interface::Prop2 retrieved" << std::endl;
     testNestedStruct2Interface->setProp2(l_prop2);
+    std::cout << "  NestedStruct2Interface::Prop2 set" << std::endl;
 }
 
 void testTestbed2NestedStruct3Interface()
@@ -109,13 +125,19 @@ void testTestbed2NestedStruct3Interface()
     // Thread safe access
     auto l_prop1 = NestedStruct1();
     l_prop1 = testNestedStruct3Interface->getProp1();
+    std::cout << "  NestedStruct3Interface::Prop1 retrieved" << std::endl;
     testNestedStruct3Interface->setProp1(l_prop1);
+    std::cout << "  NestedStruct3Interface::Prop1 set" << std::endl;
     auto l_prop2 = NestedStruct2();
     l_prop2 = testNestedStruct3Interface->getProp2();
+    std::cout << "  NestedStruct3Interface::Prop2 retrieved" << std::endl;
     testNestedStruct3Interface->setProp2(l_prop2);
+    std::cout << "  NestedStruct3Interface::Prop2 set" << std::endl;
     auto l_prop3 = NestedStruct3();
     l_prop3 = testNestedStruct3Interface->getProp3();
+    std::cout << "  NestedStruct3Interface::Prop3 retrieved" << std::endl;
     testNestedStruct3Interface->setProp3(l_prop3);
+    std::cout << "  NestedStruct3Interface::Prop3 set" << std::endl;
 }
 
 void testTbEnumEnumInterface()
@@ -127,16 +149,24 @@ void testTbEnumEnumInterface()
     // Thread safe access
     auto l_prop0 = Enum0Enum::value0;
     l_prop0 = testEnumInterface->getProp0();
+    std::cout << "  EnumInterface::Prop0 retrieved" << std::endl;
     testEnumInterface->setProp0(l_prop0);
+    std::cout << "  EnumInterface::Prop0 set" << std::endl;
     auto l_prop1 = Enum1Enum::value1;
     l_prop1 = testEnumInterface->getProp1();
+    std::cout << "  EnumInterface::Prop1 retrieved" << std::endl;
     testEnumInterface->setProp1(l_prop1);
+    std::cout << "  EnumInterface::Prop1 set" << std::endl;
     auto l_prop2 = Enum2Enum::value2;
     l_prop2 = testEnumInterface->getProp2();
+    std::cout << "  EnumInterface::Prop2 retrieved" << std::endl;
     testEnumInterface->setProp2(l_prop2);
+    std::cout << "  EnumInterface::Prop2 set" << std::endl;
     auto l_prop3 = Enum3Enum::value3;
     l_prop3 = testEnumInterface->getProp3();
+    std::cout << "  EnumInterface::Prop3 retrieved" << std::endl;
     testEnumInterface->setProp3(l_prop3);
+    std::cout << "  EnumInterface::Prop3 set" << std::endl;
 }
 
 void testTbSame1SameStruct1Interface()
@@ -148,7 +178,9 @@ void testTbSame1SameStruct1Interface()
     // Thread safe access
     auto l_prop1 = Struct1();
     l_prop1 = testSameStruct1Interface->getProp1();
+    std::cout << "  SameStruct1Interface::Prop1 retrieved" << std::endl;
     testSameStruct1Interface->setProp1(l_prop1);
+    std::cout << "  SameStruct1Interface::Prop1 set" << std::endl;
 }
 
 void testTbSame1SameStruct2Interface()
@@ -160,10 +192,14 @@ void testTbSame1SameStruct2Interface()
     // Thread safe access
     auto l_prop1 = Struct2();
     l_prop1 = testSameStruct2Interface->getProp1();
+    std::cout << "  SameStruct2Interface::Prop1 retrieved" << std::endl;
     testSameStruct2Interface->setProp1(l_prop1);
+    std::cout << "  SameStruct2Interface::Prop1 set" << std::endl;
     auto l_prop2 = Struct2();
     l_prop2 = testSameStruct2Interface->getProp2();
+    std::cout << "  SameStruct2Interface::Prop2 retrieved" << std::endl;
     testSameStruct2Interface->setProp2(l_prop2);
+    std::cout << "  SameStruct2Interface::Prop2 set" << std::endl;
 }
 
 void testTbSame1SameEnum1Interface()
@@ -175,7 +211,9 @@ void testTbSame1SameEnum1Interface()
     // Thread safe access
     auto l_prop1 = Enum1Enum::value1;
     l_prop1 = testSameEnum1Interface->getProp1();
+    std::cout << "  SameEnum1Interface::Prop1 retrieved" << std::endl;
     testSameEnum1Interface->setProp1(l_prop1);
+    std::cout << "  SameEnum1Interface::Prop1 set" << std::endl;
 }
 
 void testTbSame1SameEnum2Interface()
@@ -187,10 +225,14 @@ void testTbSame1SameEnum2Interface()
     // Thread safe access
     auto l_prop1 = Enum1Enum::value1;
     l_prop1 = testSameEnum2Interface->getProp1();
+    std::cout << "  SameEnum2Interface::Prop1 retrieved" << std::endl;
     testSameEnum2Interface->setProp1(l_prop1);
+    std::cout << "  SameEnum2Interface::Prop1 set" << std::endl;
     auto l_prop2 = Enum2Enum::value1;
     l_prop2 = testSameEnum2Interface->getProp2();
+    std::cout << "  SameEnum2Interface::Prop2 retrieved" << std::endl;
     testSameEnum2Interface->setProp2(l_prop2);
+    std::cout << "  SameEnum2Interface::Prop2 set" << std::endl;
 }
 
 void testTbSame2SameStruct1Interface()
@@ -202,7 +244,9 @@ void testTbSame2SameStruct1Interface()
     // Thread safe access
     auto l_prop1 = Struct1();
     l_prop1 = testSameStruct1Interface->getProp1();
+    std::cout << "  SameStruct1Interface::Prop1 retrieved" << std::endl;
     testSameStruct1Interface->setProp1(l_prop1);
+    std::cout << "  SameStruct1Interface::Prop1 set" << std::endl;
 }
 
 void testTbSame2SameStruct2Interface()
@@ -214,10 +258,14 @@ void testTbSame2SameStruct2Interface()
     // Thread safe access
     auto l_prop1 = Struct2();
     l_prop1 = testSameStruct2Interface->getProp1();
+    std::cout << "  SameStruct2Interface::Prop1 retrieved" << std::endl;
     testSameStruct2Interface->setProp1(l_prop1);
+    std::cout << "  SameStruct2Interface::Prop1 set" << std::endl;
     auto l_prop2 = Struct2();
     l_prop2 = testSameStruct2Interface->getProp2();
+    std::cout << "  SameStruct2Interface::Prop2 retrieved" << std::endl;
     testSameStruct2Interface->setProp2(l_prop2);
+    std::cout << "  SameStruct2Interface::Prop2 set" << std::endl;
 }
 
 void testTbSame2SameEnum1Interface()
@@ -229,7 +277,9 @@ void testTbSame2SameEnum1Interface()
     // Thread safe access
     auto l_prop1 = Enum1Enum::value1;
     l_prop1 = testSameEnum1Interface->getProp1();
+    std::cout << "  SameEnum1Interface::Prop1 retrieved" << std::endl;
     testSameEnum1Interface->setProp1(l_prop1);
+    std::cout << "  SameEnum1Interface::Prop1 set" << std::endl;
 }
 
 void testTbSame2SameEnum2Interface()
@@ -241,10 +291,14 @@ void testTbSame2SameEnum2Interface()
     // Thread safe access
     auto l_prop1 = Enum1Enum::value1;
     l_prop1 = testSameEnum2Interface->getProp1();
+    std::cout << "  SameEnum2Interface::Prop1 retrieved" << std::endl;
     testSameEnum2Interface->setProp1(l_prop1);
+    std::cout << "  SameEnum2Interface::Prop1 set" << std::endl;
     auto l_prop2 = Enum2Enum::value1;
     l_prop2 = testSameEnum2Interface->getProp2();
+    std::cout << "  SameEnum2Interface::Prop2 retrieved" << std::endl;
     testSameEnum2Interface->setProp2(l_prop2);
+    std::cout << "  SameEnum2Interface::Prop2 set" << std::endl;
 }
 
 void testTbSimpleVoidInterface()
@@ -265,28 +319,44 @@ void testTbSimpleSimpleInterface()
     // Thread safe access
     auto l_propBool = false;
     l_propBool = testSimpleInterface->getPropBool();
+    std::cout << "  SimpleInterface::PropBool retrieved" << std::endl;
     testSimpleInterface->setPropBool(l_propBool);
+    std::cout << "  SimpleInterface::PropBool set" << std::endl;
     auto l_propInt = 0;
     l_propInt = testSimpleInterface->getPropInt();
+    std::cout << "  SimpleInterface::PropInt retrieved" << std::endl;
     testSimpleInterface->setPropInt(l_propInt);
+    std::cout << "  SimpleInterface::PropInt set" << std::endl;
     auto l_propInt32 = 0;
     l_propInt32 = testSimpleInterface->getPropInt32();
+    std::cout << "  SimpleInterface::PropInt32 retrieved" << std::endl;
     testSimpleInterface->setPropInt32(l_propInt32);
+    std::cout << "  SimpleInterface::PropInt32 set" << std::endl;
     auto l_propInt64 = 0LL;
     l_propInt64 = testSimpleInterface->getPropInt64();
+    std::cout << "  SimpleInterface::PropInt64 retrieved" << std::endl;
     testSimpleInterface->setPropInt64(l_propInt64);
+    std::cout << "  SimpleInterface::PropInt64 set" << std::endl;
     auto l_propFloat = 0.0f;
     l_propFloat = testSimpleInterface->getPropFloat();
+    std::cout << "  SimpleInterface::PropFloat retrieved" << std::endl;
     testSimpleInterface->setPropFloat(l_propFloat);
+    std::cout << "  SimpleInterface::PropFloat set" << std::endl;
     auto l_propFloat32 = 0.0f;
     l_propFloat32 = testSimpleInterface->getPropFloat32();
+    std::cout << "  SimpleInterface::PropFloat32 retrieved" << std::endl;
     testSimpleInterface->setPropFloat32(l_propFloat32);
+    std::cout << "  SimpleInterface::PropFloat32 set" << std::endl;
     auto l_propFloat64 = 0.0;
     l_propFloat64 = testSimpleInterface->getPropFloat64();
+    std::cout << "  SimpleInterface::PropFloat64 retrieved" << std::endl;
     testSimpleInterface->setPropFloat64(l_propFloat64);
+    std::cout << "  SimpleInterface::PropFloat64 set" << std::endl;
     auto l_propString = std::string();
     l_propString = testSimpleInterface->getPropString();
+    std::cout << "  SimpleInterface::PropString retrieved" << std::endl;
     testSimpleInterface->setPropString(l_propString);
+    std::cout << "  SimpleInterface::PropString set" << std::endl;
 }
 
 void testTbSimpleSimpleArrayInterface()
@@ -298,30 +368,47 @@ void testTbSimpleSimpleArrayInterface()
     // Thread safe access
     auto l_propBool = std::list<bool>();
     l_propBool = testSimpleArrayInterface->getPropBool();
+    std::cout << "  SimpleArrayInterface::PropBool retrieved" << std::endl;
     testSimpleArrayInterface->setPropBool(l_propBool);
+    std::cout << "  SimpleArrayInterface::PropBool set" << std::endl;
     auto l_propInt = std::list<int>();
     l_propInt = testSimpleArrayInterface->getPropInt();
+    std::cout << "  SimpleArrayInterface::PropInt retrieved" << std::endl;
     testSimpleArrayInterface->setPropInt(l_propInt);
+    std::cout << "  SimpleArrayInterface::PropInt set" << std::endl;
     auto l_propInt32 = std::list<int32_t>();
     l_propInt32 = testSimpleArrayInterface->getPropInt32();
+    std::cout << "  SimpleArrayInterface::PropInt32 retrieved" << std::endl;
     testSimpleArrayInterface->setPropInt32(l_propInt32);
+    std::cout << "  SimpleArrayInterface::PropInt32 set" << std::endl;
     auto l_propInt64 = std::list<int64_t>();
     l_propInt64 = testSimpleArrayInterface->getPropInt64();
+    std::cout << "  SimpleArrayInterface::PropInt64 retrieved" << std::endl;
     testSimpleArrayInterface->setPropInt64(l_propInt64);
+    std::cout << "  SimpleArrayInterface::PropInt64 set" << std::endl;
     auto l_propFloat = std::list<float>();
     l_propFloat = testSimpleArrayInterface->getPropFloat();
+    std::cout << "  SimpleArrayInterface::PropFloat retrieved" << std::endl;
     testSimpleArrayInterface->setPropFloat(l_propFloat);
+    std::cout << "  SimpleArrayInterface::PropFloat set" << std::endl;
     auto l_propFloat32 = std::list<float>();
     l_propFloat32 = testSimpleArrayInterface->getPropFloat32();
+    std::cout << "  SimpleArrayInterface::PropFloat32 retrieved" << std::endl;
     testSimpleArrayInterface->setPropFloat32(l_propFloat32);
+    std::cout << "  SimpleArrayInterface::PropFloat32 set" << std::endl;
     auto l_propFloat64 = std::list<double>();
     l_propFloat64 = testSimpleArrayInterface->getPropFloat64();
+    std::cout << "  SimpleArrayInterface::PropFloat64 retrieved" << std::endl;
     testSimpleArrayInterface->setPropFloat64(l_propFloat64);
+    std::cout << "  SimpleArrayInterface::PropFloat64 set" << std::endl;
     auto l_propString = std::list<std::string>();
     l_propString = testSimpleArrayInterface->getPropString();
+    std::cout << "  SimpleArrayInterface::PropString retrieved" << std::endl;
     testSimpleArrayInterface->setPropString(l_propString);
+    std::cout << "  SimpleArrayInterface::PropString set" << std::endl;
     auto l_propReadOnlyString = std::string();
     l_propReadOnlyString = testSimpleArrayInterface->getPropReadOnlyString();
+    std::cout << "  SimpleArrayInterface::PropReadOnlyString retrieved" << std::endl;
 }
 
 void testTbSimpleNoPropertiesInterface()
@@ -342,10 +429,14 @@ void testTbSimpleNoOperationsInterface()
     // Thread safe access
     auto l_propBool = false;
     l_propBool = testNoOperationsInterface->getPropBool();
+    std::cout << "  NoOperationsInterface::PropBool retrieved" << std::endl;
     testNoOperationsInterface->setPropBool(l_propBool);
+    std::cout << "  NoOperationsInterface::PropBool set" << std::endl;
     auto l_propInt = 0;
     l_propInt = testNoOperationsInterface->getPropInt();
+    std::cout << "  NoOperationsInterface::PropInt retrieved" << std::endl;
     testNoOperationsInterface->setPropInt(l_propInt);
+    std::cout << "  NoOperationsInterface::PropInt set" << std::endl;
 }
 
 void testTbSimpleNoSignalsInterface()
@@ -357,10 +448,14 @@ void testTbSimpleNoSignalsInterface()
     // Thread safe access
     auto l_propBool = false;
     l_propBool = testNoSignalsInterface->getPropBool();
+    std::cout << "  NoSignalsInterface::PropBool retrieved" << std::endl;
     testNoSignalsInterface->setPropBool(l_propBool);
+    std::cout << "  NoSignalsInterface::PropBool set" << std::endl;
     auto l_propInt = 0;
     l_propInt = testNoSignalsInterface->getPropInt();
+    std::cout << "  NoSignalsInterface::PropInt retrieved" << std::endl;
     testNoSignalsInterface->setPropInt(l_propInt);
+    std::cout << "  NoSignalsInterface::PropInt set" << std::endl;
 }
 
 void testTbSimpleEmptyInterface()
@@ -381,16 +476,24 @@ void testTestbed1StructInterface()
     // Thread safe access
     auto l_propBool = StructBool();
     l_propBool = testStructInterface->getPropBool();
+    std::cout << "  StructInterface::PropBool retrieved" << std::endl;
     testStructInterface->setPropBool(l_propBool);
+    std::cout << "  StructInterface::PropBool set" << std::endl;
     auto l_propInt = StructInt();
     l_propInt = testStructInterface->getPropInt();
+    std::cout << "  StructInterface::PropInt retrieved" << std::endl;
     testStructInterface->setPropInt(l_propInt);
+    std::cout << "  StructInterface::PropInt set" << std::endl;
     auto l_propFloat = StructFloat();
     l_propFloat = testStructInterface->getPropFloat();
+    std::cout << "  StructInterface::PropFloat retrieved" << std::endl;
     testStructInterface->setPropFloat(l_propFloat);
+    std::cout << "  StructInterface::PropFloat set" << std::endl;
     auto l_propString = StructString();
     l_propString = testStructInterface->getPropString();
+    std::cout << "  StructInterface::PropString retrieved" << std::endl;
     testStructInterface->setPropString(l_propString);
+    std::cout << "  StructInterface::PropString set" << std::endl;
 }
 
 void testTestbed1StructArrayInterface()
@@ -402,19 +505,29 @@ void testTestbed1StructArrayInterface()
     // Thread safe access
     auto l_propBool = std::list<StructBool>();
     l_propBool = testStructArrayInterface->getPropBool();
+    std::cout << "  StructArrayInterface::PropBool retrieved" << std::endl;
     testStructArrayInterface->setPropBool(l_propBool);
+    std::cout << "  StructArrayInterface::PropBool set" << std::endl;
     auto l_propInt = std::list<StructInt>();
     l_propInt = testStructArrayInterface->getPropInt();
+    std::cout << "  StructArrayInterface::PropInt retrieved" << std::endl;
     testStructArrayInterface->setPropInt(l_propInt);
+    std::cout << "  StructArrayInterface::PropInt set" << std::endl;
     auto l_propFloat = std::list<StructFloat>();
     l_propFloat = testStructArrayInterface->getPropFloat();
+    std::cout << "  StructArrayInterface::PropFloat retrieved" << std::endl;
     testStructArrayInterface->setPropFloat(l_propFloat);
+    std::cout << "  StructArrayInterface::PropFloat set" << std::endl;
     auto l_propString = std::list<StructString>();
     l_propString = testStructArrayInterface->getPropString();
+    std::cout << "  StructArrayInterface::PropString retrieved" << std::endl;
     testStructArrayInterface->setPropString(l_propString);
+    std::cout << "  StructArrayInterface::PropString set" << std::endl;
     auto l_propEnum = std::list<Enum0Enum>();
     l_propEnum = testStructArrayInterface->getPropEnum();
+    std::cout << "  StructArrayInterface::PropEnum retrieved" << std::endl;
     testStructArrayInterface->setPropEnum(l_propEnum);
+    std::cout << "  StructArrayInterface::PropEnum set" << std::endl;
 }
 
 void testTestbed1StructArray2Interface()
@@ -426,19 +539,29 @@ void testTestbed1StructArray2Interface()
     // Thread safe access
     auto l_propBool = StructBoolWithArray();
     l_propBool = testStructArray2Interface->getPropBool();
+    std::cout << "  StructArray2Interface::PropBool retrieved" << std::endl;
     testStructArray2Interface->setPropBool(l_propBool);
+    std::cout << "  StructArray2Interface::PropBool set" << std::endl;
     auto l_propInt = StructIntWithArray();
     l_propInt = testStructArray2Interface->getPropInt();
+    std::cout << "  StructArray2Interface::PropInt retrieved" << std::endl;
     testStructArray2Interface->setPropInt(l_propInt);
+    std::cout << "  StructArray2Interface::PropInt set" << std::endl;
     auto l_propFloat = StructFloatWithArray();
     l_propFloat = testStructArray2Interface->getPropFloat();
+    std::cout << "  StructArray2Interface::PropFloat retrieved" << std::endl;
     testStructArray2Interface->setPropFloat(l_propFloat);
+    std::cout << "  StructArray2Interface::PropFloat set" << std::endl;
     auto l_propString = StructStringWithArray();
     l_propString = testStructArray2Interface->getPropString();
+    std::cout << "  StructArray2Interface::PropString retrieved" << std::endl;
     testStructArray2Interface->setPropString(l_propString);
+    std::cout << "  StructArray2Interface::PropString set" << std::endl;
     auto l_propEnum = StructEnumWithArray();
     l_propEnum = testStructArray2Interface->getPropEnum();
+    std::cout << "  StructArray2Interface::PropEnum retrieved" << std::endl;
     testStructArray2Interface->setPropEnum(l_propEnum);
+    std::cout << "  StructArray2Interface::PropEnum set" << std::endl;
 }
 
 void testTbNamesNamEs()
@@ -450,16 +573,24 @@ void testTbNamesNamEs()
     // Thread safe access
     auto l_switch = false;
     l_switch = testNamEs->getSwitch();
+    std::cout << "  NamEs::Switch retrieved" << std::endl;
     testNamEs->setSwitch(l_switch);
+    std::cout << "  NamEs::Switch set" << std::endl;
     auto l_someProperty = 0;
     l_someProperty = testNamEs->getSomeProperty();
+    std::cout << "  NamEs::SomeProperty retrieved" << std::endl;
     testNamEs->setSomeProperty(l_someProperty);
+    std::cout << "  NamEs::SomeProperty set" << std::endl;
     auto l_somePoperty2 = 0;
     l_somePoperty2 = testNamEs->getSomePoperty2();
+    std::cout << "  NamEs::SomePoperty2 retrieved" << std::endl;
     testNamEs->setSomePoperty2(l_somePoperty2);
+    std::cout << "  NamEs::SomePoperty2 set" << std::endl;
     auto l_enumProperty = Enum_With_Under_scoresEnum::First_Value;
     l_enumProperty = testNamEs->getEnumProperty();
+    std::cout << "  NamEs::EnumProperty retrieved" << std::endl;
     testNamEs->setEnumProperty(l_enumProperty);
+    std::cout << "  NamEs::EnumProperty set" << std::endl;
 }
 
 void testCounterCounter()
@@ -471,16 +602,24 @@ void testCounterCounter()
     // Thread safe access
     auto l_vector = Test::CustomTypes::Vector3D();
     l_vector = testCounter->getVector();
+    std::cout << "  Counter::Vector retrieved" << std::endl;
     testCounter->setVector(l_vector);
+    std::cout << "  Counter::Vector set" << std::endl;
     auto l_externVector = Eigen::Vector3f(0,0,0);
     l_externVector = testCounter->getExternVector();
+    std::cout << "  Counter::ExternVector retrieved" << std::endl;
     testCounter->setExternVector(l_externVector);
+    std::cout << "  Counter::ExternVector set" << std::endl;
     auto l_vectorArray = std::list<Test::CustomTypes::Vector3D>();
     l_vectorArray = testCounter->getVectorArray();
+    std::cout << "  Counter::VectorArray retrieved" << std::endl;
     testCounter->setVectorArray(l_vectorArray);
+    std::cout << "  Counter::VectorArray set" << std::endl;
     auto l_externVectorArray = std::list<Eigen::Vector3f>();
     l_externVectorArray = testCounter->getExternVectorArray();
+    std::cout << "  Counter::ExternVectorArray retrieved" << std::endl;
     testCounter->setExternVectorArray(l_externVectorArray);
+    std::cout << "  Counter::ExternVectorArray set" << std::endl;
 }
 
 void testTbStructArrayStructArrayFieldInterface()
@@ -492,46 +631,81 @@ void testTbStructArrayStructArrayFieldInterface()
     // Thread safe access
     auto l_propStructArray = StructWithArrayOfStructs();
     l_propStructArray = testStructArrayFieldInterface->getPropStructArray();
+    std::cout << "  StructArrayFieldInterface::PropStructArray retrieved" << std::endl;
     testStructArrayFieldInterface->setPropStructArray(l_propStructArray);
+    std::cout << "  StructArrayFieldInterface::PropStructArray set" << std::endl;
     auto l_propEnumArray = StructWithArrayOfEnums();
     l_propEnumArray = testStructArrayFieldInterface->getPropEnumArray();
+    std::cout << "  StructArrayFieldInterface::PropEnumArray retrieved" << std::endl;
     testStructArrayFieldInterface->setPropEnumArray(l_propEnumArray);
+    std::cout << "  StructArrayFieldInterface::PropEnumArray set" << std::endl;
     auto l_propIntArray = StructWithArrayOfInts();
     l_propIntArray = testStructArrayFieldInterface->getPropIntArray();
+    std::cout << "  StructArrayFieldInterface::PropIntArray retrieved" << std::endl;
     testStructArrayFieldInterface->setPropIntArray(l_propIntArray);
+    std::cout << "  StructArrayFieldInterface::PropIntArray set" << std::endl;
     auto l_propMixed = MixedStruct();
     l_propMixed = testStructArrayFieldInterface->getPropMixed();
+    std::cout << "  StructArrayFieldInterface::PropMixed retrieved" << std::endl;
     testStructArrayFieldInterface->setPropMixed(l_propMixed);
+    std::cout << "  StructArrayFieldInterface::PropMixed set" << std::endl;
 }
 
 
 int main(){
+    std::cout << "Testing Testbed2::ManyParamInterface (thread-safe)" << std::endl;
     testTestbed2ManyParamInterface();
+    std::cout << "Testing Testbed2::NestedStruct1Interface (thread-safe)" << std::endl;
     testTestbed2NestedStruct1Interface();
+    std::cout << "Testing Testbed2::NestedStruct2Interface (thread-safe)" << std::endl;
     testTestbed2NestedStruct2Interface();
+    std::cout << "Testing Testbed2::NestedStruct3Interface (thread-safe)" << std::endl;
     testTestbed2NestedStruct3Interface();
+    std::cout << "Testing TbEnum::EnumInterface (thread-safe)" << std::endl;
     testTbEnumEnumInterface();
+    std::cout << "Testing TbSame1::SameStruct1Interface (thread-safe)" << std::endl;
     testTbSame1SameStruct1Interface();
+    std::cout << "Testing TbSame1::SameStruct2Interface (thread-safe)" << std::endl;
     testTbSame1SameStruct2Interface();
+    std::cout << "Testing TbSame1::SameEnum1Interface (thread-safe)" << std::endl;
     testTbSame1SameEnum1Interface();
+    std::cout << "Testing TbSame1::SameEnum2Interface (thread-safe)" << std::endl;
     testTbSame1SameEnum2Interface();
+    std::cout << "Testing TbSame2::SameStruct1Interface (thread-safe)" << std::endl;
     testTbSame2SameStruct1Interface();
+    std::cout << "Testing TbSame2::SameStruct2Interface (thread-safe)" << std::endl;
     testTbSame2SameStruct2Interface();
+    std::cout << "Testing TbSame2::SameEnum1Interface (thread-safe)" << std::endl;
     testTbSame2SameEnum1Interface();
+    std::cout << "Testing TbSame2::SameEnum2Interface (thread-safe)" << std::endl;
     testTbSame2SameEnum2Interface();
+    std::cout << "Testing TbSimple::VoidInterface (thread-safe)" << std::endl;
     testTbSimpleVoidInterface();
+    std::cout << "Testing TbSimple::SimpleInterface (thread-safe)" << std::endl;
     testTbSimpleSimpleInterface();
+    std::cout << "Testing TbSimple::SimpleArrayInterface (thread-safe)" << std::endl;
     testTbSimpleSimpleArrayInterface();
+    std::cout << "Testing TbSimple::NoPropertiesInterface (thread-safe)" << std::endl;
     testTbSimpleNoPropertiesInterface();
+    std::cout << "Testing TbSimple::NoOperationsInterface (thread-safe)" << std::endl;
     testTbSimpleNoOperationsInterface();
+    std::cout << "Testing TbSimple::NoSignalsInterface (thread-safe)" << std::endl;
     testTbSimpleNoSignalsInterface();
+    std::cout << "Testing TbSimple::EmptyInterface (thread-safe)" << std::endl;
     testTbSimpleEmptyInterface();
+    std::cout << "Testing Testbed1::StructInterface (thread-safe)" << std::endl;
     testTestbed1StructInterface();
+    std::cout << "Testing Testbed1::StructArrayInterface (thread-safe)" << std::endl;
     testTestbed1StructArrayInterface();
+    std::cout << "Testing Testbed1::StructArray2Interface (thread-safe)" << std::endl;
     testTestbed1StructArray2Interface();
+    std::cout << "Testing TbNames::NamEs (thread-safe)" << std::endl;
     testTbNamesNamEs();
+    std::cout << "Testing Counter::Counter (thread-safe)" << std::endl;
     testCounterCounter();
+    std::cout << "Testing TbStructArray::StructArrayFieldInterface (thread-safe)" << std::endl;
     testTbStructArrayStructArrayFieldInterface();
 
+    std::cout << "AppThreadSafe example finished." << std::endl;
     return 0;
 }

--- a/goldenmaster/examples/mqttclient/CMakeLists.txt
+++ b/goldenmaster/examples/mqttclient/CMakeLists.txt
@@ -51,6 +51,7 @@ target_link_libraries(MQTTClient
 # we assume that the examples are built together with the libraries and thus ignore this warning
 if(MSVC)
   target_compile_options(MQTTClient PRIVATE /wd4251)
+  target_compile_definitions(MQTTClient PRIVATE -D_CRT_SECURE_NO_WARNINGS)
 endif()
 
 install(TARGETS MQTTClient

--- a/goldenmaster/examples/mqttclient/main.cpp
+++ b/goldenmaster/examples/mqttclient/main.cpp
@@ -1,4 +1,4 @@
-#include <iostream>
+
 #include "testbed2/generated/mqtt/manyparaminterfaceclient.h"
 #include "testbed2/generated/mqtt/nestedstruct1interfaceclient.h"
 #include "testbed2/generated/mqtt/nestedstruct2interfaceclient.h"
@@ -27,40 +27,95 @@
 #include "tb_struct_array/generated/mqtt/structarrayfieldinterfaceclient.h"
 #include "apigear/mqtt/mqttclient.h"
 #include "apigear/utilities/logger.h"
-#include <iostream>
-#include <sstream>
 #include <cstdlib>
+#include <sstream>
+#include <iostream>
+#include <string>
+#include <functional>
+#include <map>
+
+namespace Examples {
+
+using CommandHandler = std::function<void(const std::string& args)>;
+using CommandMap = std::map<std::string, CommandHandler>;
+
+inline ApiGear::Utilities::WriteLogFunc initLogging()
+{
+    ApiGear::Utilities::LogLevel logLevel = ApiGear::Utilities::LogLevel::Warning;
+    if (const char* envLogLevel = std::getenv("LOG_LEVEL"))
+    {
+        int parsed = -1;
+        std::istringstream iss(envLogLevel);
+        if (!(iss >> parsed) || parsed < 0) {
+            std::cerr << "Warning: invalid LOG_LEVEL=\"" << envLogLevel
+                      << "\", using default (Warning)" << std::endl;
+        } else if (parsed > static_cast<int>(ApiGear::Utilities::LogLevel::Error)) {
+            ApiGear::Utilities::setLog(nullptr);
+            return nullptr;
+        } else {
+            logLevel = static_cast<ApiGear::Utilities::LogLevel>(parsed);
+        }
+    }
+    auto logFunc = ApiGear::Utilities::getConsoleLogFunc(logLevel);
+    ApiGear::Utilities::setLog(logFunc);
+    return logFunc;
+}
+
+inline void runCommandLoop(CommandMap commands, std::function<void()> onQuit)
+{
+    commands["help"] = [&](const std::string&) {
+        std::cout << "Available commands:";
+        for (const auto& [name, _] : commands) { std::cout << " " << name; }
+        std::cout << " quit exit" << std::endl;
+    };
+    std::string line;
+    std::cout << "Type \"help\" for available commands." << std::endl;
+    while (std::getline(std::cin, line)) {
+        auto start = line.find_first_not_of(" \t\r\n");
+        auto end = line.find_last_not_of(" \t\r\n");
+        if (start != std::string::npos) {
+            line = line.substr(start, end - start + 1);
+        } else {
+            line.clear();
+        }
+        for (auto& c : line) { c = static_cast<char>(std::tolower(static_cast<unsigned char>(c))); }
+        if (line == "quit" || line == "exit") {
+            if (onQuit) { onQuit(); }
+            return;
+        }
+        auto spacePos = line.find(' ');
+        std::string cmd = (spacePos == std::string::npos) ? line : line.substr(0, spacePos);
+        std::string args = (spacePos == std::string::npos) ? "" : line.substr(spacePos + 1);
+        auto it = commands.find(cmd);
+        if (it != commands.end()) {
+            it->second(args);
+        } else if (!cmd.empty()) {
+            std::cout << "Unknown command: \"" << cmd
+                      << "\". Type \"help\" for available commands." << std::endl;
+        }
+    }
+    if (onQuit) { onQuit(); }
+}
+
+} // namespace Examples
 #include <random>
 
 using namespace Test;
 
-ApiGear::Utilities::WriteLogFunc getLogging(){
+int main(int argc, char* argv[]){
 
-    ApiGear::Utilities::WriteLogFunc logConsoleFunc = nullptr;
-    ApiGear::Utilities::LogLevel logLevel = ApiGear::Utilities::LogLevel::Warning;
-
-    // check whether logging level is set via env
-    if (const char* envLogLevel = std::getenv("LOG_LEVEL"))
-    {
-        int logLevelNumber = 255;
-        std::stringstream(envLogLevel) >> logLevelNumber;
-        logLevel = static_cast<ApiGear::Utilities::LogLevel>(logLevelNumber);
+    // Parse command line arguments
+    std::string host = "localhost";
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--host" && i + 1 < argc) { host = argv[++i]; }
+        else if (arg == "--help") {
+            std::cout << "Usage: " << argv[0] << " [--host HOST]" << std::endl;
+            return 0;
+        }
     }
 
-    logConsoleFunc = ApiGear::Utilities::getConsoleLogFunc(logLevel);
-    // check whether logging was disabled
-    if (logLevel > ApiGear::Utilities::LogLevel::Error) {
-        logConsoleFunc = nullptr;
-    }
-
-    // set global log function
-    ApiGear::Utilities::setLog(logConsoleFunc);
-
-    return logConsoleFunc;
-}
-
-int main(){
-    auto logConsoleFunc = getLogging();
+    auto logConsoleFunc = Examples::initLogging();
     std::mt19937 randomNumberGenerator (std::random_device{}());
     std::uniform_int_distribution<> distribution (0, 100000);
 
@@ -97,21 +152,11 @@ int main(){
     std::unique_ptr<TbStructArray::IStructArrayFieldInterface> testTbStructArrayStructArrayFieldInterface = std::make_unique<TbStructArray::MQTT::StructArrayFieldInterfaceClient>(mqttclient);
 
     // start mqtt connection
-    mqttclient->connectToHost("");
+    mqttclient->connectToHost(host);
 
-    bool keepRunning = true;
-    std::string cmd;
-    do {
-        std::cout << "Enter command:" << std::endl;
-        getline (std::cin, cmd);
-
-        if(cmd == "quit"){
-            mqttclient->disconnect();
-            keepRunning = false;
-        } else {
-
-        }
-    } while(keepRunning);
+    Examples::runCommandLoop({}, [&](){
+        mqttclient->disconnect();
+    });
 
     return 0;
 }

--- a/goldenmaster/examples/mqttserver/CMakeLists.txt
+++ b/goldenmaster/examples/mqttserver/CMakeLists.txt
@@ -62,6 +62,7 @@ target_link_libraries(MQTTServer
 # we assume that the examples are built together with the libraries and thus ignore this warning
 if(MSVC)
   target_compile_options(MQTTServer PRIVATE /wd4251)
+  target_compile_definitions(MQTTServer PRIVATE -D_CRT_SECURE_NO_WARNINGS)
 endif()
 
 install(TARGETS MQTTServer

--- a/goldenmaster/examples/mqttserver/main.cpp
+++ b/goldenmaster/examples/mqttserver/main.cpp
@@ -1,4 +1,4 @@
-#include <iostream>
+
 #include "testbed2/implementation/manyparaminterface.h"
 #include "testbed2/generated/mqtt/manyparaminterfaceservice.h"
 #include "testbed2/implementation/nestedstruct1interface.h"
@@ -53,42 +53,95 @@
 #include "tb_struct_array/generated/mqtt/structarrayfieldinterfaceservice.h"
 #include "apigear/mqtt/mqttservice.h"
 #include "apigear/utilities/logger.h"
-#include <iostream>
-#include <sstream>
 #include <cstdlib>
+#include <sstream>
+#include <iostream>
+#include <string>
+#include <functional>
+#include <map>
+
+namespace Examples {
+
+using CommandHandler = std::function<void(const std::string& args)>;
+using CommandMap = std::map<std::string, CommandHandler>;
+
+inline ApiGear::Utilities::WriteLogFunc initLogging()
+{
+    ApiGear::Utilities::LogLevel logLevel = ApiGear::Utilities::LogLevel::Warning;
+    if (const char* envLogLevel = std::getenv("LOG_LEVEL"))
+    {
+        int parsed = -1;
+        std::istringstream iss(envLogLevel);
+        if (!(iss >> parsed) || parsed < 0) {
+            std::cerr << "Warning: invalid LOG_LEVEL=\"" << envLogLevel
+                      << "\", using default (Warning)" << std::endl;
+        } else if (parsed > static_cast<int>(ApiGear::Utilities::LogLevel::Error)) {
+            ApiGear::Utilities::setLog(nullptr);
+            return nullptr;
+        } else {
+            logLevel = static_cast<ApiGear::Utilities::LogLevel>(parsed);
+        }
+    }
+    auto logFunc = ApiGear::Utilities::getConsoleLogFunc(logLevel);
+    ApiGear::Utilities::setLog(logFunc);
+    return logFunc;
+}
+
+inline void runCommandLoop(CommandMap commands, std::function<void()> onQuit)
+{
+    commands["help"] = [&](const std::string&) {
+        std::cout << "Available commands:";
+        for (const auto& [name, _] : commands) { std::cout << " " << name; }
+        std::cout << " quit exit" << std::endl;
+    };
+    std::string line;
+    std::cout << "Type \"help\" for available commands." << std::endl;
+    while (std::getline(std::cin, line)) {
+        auto start = line.find_first_not_of(" \t\r\n");
+        auto end = line.find_last_not_of(" \t\r\n");
+        if (start != std::string::npos) {
+            line = line.substr(start, end - start + 1);
+        } else {
+            line.clear();
+        }
+        for (auto& c : line) { c = static_cast<char>(std::tolower(static_cast<unsigned char>(c))); }
+        if (line == "quit" || line == "exit") {
+            if (onQuit) { onQuit(); }
+            return;
+        }
+        auto spacePos = line.find(' ');
+        std::string cmd = (spacePos == std::string::npos) ? line : line.substr(0, spacePos);
+        std::string args = (spacePos == std::string::npos) ? "" : line.substr(spacePos + 1);
+        auto it = commands.find(cmd);
+        if (it != commands.end()) {
+            it->second(args);
+        } else if (!cmd.empty()) {
+            std::cout << "Unknown command: \"" << cmd
+                      << "\". Type \"help\" for available commands." << std::endl;
+        }
+    }
+    if (onQuit) { onQuit(); }
+}
+
+} // namespace Examples
 #include <random>
 
 using namespace Test;
 
-ApiGear::Utilities::WriteLogFunc getLogging(){
+int main(int argc, char* argv[]){
 
-    ApiGear::Utilities::WriteLogFunc logConsoleFunc = nullptr;
-    ApiGear::Utilities::LogLevel logLevel = ApiGear::Utilities::LogLevel::Warning;
-
-    // check whether logging level is set via env
-    if (const char* envLogLevel = std::getenv("LOG_LEVEL"))
-    {
-        int logLevelNumber = 255;
-        std::stringstream(envLogLevel) >> logLevelNumber;
-        logLevel = static_cast<ApiGear::Utilities::LogLevel>(logLevelNumber);
+    // Parse command line arguments
+    std::string host = "localhost";
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--host" && i + 1 < argc) { host = argv[++i]; }
+        else if (arg == "--help") {
+            std::cout << "Usage: " << argv[0] << " [--host HOST]" << std::endl;
+            return 0;
+        }
     }
 
-    logConsoleFunc = ApiGear::Utilities::getConsoleLogFunc(logLevel);
-    // check whether logging was disabled
-    if (logLevel > ApiGear::Utilities::LogLevel::Error) {
-        logConsoleFunc = nullptr;
-    }
-
-    // set global log function
-    ApiGear::Utilities::setLog(logConsoleFunc);
-
-    return logConsoleFunc;
-}
-
-using namespace Test;
-
-int main(){
-    auto logConsoleFunc = getLogging();
+    auto logConsoleFunc = Examples::initLogging();
     std::mt19937 randomNumberGenerator (std::random_device{}());
     std::uniform_int_distribution<> distribution (0, 100000);
 
@@ -151,20 +204,11 @@ int main(){
     TbStructArray::MQTT::StructArrayFieldInterfaceService testTbStructArrayStructArrayFieldInterfaceService(testTbStructArrayStructArrayFieldInterface, mqttservice);
 
     // start mqtt connection
-    mqttservice->connectToHost("");
+    mqttservice->connectToHost(host);
 
-    bool keepRunning = true;
-    std::string cmd;
-    do {
-        std::cout << "Enter command:" << std::endl;
-        getline (std::cin, cmd);
-
-        if(cmd == "quit"){
-            mqttservice->disconnect();
-            keepRunning = false;
-        } else {
-        }
-    } while(keepRunning);
+    Examples::runCommandLoop({}, [&](){
+        mqttservice->disconnect();
+    });
 
     return 0;
 }

--- a/goldenmaster/examples/natsclient/CMakeLists.txt
+++ b/goldenmaster/examples/natsclient/CMakeLists.txt
@@ -53,6 +53,7 @@ target_link_libraries(NatsClient
 # we assume that the examples are built together with the libraries and thus ignore this warning
 if(MSVC)
   target_compile_options(NatsClient PRIVATE /wd4251)
+  target_compile_definitions(NatsClient PRIVATE -D_CRT_SECURE_NO_WARNINGS)
 endif()
 
 install(TARGETS NatsClient

--- a/goldenmaster/examples/natsclient/main.cpp
+++ b/goldenmaster/examples/natsclient/main.cpp
@@ -26,30 +26,95 @@
 #include "counter/generated/nats/counterclient.h"
 #include "tb_struct_array/generated/nats/structarrayfieldinterfaceclient.h"
 #include "apigear/utilities/logger.h"
-#include <iostream>
 #include "apigear/nats/natsclient.h"
+#include <cstdlib>
+#include <sstream>
+#include <iostream>
+#include <string>
+#include <functional>
+#include <map>
+
+namespace Examples {
+
+using CommandHandler = std::function<void(const std::string& args)>;
+using CommandMap = std::map<std::string, CommandHandler>;
+
+inline ApiGear::Utilities::WriteLogFunc initLogging()
+{
+    ApiGear::Utilities::LogLevel logLevel = ApiGear::Utilities::LogLevel::Warning;
+    if (const char* envLogLevel = std::getenv("LOG_LEVEL"))
+    {
+        int parsed = -1;
+        std::istringstream iss(envLogLevel);
+        if (!(iss >> parsed) || parsed < 0) {
+            std::cerr << "Warning: invalid LOG_LEVEL=\"" << envLogLevel
+                      << "\", using default (Warning)" << std::endl;
+        } else if (parsed > static_cast<int>(ApiGear::Utilities::LogLevel::Error)) {
+            ApiGear::Utilities::setLog(nullptr);
+            return nullptr;
+        } else {
+            logLevel = static_cast<ApiGear::Utilities::LogLevel>(parsed);
+        }
+    }
+    auto logFunc = ApiGear::Utilities::getConsoleLogFunc(logLevel);
+    ApiGear::Utilities::setLog(logFunc);
+    return logFunc;
+}
+
+inline void runCommandLoop(CommandMap commands, std::function<void()> onQuit)
+{
+    commands["help"] = [&](const std::string&) {
+        std::cout << "Available commands:";
+        for (const auto& [name, _] : commands) { std::cout << " " << name; }
+        std::cout << " quit exit" << std::endl;
+    };
+    std::string line;
+    std::cout << "Type \"help\" for available commands." << std::endl;
+    while (std::getline(std::cin, line)) {
+        auto start = line.find_first_not_of(" \t\r\n");
+        auto end = line.find_last_not_of(" \t\r\n");
+        if (start != std::string::npos) {
+            line = line.substr(start, end - start + 1);
+        } else {
+            line.clear();
+        }
+        for (auto& c : line) { c = static_cast<char>(std::tolower(static_cast<unsigned char>(c))); }
+        if (line == "quit" || line == "exit") {
+            if (onQuit) { onQuit(); }
+            return;
+        }
+        auto spacePos = line.find(' ');
+        std::string cmd = (spacePos == std::string::npos) ? line : line.substr(0, spacePos);
+        std::string args = (spacePos == std::string::npos) ? "" : line.substr(spacePos + 1);
+        auto it = commands.find(cmd);
+        if (it != commands.end()) {
+            it->second(args);
+        } else if (!cmd.empty()) {
+            std::cout << "Unknown command: \"" << cmd
+                      << "\". Type \"help\" for available commands." << std::endl;
+        }
+    }
+    if (onQuit) { onQuit(); }
+}
+
+} // namespace Examples
 
 using namespace Test;
 
-ApiGear::Utilities::WriteLogFunc getLogging(){
+int main(int argc, char* argv[]){
 
-    ApiGear::Utilities::WriteLogFunc logConsoleFunc = nullptr;
-    ApiGear::Utilities::LogLevel logLevel = ApiGear::Utilities::LogLevel::Warning;
-
-    logConsoleFunc = ApiGear::Utilities::getConsoleLogFunc(logLevel);
-    // check whether logging was disabled
-    if (logLevel > ApiGear::Utilities::LogLevel::Error) {
-        logConsoleFunc = nullptr;
+    // Parse command line arguments
+    std::string url = "nats://localhost:4222";
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--url" && i + 1 < argc) { url = argv[++i]; }
+        else if (arg == "--help") {
+            std::cout << "Usage: " << argv[0] << " [--url URL]" << std::endl;
+            return 0;
+        }
     }
 
-    // set global log function
-    ApiGear::Utilities::setLog(logConsoleFunc);
-
-    return logConsoleFunc;
-}
-
-int main(){
-
+    Examples::initLogging();
     auto client = std::make_shared<ApiGear::Nats::Client>();
 
     // set up modules
@@ -80,14 +145,14 @@ int main(){
     auto testCounterCounter = Counter::Nats::CounterClient::create(client);
     auto testTbStructArrayStructArrayFieldInterface = TbStructArray::Nats::StructArrayFieldInterfaceClient::create(client);
 
-   
+
     
     // Try out properties: subscribe for changes
     testTestbed2ManyParamInterface->_getPublisher().subscribeToProp1Changed([](auto value){ std::cout << " Prop1 " << std::endl; });
 
-    // or ask for change, when objest is ready
+    // or ask for change, when object is ready
     auto idSubProp = testTestbed2ManyParamInterface->_subscribeForIsReady(
-        [testTestbed2ManyParamInterface](bool connected) 
+        [testTestbed2ManyParamInterface](bool connected)
         {
             if (!connected)
             {
@@ -103,7 +168,7 @@ int main(){
     
     // Play around executing your operations
     auto idSubOperation = testTestbed2ManyParamInterface->_subscribeForIsReady(
-        [testTestbed2ManyParamInterface](bool connected) 
+        [testTestbed2ManyParamInterface](bool connected)
         {
             if (!connected)
             {
@@ -114,21 +179,11 @@ int main(){
     
 
     //connect
-    client->connect("nats://localhost:4222");
+    client->connect(url);
 
-    bool keepRunning = true;
-    std::string cmd;
-    do {
-        std::cout << "Enter command:" << std::endl;
-        getline (std::cin, cmd);
-
-        if(cmd == "quit"){
-            client->disconnect();
-            keepRunning = false;
-        } else {
-
-        }
-    } while(keepRunning);
+    Examples::runCommandLoop({}, [&](){
+        client->disconnect();
+    });
 
     return 0;
 }

--- a/goldenmaster/examples/natsserver/CMakeLists.txt
+++ b/goldenmaster/examples/natsserver/CMakeLists.txt
@@ -63,6 +63,7 @@ target_link_libraries(NatsServer
 # we assume that the examples are built together with the libraries and thus ignore this warning
 if(MSVC)
   target_compile_options(NatsServer PRIVATE /wd4251)
+  target_compile_definitions(NatsServer PRIVATE -D_CRT_SECURE_NO_WARNINGS)
 endif()
 
 install(TARGETS NatsServer

--- a/goldenmaster/examples/natsserver/main.cpp
+++ b/goldenmaster/examples/natsserver/main.cpp
@@ -53,31 +53,94 @@
 #include "tb_struct_array/generated/nats/structarrayfieldinterfaceservice.h"
 #include "apigear/nats/natsservice.h"
 #include "apigear/utilities/logger.h"
+#include <cstdlib>
+#include <sstream>
 #include <iostream>
+#include <string>
+#include <functional>
+#include <map>
 
-using namespace Test;
+namespace Examples {
 
-ApiGear::Utilities::WriteLogFunc getLogging(){
+using CommandHandler = std::function<void(const std::string& args)>;
+using CommandMap = std::map<std::string, CommandHandler>;
 
-    ApiGear::Utilities::WriteLogFunc logConsoleFunc = nullptr;
+inline ApiGear::Utilities::WriteLogFunc initLogging()
+{
     ApiGear::Utilities::LogLevel logLevel = ApiGear::Utilities::LogLevel::Warning;
-
-    logConsoleFunc = ApiGear::Utilities::getConsoleLogFunc(logLevel);
-    // check whether logging was disabled
-    if (logLevel > ApiGear::Utilities::LogLevel::Error) {
-        logConsoleFunc = nullptr;
+    if (const char* envLogLevel = std::getenv("LOG_LEVEL"))
+    {
+        int parsed = -1;
+        std::istringstream iss(envLogLevel);
+        if (!(iss >> parsed) || parsed < 0) {
+            std::cerr << "Warning: invalid LOG_LEVEL=\"" << envLogLevel
+                      << "\", using default (Warning)" << std::endl;
+        } else if (parsed > static_cast<int>(ApiGear::Utilities::LogLevel::Error)) {
+            ApiGear::Utilities::setLog(nullptr);
+            return nullptr;
+        } else {
+            logLevel = static_cast<ApiGear::Utilities::LogLevel>(parsed);
+        }
     }
-
-    // set global log function
-    ApiGear::Utilities::setLog(logConsoleFunc);
-
-    return logConsoleFunc;
+    auto logFunc = ApiGear::Utilities::getConsoleLogFunc(logLevel);
+    ApiGear::Utilities::setLog(logFunc);
+    return logFunc;
 }
 
+inline void runCommandLoop(CommandMap commands, std::function<void()> onQuit)
+{
+    commands["help"] = [&](const std::string&) {
+        std::cout << "Available commands:";
+        for (const auto& [name, _] : commands) { std::cout << " " << name; }
+        std::cout << " quit exit" << std::endl;
+    };
+    std::string line;
+    std::cout << "Type \"help\" for available commands." << std::endl;
+    while (std::getline(std::cin, line)) {
+        auto start = line.find_first_not_of(" \t\r\n");
+        auto end = line.find_last_not_of(" \t\r\n");
+        if (start != std::string::npos) {
+            line = line.substr(start, end - start + 1);
+        } else {
+            line.clear();
+        }
+        for (auto& c : line) { c = static_cast<char>(std::tolower(static_cast<unsigned char>(c))); }
+        if (line == "quit" || line == "exit") {
+            if (onQuit) { onQuit(); }
+            return;
+        }
+        auto spacePos = line.find(' ');
+        std::string cmd = (spacePos == std::string::npos) ? line : line.substr(0, spacePos);
+        std::string args = (spacePos == std::string::npos) ? "" : line.substr(spacePos + 1);
+        auto it = commands.find(cmd);
+        if (it != commands.end()) {
+            it->second(args);
+        } else if (!cmd.empty()) {
+            std::cout << "Unknown command: \"" << cmd
+                      << "\". Type \"help\" for available commands." << std::endl;
+        }
+    }
+    if (onQuit) { onQuit(); }
+}
+
+} // namespace Examples
+
 using namespace Test;
 
-int main(){
+int main(int argc, char* argv[]){
 
+    // Parse command line arguments
+    std::string url = "nats://localhost:4222";
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--url" && i + 1 < argc) { url = argv[++i]; }
+        else if (arg == "--help") {
+            std::cout << "Usage: " << argv[0] << " [--url URL]" << std::endl;
+            return 0;
+        }
+    }
+
+    Examples::initLogging();
     auto service = std::make_shared<ApiGear::Nats::Service>();
 
     // set up modules
@@ -134,20 +197,11 @@ int main(){
     std::shared_ptr<TbStructArray::IStructArrayFieldInterface> testTbStructArrayStructArrayFieldInterface = std::make_shared<TbStructArray::StructArrayFieldInterface>();
     auto testTbStructArrayStructArrayFieldInterfaceService = TbStructArray::Nats::StructArrayFieldInterfaceService::create(testTbStructArrayStructArrayFieldInterface, service);
 
-    service->connect("nats://localhost:4222");
+    service->connect(url);
 
-    bool keepRunning = true;
-    std::string cmd;
-    do {
-        std::cout << "Enter command:" << std::endl;
-        getline (std::cin, cmd);
-
-        if(cmd == "quit"){
-            service->disconnect();
-            keepRunning = false;
-        } else {
-        }
-    } while(keepRunning);
+    Examples::runCommandLoop({}, [&](){
+        service->disconnect();
+    });
 
     return 0;
 }

--- a/goldenmaster/examples/olinkclient/main.cpp
+++ b/goldenmaster/examples/olinkclient/main.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <string>
 #include "testbed2/generated/olink/manyparaminterfaceclient.h"
 #include "testbed2/generated/monitor/manyparaminterface.tracedecorator.h"
 #include "testbed2/generated/olink/nestedstruct1interfaceclient.h"
@@ -56,41 +57,102 @@
 #include "apigear/tracer/tracer.h"
 #include "apigear/olink/olinklogadapter.h"
 #include "olink/clientregistry.h"
-#include <sstream>
+#include "apigear/utilities/logger.h"
 #include <cstdlib>
+#include <sstream>
+#include <functional>
+#include <map>
 
-ApiGear::Utilities::WriteLogFunc getLogging(){
+namespace Examples {
 
-    ApiGear::Utilities::WriteLogFunc logConsoleFunc = nullptr;
+using CommandHandler = std::function<void(const std::string& args)>;
+using CommandMap = std::map<std::string, CommandHandler>;
+
+inline ApiGear::Utilities::WriteLogFunc initLogging()
+{
     ApiGear::Utilities::LogLevel logLevel = ApiGear::Utilities::LogLevel::Warning;
-
-    // check whether logging level is set via env
     if (const char* envLogLevel = std::getenv("LOG_LEVEL"))
     {
-        int logLevelNumber = 255;
-        std::stringstream(envLogLevel) >> logLevelNumber;
-        logLevel = static_cast<ApiGear::Utilities::LogLevel>(logLevelNumber);
+        int parsed = -1;
+        std::istringstream iss(envLogLevel);
+        if (!(iss >> parsed) || parsed < 0) {
+            std::cerr << "Warning: invalid LOG_LEVEL=\"" << envLogLevel
+                      << "\", using default (Warning)" << std::endl;
+        } else if (parsed > static_cast<int>(ApiGear::Utilities::LogLevel::Error)) {
+            ApiGear::Utilities::setLog(nullptr);
+            return nullptr;
+        } else {
+            logLevel = static_cast<ApiGear::Utilities::LogLevel>(parsed);
+        }
     }
-
-    logConsoleFunc = ApiGear::Utilities::getConsoleLogFunc(logLevel);
-    // check whether logging was disabled
-    if (logLevel > ApiGear::Utilities::LogLevel::Error) {
-        logConsoleFunc = nullptr;
-    }
-
-    // set global log function
-    ApiGear::Utilities::setLog(logConsoleFunc);
-
-    return logConsoleFunc;
+    auto logFunc = ApiGear::Utilities::getConsoleLogFunc(logLevel);
+    ApiGear::Utilities::setLog(logFunc);
+    return logFunc;
 }
+
+inline void runCommandLoop(CommandMap commands, std::function<void()> onQuit)
+{
+    commands["help"] = [&](const std::string&) {
+        std::cout << "Available commands:";
+        for (const auto& [name, _] : commands) { std::cout << " " << name; }
+        std::cout << " quit exit" << std::endl;
+    };
+
+    std::string line;
+    std::cout << "Type \"help\" for available commands." << std::endl;
+    while (std::getline(std::cin, line)) {
+        auto start = line.find_first_not_of(" \t\r\n");
+        auto end = line.find_last_not_of(" \t\r\n");
+        if (start != std::string::npos) {
+            line = line.substr(start, end - start + 1);
+        } else {
+            line.clear();
+        }
+        for (auto& c : line) { c = static_cast<char>(std::tolower(static_cast<unsigned char>(c))); }
+
+        if (line == "quit" || line == "exit") {
+            if (onQuit) { onQuit(); }
+            return;
+        }
+
+        auto spacePos = line.find(' ');
+        std::string cmd = (spacePos == std::string::npos) ? line : line.substr(0, spacePos);
+        std::string args = (spacePos == std::string::npos) ? "" : line.substr(spacePos + 1);
+
+        auto it = commands.find(cmd);
+        if (it != commands.end()) {
+            it->second(args);
+        } else if (!cmd.empty()) {
+            std::cout << "Unknown command: \"" << cmd
+                      << "\". Type \"help\" for available commands." << std::endl;
+        }
+    }
+    if (onQuit) { onQuit(); }
+}
+
+} // namespace Examples
 
 using namespace Test;
 
-int main(){
+int main(int argc, char* argv[]){
+
+    // Parse command line arguments
+    std::string host = "localhost";
+    int port = 8000;
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--host" && i + 1 < argc) { host = argv[++i]; }
+        else if (arg == "--port" && i + 1 < argc) { port = std::stoi(argv[++i]); }
+        else if (arg == "--help") {
+            std::cout << "Usage: " << argv[0] << " [--host HOST] [--port PORT]" << std::endl;
+            return 0;
+        }
+    }
+    auto uri = "ws://" + host + ":" + std::to_string(port);
     ApiGear::PocoImpl::Tracer tracer;
     tracer.connect("http://localhost:5555", "testExampleOLinkApp");
     ApiGear::ObjectLink::ClientRegistry registry;
-    auto logConsoleFunc = getLogging();
+    auto logConsoleFunc = Examples::initLogging();
     registry.onLog(ApiGear::Utilities::logAdapter(logConsoleFunc));
     ApiGear::PocoImpl::OlinkConnection clientNetworkEndpoint(registry);
     clientNetworkEndpoint.node()->onLog(ApiGear::Utilities::logAdapter(logConsoleFunc));
@@ -172,46 +234,38 @@ int main(){
     auto tbStructArrayStructArrayFieldInterface = std::make_shared<TbStructArray::olink::StructArrayFieldInterfaceClient>();
     clientNetworkEndpoint.connectAndLinkObject(tbStructArrayStructArrayFieldInterface);
     std::unique_ptr<TbStructArray::IStructArrayFieldInterface> tbStructArrayStructArrayFieldInterfaceTraced = TbStructArray::StructArrayFieldInterfaceTraceDecorator::connect(*tbStructArrayStructArrayFieldInterface, tracer);
-    
-    clientNetworkEndpoint.connectToHost(Poco::URI("ws://localhost:8000"));
 
-    bool keepRunning = true;
-    std::string cmd;
-    do {
-        std::cout << "Enter command:" << std::endl;
-        getline (std::cin, cmd);
+    clientNetworkEndpoint.connectToHost(Poco::URI(uri));
 
-        if(cmd == "quit"){
-            keepRunning = false;
-            clientNetworkEndpoint.disconnect();
-        }
-    } while(keepRunning);
-    clientNetworkEndpoint.disconnectAndUnlink(testbed2ManyParamInterface->olinkObjectName());
-    clientNetworkEndpoint.disconnectAndUnlink(testbed2NestedStruct1Interface->olinkObjectName());
-    clientNetworkEndpoint.disconnectAndUnlink(testbed2NestedStruct2Interface->olinkObjectName());
-    clientNetworkEndpoint.disconnectAndUnlink(testbed2NestedStruct3Interface->olinkObjectName());
-    clientNetworkEndpoint.disconnectAndUnlink(tbEnumEnumInterface->olinkObjectName());
-    clientNetworkEndpoint.disconnectAndUnlink(tbSame1SameStruct1Interface->olinkObjectName());
-    clientNetworkEndpoint.disconnectAndUnlink(tbSame1SameStruct2Interface->olinkObjectName());
-    clientNetworkEndpoint.disconnectAndUnlink(tbSame1SameEnum1Interface->olinkObjectName());
-    clientNetworkEndpoint.disconnectAndUnlink(tbSame1SameEnum2Interface->olinkObjectName());
-    clientNetworkEndpoint.disconnectAndUnlink(tbSame2SameStruct1Interface->olinkObjectName());
-    clientNetworkEndpoint.disconnectAndUnlink(tbSame2SameStruct2Interface->olinkObjectName());
-    clientNetworkEndpoint.disconnectAndUnlink(tbSame2SameEnum1Interface->olinkObjectName());
-    clientNetworkEndpoint.disconnectAndUnlink(tbSame2SameEnum2Interface->olinkObjectName());
-    clientNetworkEndpoint.disconnectAndUnlink(tbSimpleVoidInterface->olinkObjectName());
-    clientNetworkEndpoint.disconnectAndUnlink(tbSimpleSimpleInterface->olinkObjectName());
-    clientNetworkEndpoint.disconnectAndUnlink(tbSimpleSimpleArrayInterface->olinkObjectName());
-    clientNetworkEndpoint.disconnectAndUnlink(tbSimpleNoPropertiesInterface->olinkObjectName());
-    clientNetworkEndpoint.disconnectAndUnlink(tbSimpleNoOperationsInterface->olinkObjectName());
-    clientNetworkEndpoint.disconnectAndUnlink(tbSimpleNoSignalsInterface->olinkObjectName());
-    clientNetworkEndpoint.disconnectAndUnlink(tbSimpleEmptyInterface->olinkObjectName());
-    clientNetworkEndpoint.disconnectAndUnlink(testbed1StructInterface->olinkObjectName());
-    clientNetworkEndpoint.disconnectAndUnlink(testbed1StructArrayInterface->olinkObjectName());
-    clientNetworkEndpoint.disconnectAndUnlink(testbed1StructArray2Interface->olinkObjectName());
-    clientNetworkEndpoint.disconnectAndUnlink(tbNamesNamEs->olinkObjectName());
-    clientNetworkEndpoint.disconnectAndUnlink(counterCounter->olinkObjectName());
-    clientNetworkEndpoint.disconnectAndUnlink(tbStructArrayStructArrayFieldInterface->olinkObjectName());
+    Examples::runCommandLoop({}, [&](){
+        clientNetworkEndpoint.disconnectAndUnlink(testbed2ManyParamInterface->olinkObjectName());
+        clientNetworkEndpoint.disconnectAndUnlink(testbed2NestedStruct1Interface->olinkObjectName());
+        clientNetworkEndpoint.disconnectAndUnlink(testbed2NestedStruct2Interface->olinkObjectName());
+        clientNetworkEndpoint.disconnectAndUnlink(testbed2NestedStruct3Interface->olinkObjectName());
+        clientNetworkEndpoint.disconnectAndUnlink(tbEnumEnumInterface->olinkObjectName());
+        clientNetworkEndpoint.disconnectAndUnlink(tbSame1SameStruct1Interface->olinkObjectName());
+        clientNetworkEndpoint.disconnectAndUnlink(tbSame1SameStruct2Interface->olinkObjectName());
+        clientNetworkEndpoint.disconnectAndUnlink(tbSame1SameEnum1Interface->olinkObjectName());
+        clientNetworkEndpoint.disconnectAndUnlink(tbSame1SameEnum2Interface->olinkObjectName());
+        clientNetworkEndpoint.disconnectAndUnlink(tbSame2SameStruct1Interface->olinkObjectName());
+        clientNetworkEndpoint.disconnectAndUnlink(tbSame2SameStruct2Interface->olinkObjectName());
+        clientNetworkEndpoint.disconnectAndUnlink(tbSame2SameEnum1Interface->olinkObjectName());
+        clientNetworkEndpoint.disconnectAndUnlink(tbSame2SameEnum2Interface->olinkObjectName());
+        clientNetworkEndpoint.disconnectAndUnlink(tbSimpleVoidInterface->olinkObjectName());
+        clientNetworkEndpoint.disconnectAndUnlink(tbSimpleSimpleInterface->olinkObjectName());
+        clientNetworkEndpoint.disconnectAndUnlink(tbSimpleSimpleArrayInterface->olinkObjectName());
+        clientNetworkEndpoint.disconnectAndUnlink(tbSimpleNoPropertiesInterface->olinkObjectName());
+        clientNetworkEndpoint.disconnectAndUnlink(tbSimpleNoOperationsInterface->olinkObjectName());
+        clientNetworkEndpoint.disconnectAndUnlink(tbSimpleNoSignalsInterface->olinkObjectName());
+        clientNetworkEndpoint.disconnectAndUnlink(tbSimpleEmptyInterface->olinkObjectName());
+        clientNetworkEndpoint.disconnectAndUnlink(testbed1StructInterface->olinkObjectName());
+        clientNetworkEndpoint.disconnectAndUnlink(testbed1StructArrayInterface->olinkObjectName());
+        clientNetworkEndpoint.disconnectAndUnlink(testbed1StructArray2Interface->olinkObjectName());
+        clientNetworkEndpoint.disconnectAndUnlink(tbNamesNamEs->olinkObjectName());
+        clientNetworkEndpoint.disconnectAndUnlink(counterCounter->olinkObjectName());
+        clientNetworkEndpoint.disconnectAndUnlink(tbStructArrayStructArrayFieldInterface->olinkObjectName());
+        clientNetworkEndpoint.disconnect();
+    });
 
     return 0;
 }

--- a/goldenmaster/examples/olinkserver/CMakeLists.txt
+++ b/goldenmaster/examples/olinkserver/CMakeLists.txt
@@ -22,8 +22,6 @@ else()
   # disable the warning for getenv - needs better cross platform solution
   target_compile_definitions(OLinkServer PRIVATE -D_CRT_SECURE_NO_WARNINGS)
 endif()
-
-find_package(apigear REQUIRED COMPONENTS utilities)
 find_package(testbed2 REQUIRED COMPONENTS testbed2-core testbed2-implementation testbed2-olink)
 find_package(tb_enum REQUIRED COMPONENTS tb_enum-core tb_enum-implementation tb_enum-olink)
 find_package(tb_same1 REQUIRED COMPONENTS tb_same1-core tb_same1-implementation tb_same1-olink)

--- a/goldenmaster/examples/olinkserver/main.cpp
+++ b/goldenmaster/examples/olinkserver/main.cpp
@@ -81,41 +81,100 @@
 #include "apigear/olink/olinklogadapter.h"
 #include "olink/remoteregistry.h"
 #include "apigear/olink/olinkhost.h"
-
-#include <iostream>
-#include <sstream>
+#include "apigear/utilities/logger.h"
 #include <cstdlib>
+#include <sstream>
+#include <iostream>
+#include <string>
+#include <functional>
+#include <map>
 
-ApiGear::Utilities::WriteLogFunc getLogging(){
+namespace Examples {
 
-    ApiGear::Utilities::WriteLogFunc logConsoleFunc = nullptr;
+using CommandHandler = std::function<void(const std::string& args)>;
+using CommandMap = std::map<std::string, CommandHandler>;
+
+inline ApiGear::Utilities::WriteLogFunc initLogging()
+{
     ApiGear::Utilities::LogLevel logLevel = ApiGear::Utilities::LogLevel::Warning;
-
-    // check whether logging level is set via env
     if (const char* envLogLevel = std::getenv("LOG_LEVEL"))
     {
-        int logLevelNumber = 255;
-        std::stringstream(envLogLevel) >> logLevelNumber;
-        logLevel = static_cast<ApiGear::Utilities::LogLevel>(logLevelNumber);
+        int parsed = -1;
+        std::istringstream iss(envLogLevel);
+        if (!(iss >> parsed) || parsed < 0) {
+            std::cerr << "Warning: invalid LOG_LEVEL=\"" << envLogLevel
+                      << "\", using default (Warning)" << std::endl;
+        } else if (parsed > static_cast<int>(ApiGear::Utilities::LogLevel::Error)) {
+            ApiGear::Utilities::setLog(nullptr);
+            return nullptr;
+        } else {
+            logLevel = static_cast<ApiGear::Utilities::LogLevel>(parsed);
+        }
     }
-
-    logConsoleFunc = ApiGear::Utilities::getConsoleLogFunc(logLevel);
-    // check whether logging was disabled
-    if (logLevel > ApiGear::Utilities::LogLevel::Error) {
-        logConsoleFunc = nullptr;
-    }
-
-    // set global log function
-    ApiGear::Utilities::setLog(logConsoleFunc);
-
-    return logConsoleFunc;
+    auto logFunc = ApiGear::Utilities::getConsoleLogFunc(logLevel);
+    ApiGear::Utilities::setLog(logFunc);
+    return logFunc;
 }
+
+inline void runCommandLoop(CommandMap commands, std::function<void()> onQuit)
+{
+    commands["help"] = [&](const std::string&) {
+        std::cout << "Available commands:";
+        for (const auto& [name, _] : commands) { std::cout << " " << name; }
+        std::cout << " quit exit" << std::endl;
+    };
+
+    std::string line;
+    std::cout << "Type \"help\" for available commands." << std::endl;
+    while (std::getline(std::cin, line)) {
+        auto start = line.find_first_not_of(" \t\r\n");
+        auto end = line.find_last_not_of(" \t\r\n");
+        if (start != std::string::npos) {
+            line = line.substr(start, end - start + 1);
+        } else {
+            line.clear();
+        }
+        for (auto& c : line) { c = static_cast<char>(std::tolower(static_cast<unsigned char>(c))); }
+
+        if (line == "quit" || line == "exit") {
+            if (onQuit) { onQuit(); }
+            return;
+        }
+
+        auto spacePos = line.find(' ');
+        std::string cmd = (spacePos == std::string::npos) ? line : line.substr(0, spacePos);
+        std::string args = (spacePos == std::string::npos) ? "" : line.substr(spacePos + 1);
+
+        auto it = commands.find(cmd);
+        if (it != commands.end()) {
+            it->second(args);
+        } else if (!cmd.empty()) {
+            std::cout << "Unknown command: \"" << cmd
+                      << "\". Type \"help\" for available commands." << std::endl;
+        }
+    }
+    if (onQuit) { onQuit(); }
+}
+
+} // namespace Examples
 
 using namespace Test;
 
-int main(){
+int main(int argc, char* argv[]){
+
+    // Parse command line arguments
+    int port = 8000;
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--port" && i + 1 < argc) { port = std::stoi(argv[++i]); }
+        else if (arg == "--help") {
+            std::cout << "Usage: " << argv[0] << " [--port PORT]" << std::endl;
+            return 0;
+        }
+    }
+
     ApiGear::ObjectLink::RemoteRegistry registry;
-    auto logConsoleFunc = getLogging();
+    auto logConsoleFunc = Examples::initLogging();
     registry.onLog(ApiGear::Utilities::logAdapter(logConsoleFunc));
 
     ApiGear::PocoImpl::OLinkHost testserver(registry, ApiGear::Utilities::logAdapter(logConsoleFunc));
@@ -226,45 +285,37 @@ int main(){
 
     // Start your server after all the services are added.
     // This ensures that any new client that connects, will find the source it needs.
-    testserver.listen(8000);
+    testserver.listen(port);
 
-    bool keepRunning = true;
-    std::string cmd;
-    do {
-        std::cout << "Enter command:" << std::endl;
-        getline (std::cin, cmd);
+    Examples::runCommandLoop({}, [&](){
+        registry.removeSource(testbed2OlinkManyParamInterfaceService->olinkObjectName());
+        registry.removeSource(testbed2OlinkNestedStruct1InterfaceService->olinkObjectName());
+        registry.removeSource(testbed2OlinkNestedStruct2InterfaceService->olinkObjectName());
+        registry.removeSource(testbed2OlinkNestedStruct3InterfaceService->olinkObjectName());
+        registry.removeSource(tbEnumOlinkEnumInterfaceService->olinkObjectName());
+        registry.removeSource(tbSame1OlinkSameStruct1InterfaceService->olinkObjectName());
+        registry.removeSource(tbSame1OlinkSameStruct2InterfaceService->olinkObjectName());
+        registry.removeSource(tbSame1OlinkSameEnum1InterfaceService->olinkObjectName());
+        registry.removeSource(tbSame1OlinkSameEnum2InterfaceService->olinkObjectName());
+        registry.removeSource(tbSame2OlinkSameStruct1InterfaceService->olinkObjectName());
+        registry.removeSource(tbSame2OlinkSameStruct2InterfaceService->olinkObjectName());
+        registry.removeSource(tbSame2OlinkSameEnum1InterfaceService->olinkObjectName());
+        registry.removeSource(tbSame2OlinkSameEnum2InterfaceService->olinkObjectName());
+        registry.removeSource(tbSimpleOlinkVoidInterfaceService->olinkObjectName());
+        registry.removeSource(tbSimpleOlinkSimpleInterfaceService->olinkObjectName());
+        registry.removeSource(tbSimpleOlinkSimpleArrayInterfaceService->olinkObjectName());
+        registry.removeSource(tbSimpleOlinkNoPropertiesInterfaceService->olinkObjectName());
+        registry.removeSource(tbSimpleOlinkNoOperationsInterfaceService->olinkObjectName());
+        registry.removeSource(tbSimpleOlinkNoSignalsInterfaceService->olinkObjectName());
+        registry.removeSource(tbSimpleOlinkEmptyInterfaceService->olinkObjectName());
+        registry.removeSource(testbed1OlinkStructInterfaceService->olinkObjectName());
+        registry.removeSource(testbed1OlinkStructArrayInterfaceService->olinkObjectName());
+        registry.removeSource(testbed1OlinkStructArray2InterfaceService->olinkObjectName());
+        registry.removeSource(tbNamesOlinkNamEsService->olinkObjectName());
+        registry.removeSource(counterOlinkCounterService->olinkObjectName());
+        registry.removeSource(tbStructArrayOlinkStructArrayFieldInterfaceService->olinkObjectName());
+        testserver.close();
+    });
 
-        if(cmd == "quit"){
-            testserver.close();
-            keepRunning = false;
-        }
-    } while(keepRunning);
-    registry.removeSource(testbed2OlinkManyParamInterfaceService->olinkObjectName());
-    registry.removeSource(testbed2OlinkNestedStruct1InterfaceService->olinkObjectName());
-    registry.removeSource(testbed2OlinkNestedStruct2InterfaceService->olinkObjectName());
-    registry.removeSource(testbed2OlinkNestedStruct3InterfaceService->olinkObjectName());
-    registry.removeSource(tbEnumOlinkEnumInterfaceService->olinkObjectName());
-    registry.removeSource(tbSame1OlinkSameStruct1InterfaceService->olinkObjectName());
-    registry.removeSource(tbSame1OlinkSameStruct2InterfaceService->olinkObjectName());
-    registry.removeSource(tbSame1OlinkSameEnum1InterfaceService->olinkObjectName());
-    registry.removeSource(tbSame1OlinkSameEnum2InterfaceService->olinkObjectName());
-    registry.removeSource(tbSame2OlinkSameStruct1InterfaceService->olinkObjectName());
-    registry.removeSource(tbSame2OlinkSameStruct2InterfaceService->olinkObjectName());
-    registry.removeSource(tbSame2OlinkSameEnum1InterfaceService->olinkObjectName());
-    registry.removeSource(tbSame2OlinkSameEnum2InterfaceService->olinkObjectName());
-    registry.removeSource(tbSimpleOlinkVoidInterfaceService->olinkObjectName());
-    registry.removeSource(tbSimpleOlinkSimpleInterfaceService->olinkObjectName());
-    registry.removeSource(tbSimpleOlinkSimpleArrayInterfaceService->olinkObjectName());
-    registry.removeSource(tbSimpleOlinkNoPropertiesInterfaceService->olinkObjectName());
-    registry.removeSource(tbSimpleOlinkNoOperationsInterfaceService->olinkObjectName());
-    registry.removeSource(tbSimpleOlinkNoSignalsInterfaceService->olinkObjectName());
-    registry.removeSource(tbSimpleOlinkEmptyInterfaceService->olinkObjectName());
-    registry.removeSource(testbed1OlinkStructInterfaceService->olinkObjectName());
-    registry.removeSource(testbed1OlinkStructArrayInterfaceService->olinkObjectName());
-    registry.removeSource(testbed1OlinkStructArray2InterfaceService->olinkObjectName());
-    registry.removeSource(tbNamesOlinkNamEsService->olinkObjectName());
-    registry.removeSource(counterOlinkCounterService->olinkObjectName());
-    registry.removeSource(tbStructArrayOlinkStructArrayFieldInterfaceService->olinkObjectName());
-    
     return 0;
 }

--- a/goldenmaster/scripts/test_conan.sh
+++ b/goldenmaster/scripts/test_conan.sh
@@ -25,9 +25,8 @@ build_example()
 {
     mkdir -p $1 &&\
     pushd $1 &&\
-    cp -a ../../../$1/* . &&\
-    conan install --build missing . -g=VirtualRunEnv &&\
-    cmake -S . --preset conan-release &&\
+    conan install --build missing ../../../$1 -g=VirtualRunEnv &&\
+    cmake -B . -S ../../../$1 --preset conan-release &&\
     cmake --build .
     buildresult=$?
     popd

--- a/templates/examples/app/CMakeLists.txt.tpl
+++ b/templates/examples/app/CMakeLists.txt.tpl
@@ -20,6 +20,7 @@ if(NOT MSVC)
   target_compile_options(app PRIVATE -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wnon-virtual-dtor -Woverloaded-virtual -Wcast-align -Werror -fvisibility=hidden)
 else()
   target_compile_options(app PRIVATE /W4 /WX /wd4251)
+  target_compile_definitions(app PRIVATE -D_CRT_SECURE_NO_WARNINGS)
 endif()
 {{- nl }}
 

--- a/templates/examples/app/main.cpp.tpl
+++ b/templates/examples/app/main.cpp.tpl
@@ -11,7 +11,9 @@
 {{- end }}
 {{- if $features.monitor }}
 #include "apigear/tracer/tracer.h"
-{{ end}}
+{{- end}}
+#include <iostream>
+
 using namespace {{ Camel .System.Name }};
 
 int main(){
@@ -30,5 +32,47 @@ int main(){
 {{- end }}
 {{- end }}
 
+    // Demonstrate basic property access
+    {{ $propertyExampleReady := 0 -}}
+    {{ $operationExampleReady := 0 -}}
+    {{- range .System.Modules -}}
+    {{- $module := . -}}
+    {{- range $module.Interfaces -}}
+    {{- $interface := . -}}
+{{- if (and (eq $propertyExampleReady 0) (len $interface.Properties) )}}
+    {{- $property := (index $interface.Properties 0) }}
+    {{- $class := Camel $interface.Name }}
+    {{- $namespacePrefix := printf "%s::" (Camel $module.Name)}}
+    {
+        [[maybe_unused]] auto value = test{{ Camel $module.Name }}{{$class}}->get{{Camel $property.Name}}();
+        std::cout << "{{ Camel $module.Name }}::{{$class}}::{{Camel $property.Name}} default value retrieved" << std::endl;
+        test{{ Camel $module.Name }}{{$class}}->set{{Camel $property.Name}}({{cppDefault $namespacePrefix $property}});
+        std::cout << "{{ Camel $module.Name }}::{{$class}}::{{Camel $property.Name}} value set" << std::endl;
+    }
+    {{ $propertyExampleReady = 1}}
+{{- end }}
+{{- if (and (eq $operationExampleReady 0) (len $interface.Operations))}}
+    {{- $operation := (index $interface.Operations 0) }}
+    {{- $class := Camel $interface.Name }}
+    {{- $namespacePrefix := printf "%s::" (Camel $module.Name)}}
+    {
+        {{ if (not $operation.Return.IsVoid) }}[[maybe_unused]] auto result = {{ end }}test{{ Camel $module.Name }}{{$class}}->{{lower1 $operation.Name}}(
+            {{- range $i, $e := $operation.Params }}
+                {{- if $i }}, {{ end }}{{cppDefault $namespacePrefix $e}}
+            {{- end }});
+        std::cout << "{{ Camel $module.Name }}::{{$class}}::{{$operation.Name}} called" << std::endl;
+    }
+    {{ $operationExampleReady = 1}}
+{{- end }}
+{{- if (and $operationExampleReady $propertyExampleReady)}}
+    {{- break}}
+{{- end }}
+{{- end}}
+{{- if (and $operationExampleReady $propertyExampleReady)}}
+    {{- break}}
+{{- end }}
+{{- end}}
+
+    std::cout << "App example finished." << std::endl;
     return 0;
 }

--- a/templates/examples/appthreadsafe/CMakeLists.txt.tpl
+++ b/templates/examples/appthreadsafe/CMakeLists.txt.tpl
@@ -19,6 +19,7 @@ if(NOT MSVC)
   target_compile_options(appthreadsafe PRIVATE -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wnon-virtual-dtor -Woverloaded-virtual -Wcast-align -Werror -fvisibility=hidden)
 else()
   target_compile_options(appthreadsafe PRIVATE /W4 /WX /wd4251)
+  target_compile_definitions(appthreadsafe PRIVATE -D_CRT_SECURE_NO_WARNINGS)
 endif()
 {{- nl }}
 

--- a/templates/examples/appthreadsafe/main.cpp.tpl
+++ b/templates/examples/appthreadsafe/main.cpp.tpl
@@ -5,8 +5,9 @@
 #include "{{snake $module.Name}}/implementation/{{ lower ( camel $interface.Name) }}.h"
 #include "{{snake $module.Name}}/generated/core/{{ lower ( camel $interface.Name) }}.threadsafedecorator.h"
 {{- end }}
-{{- end }}{{nl}}
-
+{{- end }}
+#include <iostream>
+{{nl}}
 {{- range .System.Modules }}
 {{- $module := . }}
 {{- range $module.Interfaces }}
@@ -24,8 +25,10 @@ void test{{ Camel $module.Name }}{{$class}}()
 {{- $property := . }}
     auto l_{{lower1 (Camel $property.Name)}} = {{cppDefault "" $property}};
     l_{{lower1 (Camel $property.Name)}} = test{{$class}}->get{{Camel $property.Name}}();
+    std::cout << "  {{$class}}::{{Camel $property.Name}} retrieved" << std::endl;
 {{- if not .IsReadOnly }}
     test{{$class}}->set{{Camel $property.Name}}(l_{{lower1 (Camel $property.Name)}});
+    std::cout << "  {{$class}}::{{Camel $property.Name}} set" << std::endl;
 {{- end }}
 {{- end }}
 }{{nl}}
@@ -38,10 +41,11 @@ int main(){
 {{- range $module.Interfaces }}
 {{- $interface := . }}
     {{- $class := Camel $interface.Name }}
-    {{- $tracer_class := printf "%sThreadSafeDecorator" $class }}
+    std::cout << "Testing {{ Camel $module.Name }}::{{$class}} (thread-safe)" << std::endl;
     test{{ Camel $module.Name }}{{$class}}();
 {{- end }}
 {{- end }}
 
+    std::cout << "AppThreadSafe example finished." << std::endl;
     return 0;
 }

--- a/templates/examples/mqttclient/CMakeLists.txt.tpl
+++ b/templates/examples/mqttclient/CMakeLists.txt.tpl
@@ -35,6 +35,7 @@ target_link_libraries(MQTTClient
 # we assume that the examples are built together with the libraries and thus ignore this warning
 if(MSVC)
   target_compile_options(MQTTClient PRIVATE /wd4251)
+  target_compile_definitions(MQTTClient PRIVATE -D_CRT_SECURE_NO_WARNINGS)
 endif()
 
 install(TARGETS MQTTClient

--- a/templates/examples/mqttclient/main.cpp.tpl
+++ b/templates/examples/mqttclient/main.cpp.tpl
@@ -1,4 +1,3 @@
-#include <iostream>
 {{- range .System.Modules }}
 {{- $module := . }}
 {{- range $module.Interfaces }}
@@ -8,40 +7,95 @@
 {{- end }}
 #include "apigear/mqtt/mqttclient.h"
 #include "apigear/utilities/logger.h"
-#include <iostream>
-#include <sstream>
 #include <cstdlib>
+#include <sstream>
+#include <iostream>
+#include <string>
+#include <functional>
+#include <map>
+
+namespace Examples {
+
+using CommandHandler = std::function<void(const std::string& args)>;
+using CommandMap = std::map<std::string, CommandHandler>;
+
+inline ApiGear::Utilities::WriteLogFunc initLogging()
+{
+    ApiGear::Utilities::LogLevel logLevel = ApiGear::Utilities::LogLevel::Warning;
+    if (const char* envLogLevel = std::getenv("LOG_LEVEL"))
+    {
+        int parsed = -1;
+        std::istringstream iss(envLogLevel);
+        if (!(iss >> parsed) || parsed < 0) {
+            std::cerr << "Warning: invalid LOG_LEVEL=\"" << envLogLevel
+                      << "\", using default (Warning)" << std::endl;
+        } else if (parsed > static_cast<int>(ApiGear::Utilities::LogLevel::Error)) {
+            ApiGear::Utilities::setLog(nullptr);
+            return nullptr;
+        } else {
+            logLevel = static_cast<ApiGear::Utilities::LogLevel>(parsed);
+        }
+    }
+    auto logFunc = ApiGear::Utilities::getConsoleLogFunc(logLevel);
+    ApiGear::Utilities::setLog(logFunc);
+    return logFunc;
+}
+
+inline void runCommandLoop(CommandMap commands, std::function<void()> onQuit)
+{
+    commands["help"] = [&](const std::string&) {
+        std::cout << "Available commands:";
+        for (const auto& [name, _] : commands) { std::cout << " " << name; }
+        std::cout << " quit exit" << std::endl;
+    };
+    std::string line;
+    std::cout << "Type \"help\" for available commands." << std::endl;
+    while (std::getline(std::cin, line)) {
+        auto start = line.find_first_not_of(" \t\r\n");
+        auto end = line.find_last_not_of(" \t\r\n");
+        if (start != std::string::npos) {
+            line = line.substr(start, end - start + 1);
+        } else {
+            line.clear();
+        }
+        for (auto& c : line) { c = static_cast<char>(std::tolower(static_cast<unsigned char>(c))); }
+        if (line == "quit" || line == "exit") {
+            if (onQuit) { onQuit(); }
+            return;
+        }
+        auto spacePos = line.find(' ');
+        std::string cmd = (spacePos == std::string::npos) ? line : line.substr(0, spacePos);
+        std::string args = (spacePos == std::string::npos) ? "" : line.substr(spacePos + 1);
+        auto it = commands.find(cmd);
+        if (it != commands.end()) {
+            it->second(args);
+        } else if (!cmd.empty()) {
+            std::cout << "Unknown command: \"" << cmd
+                      << "\". Type \"help\" for available commands." << std::endl;
+        }
+    }
+    if (onQuit) { onQuit(); }
+}
+
+} // namespace Examples
 #include <random>
 
 using namespace {{ Camel .System.Name }};
 
-ApiGear::Utilities::WriteLogFunc getLogging(){
+int main(int argc, char* argv[]){
 
-    ApiGear::Utilities::WriteLogFunc logConsoleFunc = nullptr;
-    ApiGear::Utilities::LogLevel logLevel = ApiGear::Utilities::LogLevel::Warning;
-
-    // check whether logging level is set via env
-    if (const char* envLogLevel = std::getenv("LOG_LEVEL"))
-    {
-        int logLevelNumber = 255;
-        std::stringstream(envLogLevel) >> logLevelNumber;
-        logLevel = static_cast<ApiGear::Utilities::LogLevel>(logLevelNumber);
+    // Parse command line arguments
+    std::string host = "localhost";
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--host" && i + 1 < argc) { host = argv[++i]; }
+        else if (arg == "--help") {
+            std::cout << "Usage: " << argv[0] << " [--host HOST]" << std::endl;
+            return 0;
+        }
     }
 
-    logConsoleFunc = ApiGear::Utilities::getConsoleLogFunc(logLevel);
-    // check whether logging was disabled
-    if (logLevel > ApiGear::Utilities::LogLevel::Error) {
-        logConsoleFunc = nullptr;
-    }
-
-    // set global log function
-    ApiGear::Utilities::setLog(logConsoleFunc);
-
-    return logConsoleFunc;
-}
-
-int main(){
-    auto logConsoleFunc = getLogging();
+    auto logConsoleFunc = Examples::initLogging();
     std::mt19937 randomNumberGenerator (std::random_device{}());
     std::uniform_int_distribution<> distribution (0, 100000);
 
@@ -60,21 +114,11 @@ int main(){
 {{- end }}
 
     // start mqtt connection
-    mqttclient->connectToHost("");
+    mqttclient->connectToHost(host);
 
-    bool keepRunning = true;
-    std::string cmd;
-    do {
-        std::cout << "Enter command:" << std::endl;
-        getline (std::cin, cmd);
-
-        if(cmd == "quit"){
-            mqttclient->disconnect();
-            keepRunning = false;
-        } else {
-
-        }
-    } while(keepRunning);
+    Examples::runCommandLoop({}, [&](){
+        mqttclient->disconnect();
+    });
 
     return 0;
 }

--- a/templates/examples/mqttserver/CMakeLists.txt.tpl
+++ b/templates/examples/mqttserver/CMakeLists.txt.tpl
@@ -36,6 +36,7 @@ target_link_libraries(MQTTServer
 # we assume that the examples are built together with the libraries and thus ignore this warning
 if(MSVC)
   target_compile_options(MQTTServer PRIVATE /wd4251)
+  target_compile_definitions(MQTTServer PRIVATE -D_CRT_SECURE_NO_WARNINGS)
 endif()
 
 install(TARGETS MQTTServer

--- a/templates/examples/mqttserver/main.cpp.tpl
+++ b/templates/examples/mqttserver/main.cpp.tpl
@@ -1,4 +1,3 @@
-#include <iostream>
 {{- range .System.Modules }}
 {{- $module := . }}
 {{- range $module.Interfaces }}
@@ -9,42 +8,95 @@
 {{- end }}
 #include "apigear/mqtt/mqttservice.h"
 #include "apigear/utilities/logger.h"
-#include <iostream>
-#include <sstream>
 #include <cstdlib>
+#include <sstream>
+#include <iostream>
+#include <string>
+#include <functional>
+#include <map>
+
+namespace Examples {
+
+using CommandHandler = std::function<void(const std::string& args)>;
+using CommandMap = std::map<std::string, CommandHandler>;
+
+inline ApiGear::Utilities::WriteLogFunc initLogging()
+{
+    ApiGear::Utilities::LogLevel logLevel = ApiGear::Utilities::LogLevel::Warning;
+    if (const char* envLogLevel = std::getenv("LOG_LEVEL"))
+    {
+        int parsed = -1;
+        std::istringstream iss(envLogLevel);
+        if (!(iss >> parsed) || parsed < 0) {
+            std::cerr << "Warning: invalid LOG_LEVEL=\"" << envLogLevel
+                      << "\", using default (Warning)" << std::endl;
+        } else if (parsed > static_cast<int>(ApiGear::Utilities::LogLevel::Error)) {
+            ApiGear::Utilities::setLog(nullptr);
+            return nullptr;
+        } else {
+            logLevel = static_cast<ApiGear::Utilities::LogLevel>(parsed);
+        }
+    }
+    auto logFunc = ApiGear::Utilities::getConsoleLogFunc(logLevel);
+    ApiGear::Utilities::setLog(logFunc);
+    return logFunc;
+}
+
+inline void runCommandLoop(CommandMap commands, std::function<void()> onQuit)
+{
+    commands["help"] = [&](const std::string&) {
+        std::cout << "Available commands:";
+        for (const auto& [name, _] : commands) { std::cout << " " << name; }
+        std::cout << " quit exit" << std::endl;
+    };
+    std::string line;
+    std::cout << "Type \"help\" for available commands." << std::endl;
+    while (std::getline(std::cin, line)) {
+        auto start = line.find_first_not_of(" \t\r\n");
+        auto end = line.find_last_not_of(" \t\r\n");
+        if (start != std::string::npos) {
+            line = line.substr(start, end - start + 1);
+        } else {
+            line.clear();
+        }
+        for (auto& c : line) { c = static_cast<char>(std::tolower(static_cast<unsigned char>(c))); }
+        if (line == "quit" || line == "exit") {
+            if (onQuit) { onQuit(); }
+            return;
+        }
+        auto spacePos = line.find(' ');
+        std::string cmd = (spacePos == std::string::npos) ? line : line.substr(0, spacePos);
+        std::string args = (spacePos == std::string::npos) ? "" : line.substr(spacePos + 1);
+        auto it = commands.find(cmd);
+        if (it != commands.end()) {
+            it->second(args);
+        } else if (!cmd.empty()) {
+            std::cout << "Unknown command: \"" << cmd
+                      << "\". Type \"help\" for available commands." << std::endl;
+        }
+    }
+    if (onQuit) { onQuit(); }
+}
+
+} // namespace Examples
 #include <random>
 
 using namespace {{ Camel .System.Name }};
 
-ApiGear::Utilities::WriteLogFunc getLogging(){
+int main(int argc, char* argv[]){
 
-    ApiGear::Utilities::WriteLogFunc logConsoleFunc = nullptr;
-    ApiGear::Utilities::LogLevel logLevel = ApiGear::Utilities::LogLevel::Warning;
-
-    // check whether logging level is set via env
-    if (const char* envLogLevel = std::getenv("LOG_LEVEL"))
-    {
-        int logLevelNumber = 255;
-        std::stringstream(envLogLevel) >> logLevelNumber;
-        logLevel = static_cast<ApiGear::Utilities::LogLevel>(logLevelNumber);
+    // Parse command line arguments
+    std::string host = "localhost";
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--host" && i + 1 < argc) { host = argv[++i]; }
+        else if (arg == "--help") {
+            std::cout << "Usage: " << argv[0] << " [--host HOST]" << std::endl;
+            return 0;
+        }
     }
 
-    logConsoleFunc = ApiGear::Utilities::getConsoleLogFunc(logLevel);
-    // check whether logging was disabled
-    if (logLevel > ApiGear::Utilities::LogLevel::Error) {
-        logConsoleFunc = nullptr;
-    }
-
-    // set global log function
-    ApiGear::Utilities::setLog(logConsoleFunc);
-
-    return logConsoleFunc;
-}
-
-using namespace {{ Camel .System.Name }};
-
-int main(){
-    auto logConsoleFunc = getLogging();
+    auto logConsoleFunc = Examples::initLogging();
     std::mt19937 randomNumberGenerator (std::random_device{}());
     std::uniform_int_distribution<> distribution (0, 100000);
 
@@ -64,20 +116,11 @@ int main(){
 {{- end }}
 
     // start mqtt connection
-    mqttservice->connectToHost("");
+    mqttservice->connectToHost(host);
 
-    bool keepRunning = true;
-    std::string cmd;
-    do {
-        std::cout << "Enter command:" << std::endl;
-        getline (std::cin, cmd);
-
-        if(cmd == "quit"){
-            mqttservice->disconnect();
-            keepRunning = false;
-        } else {
-        }
-    } while(keepRunning);
+    Examples::runCommandLoop({}, [&](){
+        mqttservice->disconnect();
+    });
 
     return 0;
 }

--- a/templates/examples/natsclient/CMakeLists.txt.tpl
+++ b/templates/examples/natsclient/CMakeLists.txt.tpl
@@ -37,6 +37,7 @@ target_link_libraries(NatsClient
 # we assume that the examples are built together with the libraries and thus ignore this warning
 if(MSVC)
   target_compile_options(NatsClient PRIVATE /wd4251)
+  target_compile_definitions(NatsClient PRIVATE -D_CRT_SECURE_NO_WARNINGS)
 endif()
 
 install(TARGETS NatsClient

--- a/templates/examples/natsclient/main.cpp.tpl
+++ b/templates/examples/natsclient/main.cpp.tpl
@@ -6,30 +6,95 @@
 {{- end }}
 {{- end }}
 #include "apigear/utilities/logger.h"
-#include <iostream>
 #include "apigear/nats/natsclient.h"
+#include <cstdlib>
+#include <sstream>
+#include <iostream>
+#include <string>
+#include <functional>
+#include <map>
+
+namespace Examples {
+
+using CommandHandler = std::function<void(const std::string& args)>;
+using CommandMap = std::map<std::string, CommandHandler>;
+
+inline ApiGear::Utilities::WriteLogFunc initLogging()
+{
+    ApiGear::Utilities::LogLevel logLevel = ApiGear::Utilities::LogLevel::Warning;
+    if (const char* envLogLevel = std::getenv("LOG_LEVEL"))
+    {
+        int parsed = -1;
+        std::istringstream iss(envLogLevel);
+        if (!(iss >> parsed) || parsed < 0) {
+            std::cerr << "Warning: invalid LOG_LEVEL=\"" << envLogLevel
+                      << "\", using default (Warning)" << std::endl;
+        } else if (parsed > static_cast<int>(ApiGear::Utilities::LogLevel::Error)) {
+            ApiGear::Utilities::setLog(nullptr);
+            return nullptr;
+        } else {
+            logLevel = static_cast<ApiGear::Utilities::LogLevel>(parsed);
+        }
+    }
+    auto logFunc = ApiGear::Utilities::getConsoleLogFunc(logLevel);
+    ApiGear::Utilities::setLog(logFunc);
+    return logFunc;
+}
+
+inline void runCommandLoop(CommandMap commands, std::function<void()> onQuit)
+{
+    commands["help"] = [&](const std::string&) {
+        std::cout << "Available commands:";
+        for (const auto& [name, _] : commands) { std::cout << " " << name; }
+        std::cout << " quit exit" << std::endl;
+    };
+    std::string line;
+    std::cout << "Type \"help\" for available commands." << std::endl;
+    while (std::getline(std::cin, line)) {
+        auto start = line.find_first_not_of(" \t\r\n");
+        auto end = line.find_last_not_of(" \t\r\n");
+        if (start != std::string::npos) {
+            line = line.substr(start, end - start + 1);
+        } else {
+            line.clear();
+        }
+        for (auto& c : line) { c = static_cast<char>(std::tolower(static_cast<unsigned char>(c))); }
+        if (line == "quit" || line == "exit") {
+            if (onQuit) { onQuit(); }
+            return;
+        }
+        auto spacePos = line.find(' ');
+        std::string cmd = (spacePos == std::string::npos) ? line : line.substr(0, spacePos);
+        std::string args = (spacePos == std::string::npos) ? "" : line.substr(spacePos + 1);
+        auto it = commands.find(cmd);
+        if (it != commands.end()) {
+            it->second(args);
+        } else if (!cmd.empty()) {
+            std::cout << "Unknown command: \"" << cmd
+                      << "\". Type \"help\" for available commands." << std::endl;
+        }
+    }
+    if (onQuit) { onQuit(); }
+}
+
+} // namespace Examples
 
 using namespace {{ Camel .System.Name }};
 
-ApiGear::Utilities::WriteLogFunc getLogging(){
+int main(int argc, char* argv[]){
 
-    ApiGear::Utilities::WriteLogFunc logConsoleFunc = nullptr;
-    ApiGear::Utilities::LogLevel logLevel = ApiGear::Utilities::LogLevel::Warning;
-
-    logConsoleFunc = ApiGear::Utilities::getConsoleLogFunc(logLevel);
-    // check whether logging was disabled
-    if (logLevel > ApiGear::Utilities::LogLevel::Error) {
-        logConsoleFunc = nullptr;
+    // Parse command line arguments
+    std::string url = "nats://localhost:4222";
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--url" && i + 1 < argc) { url = argv[++i]; }
+        else if (arg == "--help") {
+            std::cout << "Usage: " << argv[0] << " [--url URL]" << std::endl;
+            return 0;
+        }
     }
 
-    // set global log function
-    ApiGear::Utilities::setLog(logConsoleFunc);
-
-    return logConsoleFunc;
-}
-
-int main(){
-
+    Examples::initLogging();
     auto client = std::make_shared<ApiGear::Nats::Client>();
 
     // set up modules
@@ -42,7 +107,7 @@ int main(){
 {{- end }}
 {{- end }}
 
-   
+
     {{ $propertyExampleReady := 0 -}}
     {{ $signalExampleReady := 0 -}}
     {{ $operationExampleReady := 0 -}}
@@ -57,9 +122,9 @@ int main(){
     // Try out properties: subscribe for changes
     test{{Camel $module.Name}}{{ Camel $interface.Name}}->_getPublisher().subscribeTo{{Camel $property.Name}}Changed([](auto value){ std::cout << " {{Camel $property.Name}} " << std::endl; });
 
-    // or ask for change, when objest is ready
+    // or ask for change, when object is ready
     auto idSubProp = test{{Camel $module.Name}}{{ Camel $interface.Name}}->_subscribeForIsReady(
-        [test{{Camel $module.Name}}{{ Camel $interface.Name}}](bool connected) 
+        [test{{Camel $module.Name}}{{ Camel $interface.Name}}](bool connected)
         {
             if (!connected)
             {
@@ -84,7 +149,7 @@ int main(){
     // Play around executing your operations
     {{- $namespacePrefix := printf "%s::"  (Camel .Module.Name )}}
     auto idSubOperation = test{{Camel $module.Name}}{{ Camel $interface.Name}}->_subscribeForIsReady(
-        [test{{Camel $module.Name}}{{ Camel $interface.Name}}](bool connected) 
+        [test{{Camel $module.Name}}{{ Camel $interface.Name}}](bool connected)
         {
             if (!connected)
             {
@@ -107,21 +172,11 @@ int main(){
 {{- end}}{{/* end range over modules*/}}
 
     //connect
-    client->connect("nats://localhost:4222");
+    client->connect(url);
 
-    bool keepRunning = true;
-    std::string cmd;
-    do {
-        std::cout << "Enter command:" << std::endl;
-        getline (std::cin, cmd);
-
-        if(cmd == "quit"){
-            client->disconnect();
-            keepRunning = false;
-        } else {
-
-        }
-    } while(keepRunning);
+    Examples::runCommandLoop({}, [&](){
+        client->disconnect();
+    });
 
     return 0;
 }

--- a/templates/examples/natsserver/CMakeLists.txt.tpl
+++ b/templates/examples/natsserver/CMakeLists.txt.tpl
@@ -37,6 +37,7 @@ target_link_libraries(NatsServer
 # we assume that the examples are built together with the libraries and thus ignore this warning
 if(MSVC)
   target_compile_options(NatsServer PRIVATE /wd4251)
+  target_compile_definitions(NatsServer PRIVATE -D_CRT_SECURE_NO_WARNINGS)
 endif()
 
 install(TARGETS NatsServer

--- a/templates/examples/natsserver/main.cpp.tpl
+++ b/templates/examples/natsserver/main.cpp.tpl
@@ -8,31 +8,94 @@
 {{- end }}
 #include "apigear/nats/natsservice.h"
 #include "apigear/utilities/logger.h"
+#include <cstdlib>
+#include <sstream>
 #include <iostream>
+#include <string>
+#include <functional>
+#include <map>
 
-using namespace {{ Camel .System.Name }};
+namespace Examples {
 
-ApiGear::Utilities::WriteLogFunc getLogging(){
+using CommandHandler = std::function<void(const std::string& args)>;
+using CommandMap = std::map<std::string, CommandHandler>;
 
-    ApiGear::Utilities::WriteLogFunc logConsoleFunc = nullptr;
+inline ApiGear::Utilities::WriteLogFunc initLogging()
+{
     ApiGear::Utilities::LogLevel logLevel = ApiGear::Utilities::LogLevel::Warning;
-
-    logConsoleFunc = ApiGear::Utilities::getConsoleLogFunc(logLevel);
-    // check whether logging was disabled
-    if (logLevel > ApiGear::Utilities::LogLevel::Error) {
-        logConsoleFunc = nullptr;
+    if (const char* envLogLevel = std::getenv("LOG_LEVEL"))
+    {
+        int parsed = -1;
+        std::istringstream iss(envLogLevel);
+        if (!(iss >> parsed) || parsed < 0) {
+            std::cerr << "Warning: invalid LOG_LEVEL=\"" << envLogLevel
+                      << "\", using default (Warning)" << std::endl;
+        } else if (parsed > static_cast<int>(ApiGear::Utilities::LogLevel::Error)) {
+            ApiGear::Utilities::setLog(nullptr);
+            return nullptr;
+        } else {
+            logLevel = static_cast<ApiGear::Utilities::LogLevel>(parsed);
+        }
     }
-
-    // set global log function
-    ApiGear::Utilities::setLog(logConsoleFunc);
-
-    return logConsoleFunc;
+    auto logFunc = ApiGear::Utilities::getConsoleLogFunc(logLevel);
+    ApiGear::Utilities::setLog(logFunc);
+    return logFunc;
 }
 
+inline void runCommandLoop(CommandMap commands, std::function<void()> onQuit)
+{
+    commands["help"] = [&](const std::string&) {
+        std::cout << "Available commands:";
+        for (const auto& [name, _] : commands) { std::cout << " " << name; }
+        std::cout << " quit exit" << std::endl;
+    };
+    std::string line;
+    std::cout << "Type \"help\" for available commands." << std::endl;
+    while (std::getline(std::cin, line)) {
+        auto start = line.find_first_not_of(" \t\r\n");
+        auto end = line.find_last_not_of(" \t\r\n");
+        if (start != std::string::npos) {
+            line = line.substr(start, end - start + 1);
+        } else {
+            line.clear();
+        }
+        for (auto& c : line) { c = static_cast<char>(std::tolower(static_cast<unsigned char>(c))); }
+        if (line == "quit" || line == "exit") {
+            if (onQuit) { onQuit(); }
+            return;
+        }
+        auto spacePos = line.find(' ');
+        std::string cmd = (spacePos == std::string::npos) ? line : line.substr(0, spacePos);
+        std::string args = (spacePos == std::string::npos) ? "" : line.substr(spacePos + 1);
+        auto it = commands.find(cmd);
+        if (it != commands.end()) {
+            it->second(args);
+        } else if (!cmd.empty()) {
+            std::cout << "Unknown command: \"" << cmd
+                      << "\". Type \"help\" for available commands." << std::endl;
+        }
+    }
+    if (onQuit) { onQuit(); }
+}
+
+} // namespace Examples
+
 using namespace {{ Camel .System.Name }};
 
-int main(){
+int main(int argc, char* argv[]){
 
+    // Parse command line arguments
+    std::string url = "nats://localhost:4222";
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--url" && i + 1 < argc) { url = argv[++i]; }
+        else if (arg == "--help") {
+            std::cout << "Usage: " << argv[0] << " [--url URL]" << std::endl;
+            return 0;
+        }
+    }
+
+    Examples::initLogging();
     auto service = std::make_shared<ApiGear::Nats::Service>();
 
     // set up modules
@@ -46,20 +109,11 @@ int main(){
 {{- end }}
 {{- end }}
 
-    service->connect("nats://localhost:4222");
+    service->connect(url);
 
-    bool keepRunning = true;
-    std::string cmd;
-    do {
-        std::cout << "Enter command:" << std::endl;
-        getline (std::cin, cmd);
-
-        if(cmd == "quit"){
-            service->disconnect();
-            keepRunning = false;
-        } else {
-        }
-    } while(keepRunning);
+    Examples::runCommandLoop({}, [&](){
+        service->disconnect();
+    });
 
     return 0;
 }

--- a/templates/examples/olinkclient/main.cpp.tpl
+++ b/templates/examples/olinkclient/main.cpp.tpl
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <string>
 {{- $features := .Features}}
 {{- range .System.Modules }}
 {{- $module := . }}
@@ -17,44 +18,105 @@
 {{- end}}
 #include "apigear/olink/olinklogadapter.h"
 #include "olink/clientregistry.h"
-#include <sstream>
+#include "apigear/utilities/logger.h"
 #include <cstdlib>
+#include <sstream>
+#include <functional>
+#include <map>
 
-ApiGear::Utilities::WriteLogFunc getLogging(){
+namespace Examples {
 
-    ApiGear::Utilities::WriteLogFunc logConsoleFunc = nullptr;
+using CommandHandler = std::function<void(const std::string& args)>;
+using CommandMap = std::map<std::string, CommandHandler>;
+
+inline ApiGear::Utilities::WriteLogFunc initLogging()
+{
     ApiGear::Utilities::LogLevel logLevel = ApiGear::Utilities::LogLevel::Warning;
-
-    // check whether logging level is set via env
     if (const char* envLogLevel = std::getenv("LOG_LEVEL"))
     {
-        int logLevelNumber = 255;
-        std::stringstream(envLogLevel) >> logLevelNumber;
-        logLevel = static_cast<ApiGear::Utilities::LogLevel>(logLevelNumber);
+        int parsed = -1;
+        std::istringstream iss(envLogLevel);
+        if (!(iss >> parsed) || parsed < 0) {
+            std::cerr << "Warning: invalid LOG_LEVEL=\"" << envLogLevel
+                      << "\", using default (Warning)" << std::endl;
+        } else if (parsed > static_cast<int>(ApiGear::Utilities::LogLevel::Error)) {
+            ApiGear::Utilities::setLog(nullptr);
+            return nullptr;
+        } else {
+            logLevel = static_cast<ApiGear::Utilities::LogLevel>(parsed);
+        }
     }
-
-    logConsoleFunc = ApiGear::Utilities::getConsoleLogFunc(logLevel);
-    // check whether logging was disabled
-    if (logLevel > ApiGear::Utilities::LogLevel::Error) {
-        logConsoleFunc = nullptr;
-    }
-
-    // set global log function
-    ApiGear::Utilities::setLog(logConsoleFunc);
-
-    return logConsoleFunc;
+    auto logFunc = ApiGear::Utilities::getConsoleLogFunc(logLevel);
+    ApiGear::Utilities::setLog(logFunc);
+    return logFunc;
 }
+
+inline void runCommandLoop(CommandMap commands, std::function<void()> onQuit)
+{
+    commands["help"] = [&](const std::string&) {
+        std::cout << "Available commands:";
+        for (const auto& [name, _] : commands) { std::cout << " " << name; }
+        std::cout << " quit exit" << std::endl;
+    };
+
+    std::string line;
+    std::cout << "Type \"help\" for available commands." << std::endl;
+    while (std::getline(std::cin, line)) {
+        auto start = line.find_first_not_of(" \t\r\n");
+        auto end = line.find_last_not_of(" \t\r\n");
+        if (start != std::string::npos) {
+            line = line.substr(start, end - start + 1);
+        } else {
+            line.clear();
+        }
+        for (auto& c : line) { c = static_cast<char>(std::tolower(static_cast<unsigned char>(c))); }
+
+        if (line == "quit" || line == "exit") {
+            if (onQuit) { onQuit(); }
+            return;
+        }
+
+        auto spacePos = line.find(' ');
+        std::string cmd = (spacePos == std::string::npos) ? line : line.substr(0, spacePos);
+        std::string args = (spacePos == std::string::npos) ? "" : line.substr(spacePos + 1);
+
+        auto it = commands.find(cmd);
+        if (it != commands.end()) {
+            it->second(args);
+        } else if (!cmd.empty()) {
+            std::cout << "Unknown command: \"" << cmd
+                      << "\". Type \"help\" for available commands." << std::endl;
+        }
+    }
+    if (onQuit) { onQuit(); }
+}
+
+} // namespace Examples
 
 using namespace {{ Camel .System.Name }};
 
-int main(){
+int main(int argc, char* argv[]){
+
+    // Parse command line arguments
+    std::string host = "localhost";
+    int port = 8000;
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--host" && i + 1 < argc) { host = argv[++i]; }
+        else if (arg == "--port" && i + 1 < argc) { port = std::stoi(argv[++i]); }
+        else if (arg == "--help") {
+            std::cout << "Usage: " << argv[0] << " [--host HOST] [--port PORT]" << std::endl;
+            return 0;
+        }
+    }
+    auto uri = "ws://" + host + ":" + std::to_string(port);
 
 {{- if $features.monitor }}
     ApiGear::PocoImpl::Tracer tracer;
     tracer.connect("http://localhost:5555", "testExampleOLinkApp");
 {{- end}}
     ApiGear::ObjectLink::ClientRegistry registry;
-    auto logConsoleFunc = getLogging();
+    auto logConsoleFunc = Examples::initLogging();
     registry.onLog(ApiGear::Utilities::logAdapter(logConsoleFunc));
     ApiGear::PocoImpl::OlinkConnection clientNetworkEndpoint(registry);
     clientNetworkEndpoint.node()->onLog(ApiGear::Utilities::logAdapter(logConsoleFunc));
@@ -74,30 +136,22 @@ int main(){
     {{- end}}
 {{- end }}
 {{- end }}
-    
-    clientNetworkEndpoint.connectToHost(Poco::URI("ws://localhost:8000"));
 
-    bool keepRunning = true;
-    std::string cmd;
-    do {
-        std::cout << "Enter command:" << std::endl;
-        getline (std::cin, cmd);
+    clientNetworkEndpoint.connectToHost(Poco::URI(uri));
 
-        if(cmd == "quit"){
-            keepRunning = false;
-            clientNetworkEndpoint.disconnect();
-        }
-    } while(keepRunning);
+    Examples::runCommandLoop({}, [&](){
 {{- range .System.Modules }}
 {{- $module := . }}
 {{- range $module.Interfaces }}
 {{- $interface := . }}
-    {{- $class := Camel $interface.Name }}
-    {{- $modulePrefix := lower1 (Camel $module.Name)}}
-    {{- $clientClassName := printf "%s%s"  $modulePrefix $class }}
-    clientNetworkEndpoint.disconnectAndUnlink({{$clientClassName}}->olinkObjectName());
+        {{- $class := Camel $interface.Name }}
+        {{- $modulePrefix := lower1 (Camel $module.Name)}}
+        {{- $clientClassName := printf "%s%s"  $modulePrefix $class }}
+        clientNetworkEndpoint.disconnectAndUnlink({{$clientClassName}}->olinkObjectName());
 {{- end }}
 {{- end }}
+        clientNetworkEndpoint.disconnect();
+    });
 
     return 0;
 }

--- a/templates/examples/olinkserver/CMakeLists.txt.tpl
+++ b/templates/examples/olinkserver/CMakeLists.txt.tpl
@@ -23,7 +23,6 @@ else()
   target_compile_definitions(OLinkServer PRIVATE -D_CRT_SECURE_NO_WARNINGS)
 endif()
 
-find_package(apigear REQUIRED COMPONENTS utilities)
 {{- range .System.Modules }}
 {{- $module := . }}
 {{- $module_id := snake .Name }}

--- a/templates/examples/olinkserver/main.cpp.tpl
+++ b/templates/examples/olinkserver/main.cpp.tpl
@@ -11,41 +11,100 @@
 #include "apigear/olink/olinklogadapter.h"
 #include "olink/remoteregistry.h"
 #include "apigear/olink/olinkhost.h"
-
-#include <iostream>
-#include <sstream>
+#include "apigear/utilities/logger.h"
 #include <cstdlib>
+#include <sstream>
+#include <iostream>
+#include <string>
+#include <functional>
+#include <map>
 
-ApiGear::Utilities::WriteLogFunc getLogging(){
+namespace Examples {
 
-    ApiGear::Utilities::WriteLogFunc logConsoleFunc = nullptr;
+using CommandHandler = std::function<void(const std::string& args)>;
+using CommandMap = std::map<std::string, CommandHandler>;
+
+inline ApiGear::Utilities::WriteLogFunc initLogging()
+{
     ApiGear::Utilities::LogLevel logLevel = ApiGear::Utilities::LogLevel::Warning;
-
-    // check whether logging level is set via env
     if (const char* envLogLevel = std::getenv("LOG_LEVEL"))
     {
-        int logLevelNumber = 255;
-        std::stringstream(envLogLevel) >> logLevelNumber;
-        logLevel = static_cast<ApiGear::Utilities::LogLevel>(logLevelNumber);
+        int parsed = -1;
+        std::istringstream iss(envLogLevel);
+        if (!(iss >> parsed) || parsed < 0) {
+            std::cerr << "Warning: invalid LOG_LEVEL=\"" << envLogLevel
+                      << "\", using default (Warning)" << std::endl;
+        } else if (parsed > static_cast<int>(ApiGear::Utilities::LogLevel::Error)) {
+            ApiGear::Utilities::setLog(nullptr);
+            return nullptr;
+        } else {
+            logLevel = static_cast<ApiGear::Utilities::LogLevel>(parsed);
+        }
     }
-
-    logConsoleFunc = ApiGear::Utilities::getConsoleLogFunc(logLevel);
-    // check whether logging was disabled
-    if (logLevel > ApiGear::Utilities::LogLevel::Error) {
-        logConsoleFunc = nullptr;
-    }
-
-    // set global log function
-    ApiGear::Utilities::setLog(logConsoleFunc);
-
-    return logConsoleFunc;
+    auto logFunc = ApiGear::Utilities::getConsoleLogFunc(logLevel);
+    ApiGear::Utilities::setLog(logFunc);
+    return logFunc;
 }
+
+inline void runCommandLoop(CommandMap commands, std::function<void()> onQuit)
+{
+    commands["help"] = [&](const std::string&) {
+        std::cout << "Available commands:";
+        for (const auto& [name, _] : commands) { std::cout << " " << name; }
+        std::cout << " quit exit" << std::endl;
+    };
+
+    std::string line;
+    std::cout << "Type \"help\" for available commands." << std::endl;
+    while (std::getline(std::cin, line)) {
+        auto start = line.find_first_not_of(" \t\r\n");
+        auto end = line.find_last_not_of(" \t\r\n");
+        if (start != std::string::npos) {
+            line = line.substr(start, end - start + 1);
+        } else {
+            line.clear();
+        }
+        for (auto& c : line) { c = static_cast<char>(std::tolower(static_cast<unsigned char>(c))); }
+
+        if (line == "quit" || line == "exit") {
+            if (onQuit) { onQuit(); }
+            return;
+        }
+
+        auto spacePos = line.find(' ');
+        std::string cmd = (spacePos == std::string::npos) ? line : line.substr(0, spacePos);
+        std::string args = (spacePos == std::string::npos) ? "" : line.substr(spacePos + 1);
+
+        auto it = commands.find(cmd);
+        if (it != commands.end()) {
+            it->second(args);
+        } else if (!cmd.empty()) {
+            std::cout << "Unknown command: \"" << cmd
+                      << "\". Type \"help\" for available commands." << std::endl;
+        }
+    }
+    if (onQuit) { onQuit(); }
+}
+
+} // namespace Examples
 
 using namespace {{ Camel .System.Name }};
 
-int main(){
+int main(int argc, char* argv[]){
+
+    // Parse command line arguments
+    int port = 8000;
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--port" && i + 1 < argc) { port = std::stoi(argv[++i]); }
+        else if (arg == "--help") {
+            std::cout << "Usage: " << argv[0] << " [--port PORT]" << std::endl;
+            return 0;
+        }
+    }
+
     ApiGear::ObjectLink::RemoteRegistry registry;
-    auto logConsoleFunc = getLogging();
+    auto logConsoleFunc = Examples::initLogging();
     registry.onLog(ApiGear::Utilities::logAdapter(logConsoleFunc));
 
     ApiGear::PocoImpl::OLinkHost testserver(registry, ApiGear::Utilities::logAdapter(logConsoleFunc));
@@ -68,30 +127,21 @@ int main(){
 
     // Start your server after all the services are added.
     // This ensures that any new client that connects, will find the source it needs.
-    testserver.listen(8000);
+    testserver.listen(port);
 
-    bool keepRunning = true;
-    std::string cmd;
-    do {
-        std::cout << "Enter command:" << std::endl;
-        getline (std::cin, cmd);
-
-        if(cmd == "quit"){
-            testserver.close();
-            keepRunning = false;
-        }
-    } while(keepRunning);
-
+    Examples::runCommandLoop({}, [&](){
 {{- range .System.Modules }}
 {{- $module := . }}
 {{- range $module.Interfaces }}
 {{- $interface := . }}
-    {{- $class := Camel $interface.Name }}
-    {{- $modulePrefix := lower1 (Camel $module.Name)}}
-    {{- $serviceInstanceName := printf "%sOlink%sService" $modulePrefix $class }}
-    registry.removeSource({{$serviceInstanceName}}->olinkObjectName());
+        {{- $class := Camel $interface.Name }}
+        {{- $modulePrefix := lower1 (Camel $module.Name)}}
+        {{- $serviceInstanceName := printf "%sOlink%sService" $modulePrefix $class }}
+        registry.removeSource({{$serviceInstanceName}}->olinkObjectName());
 {{- end }}
 {{- end }}
-    
+        testserver.close();
+    });
+
     return 0;
 }

--- a/templates/scripts/test_conan.sh.tpl
+++ b/templates/scripts/test_conan.sh.tpl
@@ -26,9 +26,8 @@ build_example()
 {
     mkdir -p $1 &&\
     pushd $1 &&\
-    cp -a ../../../$1/* . &&\
-    conan install --build missing . -g=VirtualRunEnv &&\
-    cmake -S . --preset conan-release &&\
+    conan install --build missing ../../../$1 -g=VirtualRunEnv &&\
+    cmake -B . -S ../../../$1 --preset conan-release &&\
     cmake --build .
     buildresult=$?
     popd


### PR DESCRIPTION
## Summary

- Extract duplicated `getLogging()` into `Examples::initLogging()` with `LOG_LEVEL` env var validation and error handling
- Add extensible `Examples::runCommandLoop()` with `CommandMap` dispatch, built-in `help`, and unknown-command feedback
- Add `--host`/`--port`/`--url` CLI argument parsing to all network examples
- Fix OLink client disconnect ordering (unlink objects before disconnecting transport)
- Fix MQTT client/server connecting to empty host (now defaults to `localhost`)
- Fix infinite CPU spin on EOF in command loop
- Fix Conan build script to use out-of-source `cmake -S`
- Add `_CRT_SECURE_NO_WARNINGS` for MSVC `getenv` warning
- Make `app` and `appthreadsafe` examples demonstrate actual property/operation usage

## Test plan

- [x] CI: `ci_generate.yml` validates goldenmaster matches template output
- [x] CI: `ci_build_test.yml` builds and tests on Windows/Ubuntu/macOS
- [x] CI: `ci_build_features.yml` tests each feature in isolation
- [x] Verify examples compile and run with `--help` flag
- [x] Verify `LOG_LEVEL=abc` prints warning instead of crashing
- [x] Verify piping `echo quit | ./OLinkClient` exits cleanly (EOF handling)
- [x] Build passes on Ubuntu (cmake + ctest 31/31)
- [x] Goldenmaster matches template output (`go run main.go diff`)